### PR TITLE
Added multi-arch support for Docker image

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -34,5 +34,4 @@ jobs:
 
       - name: Build the Docker image
         run: |
-          docker login --username=${{ secrets.DOCKER_HUB_USER }} --password=${{ secrets.DOCKER_HUB_PWD }}
-          docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 -t b3log/siyuan:latest -t b3log/siyuan:v2.0.20 .
+          docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${{ secrets.DOCKERHUB_USERNAME }}/siyuan:latest -t ${{ secrets.DOCKERHUB_USERNAME }}/siyuan:v2.0.20 .

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,3 +16,43 @@ jobs:
           docker login --username=${{ secrets.DOCKER_HUB_USER }} --password=${{ secrets.DOCKER_HUB_PWD }}
           docker build -t b3log/siyuan:latest -t b3log/siyuan:v2.0.20 .
           docker push b3log/siyuan -a
+
+
+name: Release Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - dev
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build the Docker image
+        run: |
+          docker login --username=${{ secrets.DOCKER_HUB_USER }} --password=${{ secrets.DOCKER_HUB_PWD }}
+          docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7 -t b3log/siyuan:latest -t b3log/siyuan:v2.0.20 .

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,24 +1,4 @@
 name: Release Docker Image
-on:
-  push:
-    branches:
-      - master
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          #ref: '70e4c2c0cb2f1c2f3d1c76de99a3e7593e3d7cae'
-          submodules: true
-      - name: Build the Docker image
-        run: |
-          docker login --username=${{ secrets.DOCKER_HUB_USER }} --password=${{ secrets.DOCKER_HUB_PWD }}
-          docker build -t b3log/siyuan:latest -t b3log/siyuan:v2.0.20 .
-          docker push b3log/siyuan -a
-
-
-name: Release Docker Image
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### List of changes

- [X]  Added `workflow dispatch` to manually trigger this workflow
- [X]  Removed old docker login and build steps
- [X]  Added QEMU for multi-arch compatibilty
- [X]  Image builds using Docker buildx to take advantage of multi-arch

### Note:
+ This increases the build time significantly. ~1.5 hours to build for 3 architectures  `linux/amd64,linux/arm64,linux/arm/v7`

### Run examples:
https://github.com/Just5KY/siyuan/runs/6928323019 (master branch)
https://github.com/Just5KY/siyuan/runs/6930819023 (Dev branch)

![image](https://user-images.githubusercontent.com/71321862/174237741-78fa8a54-8eff-4383-8238-0add273c5fb3.png)
