### PR TITLE
改进 `getSearch` 函数实现

### DIFF
--- a/app/src/layout/util.ts
+++ b/app/src/layout/util.ts
@@ -299,7 +299,7 @@ export const JSONToLayout = (isStart: boolean) => {
         });
     }
     // https://github.com/siyuan-note/siyuan/pull/7086
-    const openId = getSearch("id", window.location.href)
+    const openId = getSearch("id", window.location.href);
     if (openId !== null) {
         openFileById({
             id: openId,

--- a/app/src/layout/util.ts
+++ b/app/src/layout/util.ts
@@ -300,9 +300,9 @@ export const JSONToLayout = (isStart: boolean) => {
     }
     // https://github.com/siyuan-note/siyuan/pull/7086
     const openId = getSearch("id", window.location.href)
-    if (openId) {
+    if (openId !== null) {
         openFileById({
-            id: getSearch("id", window.location.href),
+            id: openId,
             action: [Constants.CB_GET_FOCUS, Constants.CB_GET_CONTEXT],
             zoomIn: getSearch("focus", window.location.href) === "1"
         });

--- a/app/src/mobile/util/initFramework.ts
+++ b/app/src/mobile/util/initFramework.ts
@@ -130,8 +130,8 @@ export const initFramework = () => {
     initEditorName();
     if (getOpenNotebookCount() > 0) {
         const openId = getSearch("id", window.location.href);
-        if (openId) {
-            openMobileFileById(getSearch("id", window.location.href),
+        if (openId !== null) {
+            openMobileFileById(openId,
                 getSearch("focus", window.location.href) === "1" ? [Constants.CB_GET_ALL, Constants.CB_GET_FOCUS] : [Constants.CB_GET_FOCUS, Constants.CB_GET_CONTEXT]);
         } else {
             const localDoc = window.siyuan.storage[Constants.LOCAL_DOCINFO];

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -1578,7 +1578,7 @@ export class WYSIWYG {
                             openBy(linkAddress, "app");
                         } else {
                             const page = getSearch("page", linkAddress);
-                            openAsset(linkPathname, page === "" ? undefined : parseInt(page), "right");
+                            openAsset(linkPathname, page === null ? undefined : parseInt(page), "right");
                         }
                     } else {
                         /// #if !BROWSER

--- a/app/src/util/functions.ts
+++ b/app/src/util/functions.ts
@@ -15,13 +15,9 @@ export const getRandom = (min: number, max: number) => {
 };
 
 export const getSearch: (key: string, link?: string) => string | null = (key: string, link = window.location.search) => {
-    try {
-        // REF https://developer.mozilla.org/zh-CN/docs/Web/API/URLSearchParams
-        const urlSearchParams = new URLSearchParams(link);
-        return urlSearchParams.get(key);
-    } catch (error) {
-        return null;
-    }
+    // REF https://developer.mozilla.org/zh-CN/docs/Web/API/URLSearchParams
+    const urlSearchParams = new URLSearchParams(link);
+    return urlSearchParams.get(key);
 };
 
 export const isBrowser = () => {

--- a/app/src/util/functions.ts
+++ b/app/src/util/functions.ts
@@ -14,20 +14,14 @@ export const getRandom = (min: number, max: number) => {
     return Math.floor(Math.random() * (max - min + 1)) + min; //含最大值，含最小值
 };
 
-export const getSearch = (key: string, link = window.location.search) => {
-    if (link.indexOf("?") === -1) {
-        return "";
+export const getSearch: (key: string, link?: string) => string | null = (key: string, link = window.location.search) => {
+    try {
+        // REF https://developer.mozilla.org/zh-CN/docs/Web/API/URLSearchParams
+        const urlSearchParams = new URLSearchParams(link);
+        return urlSearchParams.get(key);
+    } catch (error) {
+        return null;
     }
-    let value = "";
-    const data = link.split("?")[1].split("&");
-    data.find(item => {
-        const keyValue = item.split("=");
-        if (keyValue[0] === key) {
-            value = keyValue[1];
-            return true;
-        }
-    });
-    return value;
 };
 
 export const isBrowser = () => {


### PR DESCRIPTION
兼容 key 为空字符串与 value 为空字符串的 URL search params

* [x] Please commit to the dev branch 请提交到 dev 开发分支
* [x] For bug fixes, please describe the problem and solution via code comments 对于修复缺陷，请通过代码注释描述问题和解决方案

URL search params 中 `key` 与 `value` 均可为空字符串, 且其中的字符可能会进行 URI 编码, 因此需要进行规范处理
