### PR TITLE
移动端底部工具栏遮挡侧边栏问题

### DIFF
--- a/app/src/assets/scss/mobile.scss
+++ b/app/src/assets/scss/mobile.scss
@@ -227,7 +227,7 @@
   box-sizing: border-box;
   height: 32px;
   background: var(--b3-theme-background);
-  z-index: 221;
+  z-index: 219;
   display: flex;
   border-top: 1px solid var(--b3-theme-surface-lighter);
 


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支

底部工具栏原层级为 `221`, 会遮挡左侧抽屉(文档树, 大纲, 反向链接面板等)的底部, 也会遮挡右侧抽屉(设置, 搜索, 历史, 账号等)的底部