### PR TITLE
:art: 为页面 `html` 标签添加属性 `data-color-scheme`

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -24,6 +24,7 @@ import {initMessage} from "./dialog/message";
 import {resizeDrag} from "./layout/util";
 import {getAllTabs} from "./layout/getAll";
 import {getLocalStorage} from "./protyle/util/compatibility";
+import {updateColorScheme} from "./util/functions";
 
 class App {
     constructor() {
@@ -113,6 +114,7 @@ class App {
                                     (document.getElementById("themeStyle") as HTMLLinkElement).href = data.data.theme;
                                 } else {
                                     (document.getElementById("themeDefaultStyle") as HTMLLinkElement).href = data.data.theme;
+                                    updateColorScheme(window.siyuan.config.appearance.mode);
                                 }
                                 break;
                             case "createdailynote":

--- a/app/src/protyle/export/index.ts
+++ b/app/src/protyle/export/index.ts
@@ -15,6 +15,7 @@ import {lockFile} from "../../dialog/processSystem";
 import {pathPosix} from "../../util/pathName";
 import {replaceLocalPath} from "../../editor/rename";
 import {setStorageVal} from "../util/compatibility";
+import {getColorSchemeName} from "../../util/functions";
 
 export const saveExport = (option: { type: string, id: string }) => {
     /// #if !BROWSER
@@ -79,7 +80,7 @@ const renderPDF = (id: string) => {
     if (!isDefault) {
         themeStyle = `<link rel="stylesheet" type="text/css" id="themeStyle" href="${servePath}/appearance/themes/${window.siyuan.config.appearance.themeLight}/${window.siyuan.config.appearance.customCSS ? "custom" : "theme"}.css?${Constants.SIYUAN_VERSION}"/>`;
     }
-    const html = `<!DOCTYPE html><html>
+    const html = `<!DOCTYPE html><html data-color-scheme="${getColorSchemeName(window.siyuan.config.appearance.mode)}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -553,7 +554,7 @@ const onExport = (data: IWebSocketData, filePath: string, type: string, removeAs
     if (!isDefault) {
         themeStyle = `<link rel="stylesheet" type="text/css" id="themeStyle" href="appearance/themes/${themeName}/${window.siyuan.config.appearance.customCSS ? "custom" : "theme"}.css?${Constants.SIYUAN_VERSION}"/>`;
     }
-    const html = `<!DOCTYPE html><html>
+    const html = `<!DOCTYPE html><html data-color-scheme="${getColorSchemeName(window.siyuan.config.appearance.mode)}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/src/util/assets.ts
+++ b/app/src/util/assets.ts
@@ -5,7 +5,7 @@ import {addStyle} from "../protyle/util/addStyle";
 import {getAllModels} from "../layout/getAll";
 import {exportLayout} from "../layout/util";
 /// #endif
-import {isMobile} from "./functions";
+import {isMobile, updateColorScheme} from "./functions";
 import {fetchPost} from "./fetch";
 import {appearance} from "../config/appearance";
 
@@ -44,6 +44,8 @@ export const loadAssets = (data: IAppearance) => {
     } else {
         addStyle(defaultThemeAddress, "themeDefaultStyle");
     }
+    updateColorScheme(data.mode);
+
     const styleElement = document.getElementById("themeStyle");
     if ((data.mode === 1 && data.themeDark !== "midnight") || (data.mode === 0 && data.themeLight !== "daylight")) {
         const themeAddress = `/appearance/themes/${data.mode === 1 ? data.themeDark : data.themeLight}/${data.customCSS ? "custom" : "theme"}.css?v=${data.customCSS ? new Date().getTime() : data.themeVer}`;

--- a/app/src/util/functions.ts
+++ b/app/src/util/functions.ts
@@ -46,3 +46,23 @@ export const isFileAnnotation = (text: string) => {
 export const looseJsonParse = (text: string) => {
     return Function(`"use strict";return (${text})`)();
 };
+
+export const getColorSchemeName = (mode: number) => {
+    switch (mode) {
+        case 0:
+            return "light";
+        case 1:
+            return "dark";
+        default:
+            return null;
+    }
+}
+
+export const updateColorScheme = (mode: number) => {
+    const name = getColorSchemeName(mode);
+    if (name) {
+        document.documentElement.dataset.colorScheme = name;
+    } else {
+        delete document.documentElement.dataset.colorScheme;
+    }
+};

--- a/app/src/window/index.ts
+++ b/app/src/window/index.ts
@@ -21,6 +21,7 @@ import {initMessage} from "../dialog/message";
 import {getAllTabs} from "../layout/getAll";
 import {getLocalStorage} from "../protyle/util/compatibility";
 import {init} from "../window/init";
+import {updateColorScheme} from "../util/functions";
 
 class App {
     constructor() {
@@ -110,6 +111,7 @@ class App {
                                     (document.getElementById("themeStyle") as HTMLLinkElement).href = data.data.theme;
                                 } else {
                                     (document.getElementById("themeDefaultStyle") as HTMLLinkElement).href = data.data.theme;
+                                    updateColorScheme(window.siyuan.config.appearance.mode);
                                 }
                                 break;
                             case "createdailynote":


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支

目前主题判断当前主题模式共有如下方案, 但这些方案均有弊端
1. 使用 js 读取 `window.siyuan.config.appearance.mode` 属性
   - 在导出预览窗口中不加载 `theme.js`
2. 使用 css 进行媒体查询 `@media (prefers-color-scheme: light)` 与 `@media (prefers-color-scheme: dark)`
   - 浏览器中查询结果为系统应用主题而非思源主题
3. 使用 css 的 `:has` 选择器查询 `:root:has(#themeDefaultStyle[href *="/appearance/themes/midnight/"])` 与 `:root:has(#themeDefaultStyle[href *="/appearance/themes/daylight/"])`
   - 部分浏览器 暂不支持/默认关闭 `:has` 选择器

综上所述, 目前需要一个简单的方案实现使用 css 选择器判断当前主题模式
这里贡献一个为 html 标签设置属性 `data-color-scheme` 的方案, 属性值可为 `light` 或 `dark`