### PR TITLE
使用 HTTPS 访问认证页面时无法建立 WebSocket 连接

### DIFF
--- a/app/stage/auth.html
+++ b/app/stage/auth.html
@@ -529,7 +529,7 @@
   }
 
   // 用于授权页保持连接，避免非常驻内存内核自动退出 https://github.com/siyuan-note/insider/issues/1099
-  new WebSocket(window.location.protocol === 'https:' ? 'wss' : 'ws' + '://' + window.location.host + '/ws?app=siyuan&id=auth')
+  new WebSocket(`${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws?app=siyuan&id=auth`)
 </script>
 </body>
 </html>


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支
* [ ] For bug fixes, please describe the problem and solution via code comments 对于修复缺陷，请通过代码注释描述问题和解决方案

认证页面的如下语句运算符优先级错误导致使用 `https` 协议访问时 websocket 的 URL 设置错误(设置为了 `wss` 而非 `wss://host/ws?app=siyuan&id=auth`)
```js
new WebSocket(window.location.protocol === 'https:' ? 'wss' : 'ws' + '://' + window.location.host + '/ws?app=siyuan&id=auth')
```
