### PR TITLE
Enhance ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
       - id: thislatestR
         uses: pozetroninc/github-action-get-latest-release@master
         with:
-          owner: siyuan-note
-          repo: siyuan
+          # owner: siyuan-note
+          # repo: siyuan
+          repository: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           excludes: prerelease, draft
 
       - name: Gather Release Information

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,20 @@ jobs:
         with:
           python-version: "3.10"
       - run: pip install PyGithub
+      
+      - id: thislatestR
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: siyuan-note
+          repo: siyuan
+          excludes: prerelease, draft
 
       - name: Gather Release Information
         id: release_info
         run: |
           echo "release_title=$(git show --format=%s --no-patch | head -1)" >> $GITHUB_OUTPUT
           echo "release_version=$(TZ=Asia/Shanghai date +'v%Y%m%d%H%M')" >> $GITHUB_OUTPUT
-          changelog=$(python scripts/parse-changelog.py -t ${{ github.ref }} siyuan-note/siyuan)
+          changelog=$(python scripts/parse-changelog.py -t ${{ github.ref }} -b ${{ steps.thislatestR.outputs.release }} siyuan-note/siyuan)
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "release_body<<$EOF" >> $GITHUB_ENV
           echo "$changelog" >> $GITHUB_ENV
@@ -143,7 +150,7 @@ jobs:
       working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app
 
     - name: Install Node Dependencies
-      run: pnpm install
+      run: pnpm install --no-frozen-lockfile
       working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app
       
     - name: Building UI

--- a/scripts/parse-changelog.py
+++ b/scripts/parse-changelog.py
@@ -16,7 +16,7 @@ docmap = {
 }
 
 
-def generate_msg_from_repo(repo_name, tag_name):
+def generate_msg_from_repo(repo_name, tag_name, lastestRelease):
     """Generate changelog messages from repository and tag name.
 
     Envs:
@@ -33,7 +33,7 @@ def generate_msg_from_repo(repo_name, tag_name):
 
     gh = github.Github(token, base_url=f"https://{hostname}")
     repo = gh.get_repo(repo_name)
-    milestone = find_milestone(repo, tag_name)
+    milestone = find_milestone(repo, tag_name, lastestRelease)
 
     for issue in repo.get_issues(state="closed", milestone=milestone):
         # REF https://pygithub.readthedocs.io/en/latest/github_objects/Issue.html#github.Issue.Issue
@@ -43,7 +43,7 @@ def generate_msg_from_repo(repo_name, tag_name):
     generate_msg(desc_mapping)
 
 
-def find_milestone(repo, title):
+def find_milestone(repo, title, lastestRelease):
     """Find the milestone in a repository that is similar to milestone title
 
     Args:
@@ -55,9 +55,21 @@ def find_milestone(repo, title):
         If no milestone matches, it will return None
     """
     pat = re.search("v([0-9.]+)", title)
+    thisRelease = title.split("/")[-1]
     if not pat:
         return None
     version = pat.group(1)
+    print(f'''
+---
+<p align="center">
+<a href="https://github.com/siyuan-note/siyuan/actions/workflows/ci.yml"><img src="https://github.com/siyuan-note/siyuan/actions/workflows/ci.yml/badge.svg" style="cursor:pointer;height: 30px;margin: 3px auto;"/></a>
+<a href="https://github.com/siyuan-note/siyuan/releases/{thisRelease}/"><img src="https://img.shields.io/github/downloads/siyuan-note/siyuan/{thisRelease}/total?logo=github" style="cursor:pointer;height: 30px;margin: 3px auto;"/></a>
+<img alt="GitHub commits difference between two branches/tags/commits" src="https://img.shields.io/github/commits-difference/siyuan-note/siyuan?base={lastestRelease}&head={thisRelease}&logo=git" style="cursor:pointer;height: 30px;margin: 3px auto;"/>
+</p>
+
+---
+
+''')
     for milestone in repo.get_milestones():
         if version in milestone.title:
             return milestone
@@ -88,10 +100,11 @@ if __name__ == "__main__":
         description="Automaticly generate information from issues by tag."
     )
     parser.add_argument("-t", "--tag", help="the tag to filter issues.")
+    parser.add_argument("-b", "--lastestRelease", help="lastest Release")
     parser.add_argument("repo", help="The repository name")
     args = parser.parse_args()
 
     try:
-        generate_msg_from_repo(args.repo, args.tag)
+        generate_msg_from_repo(args.repo, args.tag, args.lastestRelease)
     except AssertionError:
         print(args.tag)

--- a/scripts/parse-changelog.py
+++ b/scripts/parse-changelog.py
@@ -62,7 +62,7 @@ def find_milestone(repo, title, lastestRelease):
     print(f'''
 ---
 <p align="center">
-<a href="https://github.com/siyuan-note/siyuan/actions/workflows/ci.yml"><img src="https://github.com/siyuan-note/siyuan/actions/workflows/ci.yml/badge.svg" style="cursor:pointer;height: 30px;margin: 3px auto;"/></a>
+<a href="https://github.com/siyuan-note/siyuan/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/siyuan-note/siyuan/ci.yml?event=push&label=ci.yml%20Action&logo=github" style="cursor:pointer;height: 30px;margin: 3px auto;"/></a>
 <a href="https://github.com/siyuan-note/siyuan/releases/{thisRelease}/"><img src="https://img.shields.io/github/downloads/siyuan-note/siyuan/{thisRelease}/total?logo=github" style="cursor:pointer;height: 30px;margin: 3px auto;"/></a>
 <img alt="GitHub commits difference between two branches/tags/commits" src="https://img.shields.io/github/commits-difference/siyuan-note/siyuan?base={lastestRelease}&head={thisRelease}&logo=git" style="cursor:pointer;height: 30px;margin: 3px auto;"/>
 </p>


### PR DESCRIPTION
preview
![image](https://user-images.githubusercontent.com/83791825/228293805-a3b43457-226d-4cc9-8a72-361b48547a58.png)
it works when a new *-dev tag push as a trigger
commits difference compare with latest release `excludes: prerelease, draft`
by the way, this PR fixed a possible reasons for the action failure by add `--no-frozen-lockfile` to pnpm install command