### PR TITLE
网络代理协议支持 `HTTP`

### DIFF
--- a/app/src/config/about.ts
+++ b/app/src/config/about.ts
@@ -153,6 +153,7 @@ export const about = {
             <option value="" ${window.siyuan.config.system.networkProxy.scheme === "" ? "selected" : ""}>${window.siyuan.languages.directConnection}</option>
             <option value="socks5" ${window.siyuan.config.system.networkProxy.scheme === "socks5" ? "selected" : ""}>SOCKS5</option>
             <option value="https" ${window.siyuan.config.system.networkProxy.scheme === "https" ? "selected" : ""}>HTTPS</option>
+            <option value="http" ${window.siyuan.config.system.networkProxy.scheme === "http" ? "selected" : ""}>HTTP</option>
         </select>
         <span class="fn__space"></span>
         <input id="aboutHost" placeholder="Host/IP" class="b3-text-field fn__block" value="${window.siyuan.config.system.networkProxy.host}"/>


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支

使用 HTTPS 协议链接 HTTP 代理服务器会出现 `ERR_PROXY_CONNECTION_FAILED` 错误, 因此代理协议选择器需要添加一个 `HTTP` 选项

已于 Windows 11 22H2 22621.1265 平台测试