### PR TITLE
改进检查更新时版本号比较

### DIFF
--- a/kernel/model/updater.go
+++ b/kernel/model/updater.go
@@ -26,6 +26,8 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -214,6 +216,36 @@ func GetAnnouncements() (ret []*Announcement) {
 	}
 	return
 }
+func ver2num(a string) int {
+	var version string
+	var alpha string
+	var alphapos int
+	var suffix string
+	a = strings.Trim(a, " ")
+	alphapos = strings.Index(a, "-alpha")
+	if alphapos != -1 {
+		version = a[0:alphapos]
+		alpha = a[alphapos+6 : len(a)]
+		suffix = fmt.Sprintf("%04s", alpha)
+	} else {
+		version = a
+		suffix = "1000"
+	}
+	split := strings.Split(version, ".")
+
+	var verArr []string
+
+	verArr = append(verArr, "1")
+	for i := 0; i < len(split); i++ {
+		var tmp = split[i]
+		verArr = append(verArr, fmt.Sprintf("%04s", tmp))
+	}
+	verArr = append(verArr, suffix)
+
+	ver := strings.Join(verArr, "")
+	verNum, _ := strconv.Atoi(ver)
+	return verNum
+}
 
 func CheckUpdate(showMsg bool) {
 	if !showMsg {
@@ -229,7 +261,7 @@ func CheckUpdate(showMsg bool) {
 	release := result["release"].(string)
 	var msg string
 	var timeout int
-	if ver == util.Ver {
+	if ver2num(ver) <= ver2num(util.Ver) {
 		msg = Conf.Language(10)
 		timeout = 3000
 	} else {

--- a/kernel/model/updater.go
+++ b/kernel/model/updater.go
@@ -218,26 +218,35 @@ func GetAnnouncements() (ret []*Announcement) {
 }
 func ver2num(a string) int {
 	var version string
-	var alpha string
-	var alphapos int
+	var suffixpos int
+	var suffixStr string
 	var suffix string
 	a = strings.Trim(a, " ")
-	alphapos = strings.Index(a, "-alpha")
-	if alphapos != -1 {
-		version = a[0:alphapos]
-		alpha = a[alphapos+6 : len(a)]
-		suffix = fmt.Sprintf("%04s", alpha)
+	if strings.Contains(a, "alpha") {
+		suffixpos = strings.Index(a, "-alpha")
+		version = a[0:suffixpos]
+		suffixStr = a[suffixpos+6 : len(a)]
+		suffix = "0" + fmt.Sprintf("%03s", suffixStr)
+	} else if strings.Contains(a, "beta") {
+		suffixpos = strings.Index(a, "-beta")
+		version = a[0:suffixpos]
+		suffixStr = a[suffixpos+5 : len(a)]
+		suffix = "1" + fmt.Sprintf("%03s", suffixStr)
 	} else {
 		version = a
-		suffix = "1000"
+		suffix = "5000"
 	}
 	split := strings.Split(version, ".")
-
 	var verArr []string
 
 	verArr = append(verArr, "1")
-	for i := 0; i < len(split); i++ {
-		var tmp = split[i]
+	var tmp string
+	for i := 0; i < 3; i++ {
+		if i < len(split) {
+			tmp = split[i]
+		} else {
+			tmp = "0"
+		}
 		verArr = append(verArr, fmt.Sprintf("%04s", tmp))
 	}
 	verArr = append(verArr, suffix)


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支

把版本号字符串转换成数字进行比较
数字有5个部分,
首部分固定为1
然后3个部分转换为四位整数
最后一部分如果是alpha,则转换成4位整数, 否则固定为1000
比如 " 2.3.4-alpha5 " => 1 0002 0003 0004 0005
"                  10.3.4  " => 1 0010 0003 0004 1000
这样
2.3.3 < 2.3.4-alpha5 < 2.3.4 < 10.0.0
