### PR TITLE
支持通过 URL 查询字符串参数 `id` 和 `focus` 跳转到 Web 端指定块

### DIFF
--- a/app/src/util/onGetConfig.ts
+++ b/app/src/util/onGetConfig.ts
@@ -102,7 +102,16 @@ export const setProxy = () => {
     });
     /// #endif
 };
-
+// 获取 location.search 里特定参数,失败返回false
+function getUrlArg(arg_name: string) {
+    var query = window.location.search.substring(1);
+    var vars = query.split("&");
+    for (var i=0;i<vars.length;i++) {
+        var pair = vars[i].split("=");
+        if(pair[0] == arg_name){return pair[1];}
+    }
+    return false;
+}
 export const onGetConfig = (isStart: boolean) => {
     const matchKeymap1 = matchKeymap(Constants.SIYUAN_KEYMAP.general, "general");
     const matchKeymap2 = matchKeymap(Constants.SIYUAN_KEYMAP.editor.general, "editor", "general");
@@ -176,6 +185,18 @@ export const onGetConfig = (isStart: boolean) => {
         mountHelp();
     }
     addGA();
+    //根据url里的id参数打开相应的块,用于浏览器访问
+    let url_doc_id=getUrlArg("id")
+    if (url_doc_id) {
+        fetchPost("/api/block/getBlockInfo", {id: url_doc_id}, response => {
+            if (response.code === 0 && typeof url_doc_id === "string") {
+                openFileById({
+                    id: url_doc_id,
+                    action: [Constants.CB_GET_FOCUS, Constants.CB_GET_CONTEXT,]
+                })
+            }
+        })
+    }
 };
 
 const initBar = () => {


### PR DESCRIPTION
 URL 参数支持 id=<内容块ID或文档ID>, 在 Web 端加载后可以跳转到指定的内容块或文档
https://github.com/siyuan-note/siyuan/issues/3949
使用示例:
```
打开帮助文档: 跳转到块"为您提供安全保障"
http://127.0.0.1:6806/stage/build/desktop/?id=20220212224529-ei1egya
打开帮助文档-常见问题
http://127.0.0.1:6806/stage/build/desktop/?id=20200813093015-u6bopdt
```

* [ ] Please commit to the dev branch 请提交到 dev 开发分支
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents 对于贡献新特性，请补充完善对应用户指南文档
* [ ] For bug fixes, please describe the problem and solution via code comments 对于修复缺陷，请通过代码注释描述问题和解决方案
* [ ] For text improvements (such as typos and wording adjustments), please submit directly 对于文案改进（比如错别字措辞调整）请直接提交


