### PR TITLE
支持使用picGo上传图片到图床

### DIFF
--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -1,4 +1,13 @@
 {
+  "picgo": "是否开启 PicGo",
+  "picgoTip": "使用 PicGo 上传图片到图床,3种模式",
+  "configPicgo": "配置 PicGo",
+  "picgoServePath": "PicGo 伺服地址",
+  "picgoServePathTip": "设置PicGo伺服地址,默认值 http://127.0.0.1:36677",
+  "usePicgoConfirm": "是否使用PicGo上传图片到图床?",
+  "picgoMode0": "禁用",
+  "picgoMode1": "总是",
+  "picgoMode2": "询问",
   "plugin": "插件",
   "attrBookmarkTip": "将该块和一个书签进行关联，以便后续通过书签面板查看",
   "attrNameTip": "为该块设置命名，主要用于引用和搜索，一个块只能拥有一个唯一的命名",

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const {
-    app, BrowserWindow, shell, Menu, screen, ipcMain, globalShortcut, Tray,
+    app, BrowserWindow, shell, Menu, screen, ipcMain, globalShortcut, Tray, dialog
 } = require("electron");
 const path = require("path");
 const fs = require("fs");
@@ -330,6 +330,24 @@ const boot = () => {
         }
     });
 
+    function syncConfirmDialog(message,windows) {
+        let opts={
+            type: 'none',
+            buttons: ['Yes','No'],
+            detail: " ",
+            message: message,
+            title:"SiYuan",
+            icon:path.join(appDir, "stage", "icon.png"),
+        }
+        const buttonIdx = dialog.showMessageBoxSync(windows,opts );
+        return buttonIdx == 0;
+    }
+
+    ipcMain.on('sync-confrim-dialog', (event, arg) => {
+        let senderWindow = BrowserWindow.fromWebContents(event.sender);
+        let ret = syncConfirmDialog(arg,senderWindow);
+        event.returnValue = ret
+    })
     // 加载主界面
     currentWindow.loadURL(getServer() + "/stage/build/app/index.html?v=" + new Date().getTime());
 

--- a/app/src/config/editor.ts
+++ b/app/src/config/editor.ts
@@ -138,6 +138,29 @@ export const editor = {
     <span class="fn__space"></span>
     <input class="b3-switch fn__flex-center" id="virtualBlockRef" type="checkbox"${window.siyuan.config.editor.virtualBlockRef ? " checked" : ""}/>
 </label>
+<details style="outline: auto">     
+<summary>  ${window.siyuan.languages.configPicgo}</summary>
+<label class="fn__flex b3-label config__item">
+    <div class="fn__flex-1">
+        ${window.siyuan.languages.picgo}
+        <div class="b3-label__text">${window.siyuan.languages.picgoTip}</div>
+    </div>
+    <span class="fn__space"></span>
+    <select id="picgoMode" class="b3-select fn__flex-center fn__size200">
+        <option value="0" ${window.siyuan.config.editor.picgoMode === 0 ? "selected" : ""}>${window.siyuan.languages.picgoMode0}</option>
+        <option value="1" ${window.siyuan.config.editor.picgoMode === 1 ? "selected" : ""}>${window.siyuan.languages.picgoMode1}</option>
+        <option value="2" ${window.siyuan.config.editor.picgoMode === 2 ? "selected" : ""}>${window.siyuan.languages.picgoMode2}</option>
+    </select>
+</label>
+<label class="fn__flex b3-label config__item">
+    <div class="fn__flex-1">
+        ${window.siyuan.languages.picgoServePath}
+        <div class="b3-label__text">${window.siyuan.languages.picgoServePathTip}</div>
+    </div>
+    <span class="fn__space"></span>
+    <input class="b3-text-field fn__flex-center fn__size200" id="picgoServePath" value="${window.siyuan.config.editor.picgoServePath}" />
+</label>
+</details>
 <label class="fn__flex b3-label config__item">
     <div class="fn__flex-1">
         ${window.siyuan.languages.md9}
@@ -306,7 +329,9 @@ export const editor = {
                 generateHistoryInterval: parseInt((editor.element.querySelector("#generateHistoryInterval") as HTMLInputElement).value),
                 historyRetentionDays: parseInt((editor.element.querySelector("#historyRetentionDays") as HTMLInputElement).value),
                 fontFamily: fontFamilyElement.value,
-                emoji: window.siyuan.config.editor.emoji
+                emoji: window.siyuan.config.editor.emoji,
+                picgoServePath: (editor.element.querySelector("#picgoServePath") as HTMLInputElement).value,
+                picgoMode: parseInt((editor.element.querySelector("#picgoMode") as HTMLSelectElement).value),
             }, response => {
                 editor.onSetEditor(response.data);
             });

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -359,6 +359,8 @@ declare interface IEditor {
     backmentionExpandCount: number;
 
     emoji: string[];
+    picgoMode:number;
+    picgoServePath:string;
 }
 
 declare interface IWebSocketData {

--- a/kernel/api/asset.go
+++ b/kernel/api/asset.go
@@ -270,8 +270,13 @@ func insertLocalAssets(c *gin.Context) {
 	if nil != isUploadArg {
 		isUpload = isUploadArg.(bool)
 	}
+	isUsePicgo := false
+	isUsePicgoArg := arg["isUsePicgo"]
+	if  nil != isUsePicgoArg {
+		isUsePicgo = isUsePicgoArg.(bool)
+	}
 	id := arg["id"].(string)
-	succMap, err := model.InsertLocalAssets(id, assetPaths, isUpload)
+	succMap, err := model.InsertLocalAssets(id, assetPaths, isUpload, isUsePicgo)
 	if nil != err {
 		ret.Code = -1
 		ret.Msg = err.Error()

--- a/kernel/api/setting.go
+++ b/kernel/api/setting.go
@@ -171,6 +171,10 @@ func setEditor(c *gin.Context) {
 		editor.KaTexMacros = "{}"
 	}
 
+	if "" == editor.PicgoServePath {
+		editor.PicgoServePath = "http://127.0.0.1:36677"
+	}
+
 	oldVirtualBlockRef := model.Conf.Editor.VirtualBlockRef
 	oldVirtualBlockRefInclude := model.Conf.Editor.VirtualBlockRefInclude
 	oldVirtualBlockRefExclude := model.Conf.Editor.VirtualBlockRefExclude

--- a/kernel/conf/editor.go
+++ b/kernel/conf/editor.go
@@ -46,6 +46,8 @@ type Editor struct {
 	OnlySearchForDoc                bool     `json:"onlySearchForDoc"`                // 是否启用 [[ 仅搜索文档块
 	BacklinkExpandCount             int      `json:"backlinkExpandCount"`             // 反向链接默认展开数量
 	BackmentionExpandCount          int      `json:"backmentionExpandCount"`          // 反链提及默认展开数量
+	PicgoServePath               	string   `json:"picgoServePath"`                  // picgo 伺服地址
+	PicgoMode               	    int      `json:"picgoMode"`                       // picgo模式
 }
 
 func NewEditor() *Editor {
@@ -74,5 +76,7 @@ func NewEditor() *Editor {
 		RTL:                             false,
 		BacklinkExpandCount:             8,
 		BackmentionExpandCount:          8,
+		PicgoServePath:                  "http://127.0.0.1:36677",
+		PicgoMode:                       0,
 	}
 }

--- a/kernel/model/upload.go
+++ b/kernel/model/upload.go
@@ -313,7 +313,7 @@ func uploadWithPicgo(filepath string) (ret string, err error) {
 	var sendErr error
 	// default url: http://127.0.0.1:36677/upload
 	var apiURL string
-	picgoServePath := Conf.Editor.PicgoServePath
+	picgoServePath := strings.TrimSpace(Conf.Editor.PicgoServePath)
 	logging.LogInfof("picgoServePath:[%s]", picgoServePath)
 	apiURL = strings.TrimSuffix(picgoServePath, "/") + "/upload"
 	logging.LogInfof("picgoApiURL:[%s]", apiURL)


### PR DESCRIPTION
* [ ] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

开启后ctrl+V粘贴图片时,自动上传图片到图床,使用远程图片链接而不是本地链接
用户需要配置以下几项:
- picgo伺服地址,默认是 http://127.0.0.1:36677
- 上传模式
  三种模式, 禁用/总是/询问
  总是: 只要是图片,一律调用picgo上传到图床
  询问, 如果是图片,询问是否上传到图床

配置位置: 设置>编辑器>配置 PicGo

图床的选择在picgo里配置

补充:
picgo除了图片还可以上传视频,音频,
后续的改进可能包括:
- 图片/视频/音频 分别设置上传模式: 禁用/总是/询问
- 将文档里已有的本地图片上传到图床, 指定图片或所有图片

picgo官网:
https://molunerfinn.com/PicGo/


