### PR TITLE
AI translation adds support for `Traditional Chinese`

### DIFF
--- a/app/appearance/langs/en_US.json
+++ b/app/appearance/langs/en_US.json
@@ -39,6 +39,8 @@
   "aiTranslate": "Translate",
   "aiExtractSummary": "Extract summary",
   "aiTranslate_zh_CN": "Chinese",
+  "aiTranslate_zh_Hans": "Simplified Chinese",
+  "aiTranslate_zh_Hant": "Traditional Chinese",
   "aiTranslate_ja_JP": "Japanese",
   "aiTranslate_ko_KR": "Korean",
   "aiTranslate_en_US": "English",

--- a/app/appearance/langs/es_ES.json
+++ b/app/appearance/langs/es_ES.json
@@ -39,6 +39,8 @@
   "aiTranslate": "Traducir",
   "aiExtractSummary": "Extraer resumen",
   "aiTranslate_zh_CN": "Chino",
+  "aiTranslate_zh_Hans": "Chino simplificado",
+  "aiTranslate_zh_Hant": "Chino tradicional",
   "aiTranslate_ja_JP": "Japonés",
   "aiTranslate_ko_KR": "Coreano",
   "aiTranslate_en_US": "Inglés",

--- a/app/appearance/langs/fr_FR.json
+++ b/app/appearance/langs/fr_FR.json
@@ -39,6 +39,8 @@
   "aiTranslate": "Traduire",
   "aiExtractSummary": "Résumé de l'extrait",
   "aiTranslate_zh_CN": "Chinois",
+  "aiTranslate_zh_Hans": "Chinois simplifié",
+  "aiTranslate_zh_Hant": "chinois traditionnel",
   "aiTranslate_ja_JP": "Japonais",
   "aiTranslate_ko_KR": "Coréen",
   "aiTranslate_en_US": "Anglais",

--- a/app/appearance/langs/zh_CHT.json
+++ b/app/appearance/langs/zh_CHT.json
@@ -39,6 +39,8 @@
   "aiTranslate": "翻譯",
   "aiExtractSummary": "提取摘要",
   "aiTranslate_zh_CN": "中文",
+  "aiTranslate_zh_Hans": "簡體中文",
+  "aiTranslate_zh_Hant": "繁體中文",
   "aiTranslate_ja_JP": "日文",
   "aiTranslate_ko_KR": "韓文",
   "aiTranslate_en_US": "英文",

--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -39,6 +39,8 @@
   "aiTranslate": "翻译",
   "aiExtractSummary": "提取摘要",
   "aiTranslate_zh_CN": "中文",
+  "aiTranslate_zh_Hans": "简体中文",
+  "aiTranslate_zh_Hant": "繁体中文",
   "aiTranslate_ja_JP": "日文",
   "aiTranslate_ko_KR": "韩文",
   "aiTranslate_en_US": "英文",

--- a/app/src/ai/actions.ts
+++ b/app/src/ai/actions.ts
@@ -155,11 +155,22 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
             type: "submenu",
             submenu: [{
                 iconHTML: Constants.ZWSP,
-                label: window.siyuan.languages.aiTranslate_zh_CN,
+                label: window.siyuan.languages.aiTranslate_zh_Hans,
                 click() {
                     fetchPost("/api/ai/chatGPTWithAction", {
                         ids,
-                        action: "Translate as follows to [zh_CN]"
+                        action: "Translate as follows to [zh-Hans]"
+                    }, (response) => {
+                        fillContent(protyle, response.data, elements);
+                    });
+                }
+            }, {
+                iconHTML: Constants.ZWSP,
+                label: window.siyuan.languages.aiTranslate_zh_Hant,
+                click() {
+                    fetchPost("/api/ai/chatGPTWithAction", {
+                        ids,
+                        action: "Translate as follows to [zh-Hant]"
                     }, (response) => {
                         fillContent(protyle, response.data, elements);
                     });
@@ -170,7 +181,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
                 click() {
                     fetchPost("/api/ai/chatGPTWithAction", {
                         ids,
-                        action: "Translate as follows to [ja_JP]"
+                        action: "Translate as follows to [ja-JP]"
                     }, (response) => {
                         focusByRange(protyle.toolbar.range);
                         insertHTML(response.data, protyle, true);
@@ -182,7 +193,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
                 click() {
                     fetchPost("/api/ai/chatGPTWithAction", {
                         ids,
-                        action: "Translate as follows to [ko_KR]"
+                        action: "Translate as follows to [ko-KR]"
                     }, (response) => {
                         fillContent(protyle, response.data, elements);
                     });
@@ -193,7 +204,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
                 click() {
                     fetchPost("/api/ai/chatGPTWithAction", {
                         ids,
-                        action: "Translate as follows to [en_US]"
+                        action: "Translate as follows to [en-US]"
                     }, (response) => {
                         fillContent(protyle, response.data, elements);
                     });
@@ -204,7 +215,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
                 click() {
                     fetchPost("/api/ai/chatGPTWithAction", {
                         ids,
-                        action: "Translate as follows to [es_ES]"
+                        action: "Translate as follows to [es-ES]"
                     }, (response) => {
                         fillContent(protyle, response.data, elements);
                     });
@@ -215,7 +226,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
                 click() {
                     fetchPost("/api/ai/chatGPTWithAction", {
                         ids,
-                        action: "Translate as follows to [fr_FR]"
+                        action: "Translate as follows to [fr-FR]"
                     }, (response) => {
                         fillContent(protyle, response.data, elements);
                     });
@@ -226,7 +237,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
                 click() {
                     fetchPost("/api/ai/chatGPTWithAction", {
                         ids,
-                        action: "Translate as follows to [de_DE]"
+                        action: "Translate as follows to [de-DE]"
                     }, (response) => {
                         fillContent(protyle, response.data, elements);
                     });

--- a/app/src/ai/actions.ts
+++ b/app/src/ai/actions.ts
@@ -183,8 +183,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
                         ids,
                         action: "Translate as follows to [ja-JP]"
                     }, (response) => {
-                        focusByRange(protyle.toolbar.range);
-                        insertHTML(response.data, protyle, true);
+                        fillContent(protyle, response.data, elements);
                     });
                 }
             }, {


### PR DESCRIPTION
* [x] Please commit to the dev branch 请提交到 dev 开发分支

AI 翻译功能中的 `中文` 调整为 `简体中文`  
'Chinese' in AI translation function adjusted to 'Chinese Simplified'

AI 翻译新增对 `繁体中文` 的支持  
AI translation adds support for `Traditional Chinese`

已通过测试  
Tested passed