### PR TITLE
Bazaar resource directories support symlink

### DIFF
--- a/kernel/bazaar/icon.go
+++ b/kernel/bazaar/icon.go
@@ -110,7 +110,7 @@ func InstalledIcons() (ret []*Icon) {
 	bazaarIcons := Icons()
 
 	for _, iconDir := range iconDirs {
-		if !iconDir.IsDir() {
+		if !util.IsDirOrSymlink(iconDir) {
 			continue
 		}
 		dirName := iconDir.Name()

--- a/kernel/bazaar/icon.go
+++ b/kernel/bazaar/icon.go
@@ -101,6 +101,11 @@ func Icons() (icons []*Icon) {
 
 func InstalledIcons() (ret []*Icon) {
 	ret = []*Icon{}
+
+	if !util.IsPathRegularDirOrSymlinkDir(util.IconsPath) {
+		return
+	}
+
 	iconDirs, err := os.ReadDir(util.IconsPath)
 	if nil != err {
 		logging.LogWarnf("read icons folder failed: %s", err)
@@ -110,7 +115,7 @@ func InstalledIcons() (ret []*Icon) {
 	bazaarIcons := Icons()
 
 	for _, iconDir := range iconDirs {
-		if !util.IsDirOrSymlink(iconDir) {
+		if !util.IsDirRegularOrSymlink(iconDir) {
 			continue
 		}
 		dirName := iconDir.Name()

--- a/kernel/bazaar/plugin.go
+++ b/kernel/bazaar/plugin.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/88250/gulu"
 	"github.com/dustin/go-humanize"
 	ants "github.com/panjf2000/ants/v2"
 	"github.com/siyuan-note/httpclient"
@@ -106,7 +105,7 @@ func InstalledPlugins() (ret []*Plugin) {
 	ret = []*Plugin{}
 
 	pluginsPath := filepath.Join(util.DataDir, "plugins")
-	if !gulu.File.IsDir(pluginsPath) {
+	if !util.IsPathRegularDirOrSymlinkDir(pluginsPath) {
 		return
 	}
 
@@ -119,7 +118,7 @@ func InstalledPlugins() (ret []*Plugin) {
 	bazaarPlugins := Plugins()
 
 	for _, pluginDir := range pluginDirs {
-		if !util.IsDirOrSymlink(pluginDir) {
+		if !util.IsDirRegularOrSymlink(pluginDir) {
 			continue
 		}
 		dirName := pluginDir.Name()

--- a/kernel/bazaar/plugin.go
+++ b/kernel/bazaar/plugin.go
@@ -119,7 +119,7 @@ func InstalledPlugins() (ret []*Plugin) {
 	bazaarPlugins := Plugins()
 
 	for _, pluginDir := range pluginDirs {
-		if !pluginDir.IsDir() {
+		if !util.IsDirOrSymlink(pluginDir) {
 			continue
 		}
 		dirName := pluginDir.Name()

--- a/kernel/bazaar/template.go
+++ b/kernel/bazaar/template.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/88250/gulu"
 	"github.com/dustin/go-humanize"
 	"github.com/panjf2000/ants/v2"
 	"github.com/siyuan-note/httpclient"
@@ -107,7 +106,7 @@ func InstalledTemplates() (ret []*Template) {
 	ret = []*Template{}
 
 	templatesPath := filepath.Join(util.DataDir, "templates")
-	if !gulu.File.IsDir(templatesPath) {
+	if !util.IsPathRegularDirOrSymlinkDir(templatesPath) {
 		return
 	}
 
@@ -120,7 +119,7 @@ func InstalledTemplates() (ret []*Template) {
 	bazaarTemplates := Templates()
 
 	for _, templateDir := range templateDirs {
-		if !util.IsDirOrSymlink(templateDir) {
+		if !util.IsDirRegularOrSymlink(templateDir) {
 			continue
 		}
 		dirName := templateDir.Name()

--- a/kernel/bazaar/template.go
+++ b/kernel/bazaar/template.go
@@ -120,7 +120,7 @@ func InstalledTemplates() (ret []*Template) {
 	bazaarTemplates := Templates()
 
 	for _, templateDir := range templateDirs {
-		if !templateDir.IsDir() {
+		if !util.IsDirOrSymlink(templateDir) {
 			continue
 		}
 		dirName := templateDir.Name()

--- a/kernel/bazaar/theme.go
+++ b/kernel/bazaar/theme.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/88250/gulu"
 	"github.com/dustin/go-humanize"
 	ants "github.com/panjf2000/ants/v2"
 	"github.com/siyuan-note/httpclient"
@@ -105,7 +104,7 @@ func Themes() (ret []*Theme) {
 func InstalledThemes() (ret []*Theme) {
 	ret = []*Theme{}
 
-	if !gulu.File.IsDir(util.ThemesPath) {
+	if !util.IsPathRegularDirOrSymlinkDir(util.ThemesPath) {
 		return
 	}
 
@@ -118,7 +117,7 @@ func InstalledThemes() (ret []*Theme) {
 	bazaarThemes := Themes()
 
 	for _, themeDir := range themeDirs {
-		if !util.IsDirOrSymlink(themeDir) {
+		if !util.IsDirRegularOrSymlink(themeDir) {
 			continue
 		}
 		dirName := themeDir.Name()

--- a/kernel/bazaar/theme.go
+++ b/kernel/bazaar/theme.go
@@ -118,7 +118,7 @@ func InstalledThemes() (ret []*Theme) {
 	bazaarThemes := Themes()
 
 	for _, themeDir := range themeDirs {
-		if !themeDir.IsDir() {
+		if !util.IsDirOrSymlink(themeDir) {
 			continue
 		}
 		dirName := themeDir.Name()

--- a/kernel/bazaar/widget.go
+++ b/kernel/bazaar/widget.go
@@ -118,7 +118,7 @@ func InstalledWidgets() (ret []*Widget) {
 	bazaarWidgets := Widgets()
 
 	for _, widgetDir := range widgetDirs {
-		if !widgetDir.IsDir() {
+		if !util.IsDirOrSymlink(widgetDir) {
 			continue
 		}
 		dirName := widgetDir.Name()

--- a/kernel/bazaar/widget.go
+++ b/kernel/bazaar/widget.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/88250/gulu"
 	"github.com/dustin/go-humanize"
 	ants "github.com/panjf2000/ants/v2"
 	"github.com/siyuan-note/httpclient"
@@ -105,7 +104,7 @@ func InstalledWidgets() (ret []*Widget) {
 	ret = []*Widget{}
 
 	widgetsPath := filepath.Join(util.DataDir, "widgets")
-	if !gulu.File.IsDir(widgetsPath) {
+	if !util.IsPathRegularDirOrSymlinkDir(widgetsPath) {
 		return
 	}
 
@@ -118,7 +117,7 @@ func InstalledWidgets() (ret []*Widget) {
 	bazaarWidgets := Widgets()
 
 	for _, widgetDir := range widgetDirs {
-		if !util.IsDirOrSymlink(widgetDir) {
+		if !util.IsDirRegularOrSymlink(widgetDir) {
 			continue
 		}
 		dirName := widgetDir.Name()

--- a/kernel/model/appearance.go
+++ b/kernel/model/appearance.go
@@ -78,7 +78,7 @@ func closeThemeWatchers() {
 }
 
 func unloadThemes() {
-	if !gulu.File.IsDir(util.ThemesPath) {
+	if !util.IsPathRegularDirOrSymlinkDir(util.ThemesPath) {
 		return
 	}
 
@@ -89,7 +89,7 @@ func unloadThemes() {
 	}
 
 	for _, themeDir := range themeDirs {
-		if !util.IsDirOrSymlink(themeDir) {
+		if !util.IsDirRegularOrSymlink(themeDir) {
 			continue
 		}
 		unwatchTheme(filepath.Join(util.ThemesPath, themeDir.Name()))
@@ -107,7 +107,7 @@ func loadThemes() {
 	Conf.Appearance.DarkThemes = nil
 	Conf.Appearance.LightThemes = nil
 	for _, themeDir := range themeDirs {
-		if !util.IsDirOrSymlink(themeDir) {
+		if !util.IsDirRegularOrSymlink(themeDir) {
 			continue
 		}
 		name := themeDir.Name()
@@ -151,7 +151,7 @@ func loadIcons() {
 
 	Conf.Appearance.Icons = nil
 	for _, iconDir := range iconDirs {
-		if !util.IsDirOrSymlink(iconDir) {
+		if !util.IsDirRegularOrSymlink(iconDir) {
 			continue
 		}
 		name := iconDir.Name()

--- a/kernel/model/appearance.go
+++ b/kernel/model/appearance.go
@@ -89,7 +89,7 @@ func unloadThemes() {
 	}
 
 	for _, themeDir := range themeDirs {
-		if !themeDir.IsDir() {
+		if !util.IsDirOrSymlink(themeDir) {
 			continue
 		}
 		unwatchTheme(filepath.Join(util.ThemesPath, themeDir.Name()))
@@ -107,7 +107,7 @@ func loadThemes() {
 	Conf.Appearance.DarkThemes = nil
 	Conf.Appearance.LightThemes = nil
 	for _, themeDir := range themeDirs {
-		if !themeDir.IsDir() {
+		if !util.IsDirOrSymlink(themeDir) {
 			continue
 		}
 		name := themeDir.Name()
@@ -151,7 +151,7 @@ func loadIcons() {
 
 	Conf.Appearance.Icons = nil
 	for _, iconDir := range iconDirs {
-		if !iconDir.IsDir() {
+		if !util.IsDirOrSymlink(iconDir) {
 			continue
 		}
 		name := iconDir.Name()

--- a/kernel/model/bazzar.go
+++ b/kernel/model/bazzar.go
@@ -35,7 +35,7 @@ func GetPackageREADME(repoURL, repoHash, packageType string) (ret string) {
 func BazaarPlugins() (plugins []*bazaar.Plugin) {
 	plugins = bazaar.Plugins()
 	for _, plugin := range plugins {
-		plugin.Installed = gulu.File.IsDir(filepath.Join(util.DataDir, "plugins", plugin.Name))
+		plugin.Installed = util.IsPathRegularDirOrSymlinkDir(filepath.Join(util.DataDir, "plugins", plugin.Name))
 		if plugin.Installed {
 			if plugin.Installed {
 				if pluginConf, err := bazaar.PluginJSON(plugin.Name); nil == err && nil != plugin {
@@ -96,7 +96,7 @@ func UninstallBazaarPlugin(pluginName string) error {
 func BazaarWidgets() (widgets []*bazaar.Widget) {
 	widgets = bazaar.Widgets()
 	for _, widget := range widgets {
-		widget.Installed = gulu.File.IsDir(filepath.Join(util.DataDir, "widgets", widget.Name))
+		widget.Installed = util.IsPathRegularDirOrSymlinkDir(filepath.Join(util.DataDir, "widgets", widget.Name))
 		if widget.Installed {
 			if widget.Installed {
 				if widgetConf, err := bazaar.WidgetJSON(widget.Name); nil == err && nil != widget {

--- a/kernel/util/file.go
+++ b/kernel/util/file.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -40,6 +41,10 @@ func IsEmptyDir(p string) bool {
 		return false
 	}
 	return 1 > len(files)
+}
+
+func IsDirOrSymlink(dir fs.DirEntry) bool {
+	return dir.IsDir() || dir.Type() == fs.ModeSymlink
 }
 
 func RemoveID(name string) string {

--- a/kernel/util/file.go
+++ b/kernel/util/file.go
@@ -43,8 +43,21 @@ func IsEmptyDir(p string) bool {
 	return 1 > len(files)
 }
 
-func IsDirOrSymlink(dir fs.DirEntry) bool {
+func IsDirRegularOrSymlink(dir fs.DirEntry) bool {
 	return dir.IsDir() || dir.Type() == fs.ModeSymlink
+}
+
+func IsPathRegularDirOrSymlinkDir(path string) bool {
+	fio, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	if nil != err {
+		return false
+	}
+
+	return fio.IsDir()
 }
 
 func RemoveID(name string) string {


### PR DESCRIPTION
* [x] Please commit to the dev branch

社区资源目录及其下级目录支持符号链接目录  
The community resource directories and their subdirectories support symbolic link directories.
- `workspace/conf/appearance/icons/`
- `workspace/conf/appearance/themes/`
- `workspace/data/plugins/`
- `workspace/data/templates/`
- `workspace/data/widgets/`

注: 方便开发者进行开发与测试  
Note: It is convenient for developers to develop and test

已通过测试 | Tested passed

OS: Windows 11 22H2 22621.1702