### PR TITLE
修复窗口内浮窗滚动条问题

### DIFF
--- a/app/src/assets/scss/protyle/_content.scss
+++ b/app/src/assets/scss/protyle/_content.scss
@@ -1,6 +1,6 @@
 .protyle {
   font-family: var(--b3-font-family);
-  overflow-x: hidden;
+  overflow: hidden;
   background-color: var(--b3-theme-background);
   position: relative;
   max-height: 100%;


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支

由于浮窗预览中的 `.protyle` 元素的 `overflow-y` 属性未设置为 `hidden`, 导致出现双滚动条, 且外侧滚动条向下滚动时面包屑栏会移出视窗外, 如下图所示

![image](https://user-images.githubusercontent.com/49649786/222906764-47610a0c-5e9c-437d-bdd6-cc867db49a4f.png)

