### PR TITLE
Adjusted the YFM style with widget export

### DIFF
--- a/app/src/assets/scss/component/_typography.scss
+++ b/app/src/assets/scss/component/_typography.scss
@@ -245,7 +245,7 @@
     }
   }
 
-  code:not(.hljs),
+  code:not(.hljs):not([data-type="yaml-front-matter"]),
   span[data-type~="code"] {
     @extend .fn__code;
   }


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支
* [x] For bug fixes, please describe the problem and solution via code comments 对于修复缺陷，请通过代码注释描述问题和解决方案

![image](https://user-images.githubusercontent.com/49649786/228557402-055eaef8-8a24-4837-9517-6298531716b0.png)

应用于 `<code>` 标签的样式未忽略 `[data-type="yaml-front-matter"]` 元素  
Styles applied to the `<code>` tag do not ignore elements with `[data-type="yaml-front-matter"]`.
