### PR TITLE
:art: 文档树，当需要自动定位的文件在可视区域内，则不跳转；

### DIFF
--- a/app/src/assets/scss/base.scss
+++ b/app/src/assets/scss/base.scss
@@ -508,6 +508,10 @@ progressLoading: 400
       box-shadow: 0 2px 0 var(--b3-theme-primary-lighter), inset 0px -2px 0 var(--b3-theme-primary-lighter);
     }
   }
+  
+  &__content {
+    position: relative;
+  }
 
   &:hover .block__icons .block__icon:not([disabled]) {
     opacity: 1;

--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -80,7 +80,7 @@ export class Files extends Model {
     <span class="fn__space"></span>
     <span data-type="min" class="block__icon b3-tooltips b3-tooltips__sw" aria-label="${window.siyuan.languages.min} ${updateHotkeyTip(window.siyuan.config.keymap.general.closeTab.custom)}"><svg><use xlink:href='#iconMin'></use></svg></span>
 </div>
-<div class="fn__flex-1"></div>
+<div class="fn__flex-1 file-tree__content"></div>
 <ul class="b3-list fn__flex-column" style="min-height: auto;transition: var(--b3-transition)">
     <li class="b3-list-item" data-type="toggle">
         <span class="b3-list-item__toggle">
@@ -861,10 +861,19 @@ export class Files extends Model {
             liItem.classList.remove("b3-list-item--focus");
         });
         target.classList.add("b3-list-item--focus");
-        if (isScroll) {
-            this.element.scrollTop = target.offsetTop - this.element.clientHeight / 2 - this.actionsElement.clientHeight;
+        if (isScroll && !this.isInViewPort(target)) {
+            this.element.scrollTop = target.offsetTop - this.element.clientHeight / 2;
         }
-    }
+    }  
+    /**
+    * 判断元素是否在文件树的可见视图中
+    * @param el 
+    * @returns 
+    */
+    private isInViewPort(target: HTMLElement) {
+         const pos = target.offsetTop - this.element.scrollTop;
+         return pos > 0 && pos < this.element.clientHeight - target.clientHeight;
+     }
 
     public getLeaf(liElement: Element, notebookId: string) {
         const toggleElement = liElement.querySelector(".b3-list-item__arrow");


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents 对于贡献新特性，请补充完善对应用户指南文档
* [x] For bug fixes, please describe the problem and solution via code comments 对于修复缺陷，请通过代码注释描述问题和解决方案
* [ ] For text improvements (such as typos and wording adjustments), please submit directly 对于文案改进（比如错别字措辞调整）请直接提交


文档树，当需要自动定位的文件在可视范围内，则不跳转；当不在可视范围内，则自动跳转。

重现方法：
1. 设置>文档树，开启【适中定位打开的文档】
2. 点击文档树中的文件（选择在可视区域内的文件），文档树进行自动跳转。

修改方法：
1. 自动定位时，判断文件在可视区域，则不跳转；不在可视区域则跳转
