### PR TITLE
开启 `始终定位打开的文档` 后再次选中文档页签时不再定位

### DIFF
--- a/app/src/editor/util.ts
+++ b/app/src/editor/util.ts
@@ -345,7 +345,7 @@ export const updatePanelByEditor = (protyle?: IProtyle, focus = true, pushBackSt
         }
         if (window.siyuan.config.fileTree.alwaysSelectOpenedFile && protyle) {
             const fileModel = getDockByType("file")?.data.file;
-            if (fileModel instanceof Files) {
+            if (fileModel instanceof Files && !fileModel.isSelected(protyle.path)) {
                 fileModel.selectItem(protyle.notebookId, protyle.path);
             }
         }

--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -852,6 +852,21 @@ export class Files extends Model {
         liElement.insertAdjacentHTML("afterend", `<ul>${fileHTML}</ul>`);
         this.setCurrent(this.element.querySelector(`ul[data-url="${data.box}"] li[data-path="${filePath}"]`));
     }
+    /**
+     * 判断文件树中当前选中的是否是此文件
+     * @param filePath 要判断的文件路径
+     * @returns 
+     */
+    public isSelected(filePath: string): boolean {
+        if(!filePath) {
+            return false;
+        }
+        const target = this.element.querySelector(`li[data-path="${filePath}"]`);
+        if(target) {
+            return target.classList.contains("b3-list-item--focus");
+        }
+        return false;
+    }
 
     private setCurrent(target: HTMLElement, isScroll = true) {
         if (!target) {


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents 对于贡献新特性，请补充完善对应用户指南文档
* [x] For bug fixes, please describe the problem and solution via code comments 对于修复缺陷，请通过代码注释描述问题和解决方案
* [ ] For text improvements (such as typos and wording adjustments), please submit directly 对于文案改进（比如错别字措辞调整）请直接提交

已选中的文件再次选中时，不会在文件树中跳转

问题：
1. 在文件树中，选中一个文件后，文件树会自动滚动，与常用的用户习惯不一样（在文件树中操作时，文件树不应滚动，便于用户对文件树进行其他操作）
2. 选中一个文件后，手动滚动文件树，在Tab中点击文件，文件树也会自动滚动；可以参照vscode，已选中的文件再次选中后，不应滚动文件树。
![动画](https://user-images.githubusercontent.com/21106029/206445402-a1afe09f-0d2b-40ff-954a-6521cc1a14ee.gif)



重现方法：
1. 设置>文档树，开启【适中定位打开的文档】
4. 点击文档树中的文件（选择在可视区域内的文件），文档树进行自动滚动，将点击的文件居中。

修改方法：
1. 已选中的文件再次选中时，禁止在文件树中跳转

