### PR TITLE
Improve PDF export paging strategy

### DIFF
--- a/app/src/assets/scss/export.scss
+++ b/app/src/assets/scss/export.scss
@@ -34,3 +34,41 @@ svg {
 .b3-typography table, .protyle-wysiwyg table {
   display: table;
 }
+
+@media print {
+  #preview.protyle-wysiwyg {
+    [data-node-id] {
+
+      // 尽量避免音频块内分页
+      &[data-type=NodeAudio],
+      // 尽量避免图表块内分页
+      &[data-type=NodeCodeBlock][data-subtype=abc],
+      &[data-type=NodeCodeBlock][data-subtype=echarts],
+      &[data-type=NodeCodeBlock][data-subtype=flowchart],
+      &[data-type=NodeCodeBlock][data-subtype=graphviz],
+      &[data-type=NodeCodeBlock][data-subtype=mermaid],
+      &[data-type=NodeCodeBlock][data-subtype=mindmap],
+      &[data-type=NodeCodeBlock][data-subtype=plantuml],
+      // 尽量避免标题块内分页
+      &[data-type=NodeHeading],
+      // 尽量避免 Iframe 块内分页
+      &[data-type=NodeIFrame],
+      // 尽量避免公式块内分页
+      &[data-type=NodeMathBlock],
+      // 尽量避免段落块内分页
+      &[data-type=NodeParagraph],
+      // 尽量避免分割线内分页
+      &[data-type=NodeThematicBreak],
+      // 尽量避免视频块内分页
+      &[data-type=NodeVideo],
+      // 尽量避免挂件块内分页
+      &[data-type=NodeWidget],
+      // 尽量避免表格块行内分页
+      tr,
+      // 尽量避免图片内分页
+      img {
+        break-inside: avoid;
+      }
+    }
+  }
+}

--- a/app/src/assets/scss/export.scss
+++ b/app/src/assets/scss/export.scss
@@ -66,7 +66,7 @@ svg {
       // 尽量避免表格块行内分页
       tr,
       // 尽量避免图片内分页
-      img {
+      .img {
         break-inside: avoid;
       }
     }

--- a/app/src/assets/scss/export.scss
+++ b/app/src/assets/scss/export.scss
@@ -36,7 +36,7 @@ svg {
 }
 
 @media print {
-  #preview.protyle-wysiwyg {
+  .protyle-wysiwyg {
     [data-node-id] {
 
       // 尽量避免音频块内分页


### PR DESCRIPTION
* [x] Please commit to the dev branch

改进 PDF 导出时的分页策略  
Improved PDF export paging strategy

尽量避免在如下内容中分页:  
Try to avoid pagination in the following:

- 音频块内 | Inside the audio block
- 图表块内 | Inside the graph block
- 标题块内 | Inside the heading block
- IFrame 块内 | Inside the IFrame block
- 公式块内 | Inside the math block
- 段落块内 | Inside the paragraph block
- 分割线内 | Inside the thematic break block
- 视频块内 | Inside the video block
- 挂件块内 | Inside the widget block
- 表格块行内 | Inside the table row
- 图片内 | Inside the image

已使用默认主题在用户指南中 `排版元素` 文档进行测试  
Tested on the `Formatting elements` document in the User Guide using the default theme.