### PR TITLE
修复桌面端切换主题时不更改 `nativeTheme.themeSource` 的问题

### DIFF
--- a/app/src/config/appearance.ts
+++ b/app/src/config/appearance.ts
@@ -9,7 +9,7 @@ import {fetchPost} from "../util/fetch";
 import {genOptions} from "../util/genOptions";
 import {openSnippets} from "./util/snippets";
 import {openColorPicker} from "./util/colorPicker";
-import {loadAssets} from "../util/assets";
+import {loadAssets, setNativeTheme} from "../util/assets";
 import {resetFloatDockSize} from "../layout/dock/util";
 
 export const appearance = {
@@ -189,21 +189,24 @@ export const appearance = {
             nativeEmoji: (appearance.element.querySelector("#nativeEmoji") as HTMLInputElement).checked,
             hideStatusBar: (appearance.element.querySelector("#hideStatusBar") as HTMLInputElement).checked,
         }, response => {
+            setNativeTheme(response.data.modeOS, response.data.mode);
             if (window.siyuan.config.appearance.themeJS) {
-                if (!response.data.modeOS && (
-                    response.data.mode !== window.siyuan.config.appearance.mode ||
-                    window.siyuan.config.appearance.themeLight !== response.data.themeLight ||
-                    window.siyuan.config.appearance.themeDark !== response.data.themeDark
-                )) {
-                    exportLayout(true);
-                    return;
-                }
-                const OSTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-                if (response.data.modeOS && (
-                    (response.data.mode === 1 && OSTheme === "light") || (response.data.mode === 0 && OSTheme === "dark")
-                )) {
-                    exportLayout(true);
-                    return;
+                if (response.data.modeOS) {
+                    const OSTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+                    if ((response.data.mode === 1 && OSTheme === "light") ||
+                    (response.data.mode === 0 && OSTheme === "dark")
+                    ) {
+                        exportLayout(true);
+                        return;
+                    }
+                } else {
+                    if (response.data.mode !== window.siyuan.config.appearance.mode ||
+                        window.siyuan.config.appearance.themeLight !== response.data.themeLight ||
+                        window.siyuan.config.appearance.themeDark !== response.data.themeDark
+                    ) {
+                        exportLayout(true);
+                        return;
+                    }
                 }
             }
             appearance.onSetappearance(response.data);

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -6,6 +6,7 @@ import "./assets/scss/base.scss";
 import {initBlockPopover} from "./block/popover";
 import {account} from "./config/account";
 import {addScript, addScriptSync} from "./protyle/util/addScript";
+import {setNativeTheme} from "./util/assets";
 import {genUUID} from "./util/genID";
 import {fetchGet, fetchPost} from "./util/fetch";
 import {addBaseURL, setNoteBook} from "./util/pathName";
@@ -163,6 +164,7 @@ class App {
                     });
                 });
             });
+            setNativeTheme();
         });
         setNoteBook();
         initBlockPopover();


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支

由于目前仅通过加载不同样式文件的方案更改配色, 未改变 electron 的 `nativeTheme.themeSource` 值, 由于该值默认为 `'system'`, 这会导致如下问题
- 开发者工具主题模式与当前界面主题模式可能不一致
- 内嵌的挂件/iframe 使用 `@media (prefers-color-scheme: dark)` 或 `window.matchMedia("(prefers-color-scheme: dark)").matches` 查询的是系统主题模式而非当前界面的主题模式, 因此可能导致色彩渲染异常

本次提交新增了在加载界面/更改主题模式时同步更新 `nativeTheme.themeSource` 的功能, 可以解决以上问题

已于 Windows 11 22H2 22621.1344 平台测试