### PR TITLE
fix action Warning: The set-output command is deprecated and will be disabled soon.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,19 @@ jobs:
 
       - name: Gather Release Information
         id: release_info
+        # 注意：创建或更新环境变量的步骤无权访问新值；$GITHUB_OUTPUT 需要定义步骤 id 才能稍后检索输出值，$GITHUB_ENV 则不需要
+        # 以下转换不再需要：
+        #   changelog="${changelog//'%'/'%25'}"
+        #   changelog="${changelog//$'\n'/'%0A'}"
+        #   changelog="${changelog//$'\r'/'%0D'}"
         run: |
-          echo "::set-output name=release_title::$(git show --format=%s --no-patch | head -1)"
-          echo "::set-output name=release_version::$(TZ=Asia/Shanghai date +'v%Y%m%d%H%M')"
+          echo "release_title=$(git show --format=%s --no-patch | head -1)" >> $GITHUB_OUTPUT
+          echo "release_version=$(TZ=Asia/Shanghai date +'v%Y%m%d%H%M')" >> $GITHUB_OUTPUT
           changelog=$(python scripts/parse-changelog.py -t ${{ github.ref }} siyuan-note/siyuan)
-          changelog="${changelog//'%'/'%25'}"
-          changelog="${changelog//$'\n'/'%0A'}"
-          changelog="${changelog//$'\r'/'%0D'}"
-          echo "::set-output name=release_body::$changelog"
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "release_body<<$EOF" >> $GITHUB_ENV
+          echo "$changelog" >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,7 +58,7 @@ jobs:
         with:
           release_name: ${{ steps.release_info.outputs.release_version }}
           tag_name: ${{ github.ref }}
-          body: ${{ steps.release_info.outputs.release_body }}
+          body: ${{ env.release_body }}
           draft: false
           prerelease: true
 


### PR DESCRIPTION
[Starting 1st June 2023 workflows using or commands via stdout will fail with an error](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

- [x]  test run pass