### PR TITLE
Add `Tab` context to the method in plugin `addTab`

### DIFF
--- a/app/src/layout/dock/Custom.ts
+++ b/app/src/layout/dock/Custom.ts
@@ -4,6 +4,7 @@ import {App} from "../../index";
 
 export class Custom extends Model {
     public element: Element;
+    public tab: Tab;
     public data: any;
     public type: string;
     public init: () => void;
@@ -22,12 +23,14 @@ export class Custom extends Model {
         init: () => void
     }) {
         super({app: options.app, id: options.tab.id});
-        this.type = options.type;
         if (window.siyuan.config.fileTree.openFilesUseCurrentTab) {
             options.tab.headElement.classList.add("item--unupdate");
         }
+
         this.element = options.tab.panelElement;
+        this.tab = options.tab;
         this.data = options.data;
+        this.type = options.type;
         this.init = options.init;
         this.destroy = options.destroy;
         this.resize = options.resize;


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For contributing new features, please supplement and improve the corresponding user guide documents

插件 API `addTab` 中的 `init` 等方法的 `this` 指向的是一个 `Custom` 对象, 该对象在初始化时传入的 `tab` 参数由于没有挂载到对象属性中作为上下文, 因此插件无法对其打开的页签进行控制(例如更新标题, 钉住/取消钉住)  
The `this` of methods such as `init` in the plugin API `addTab` points to a `Custom` object, and the `tab` parameter passed in when the object is initialized is not mounted into the object properties as a context, so the plugin cannot control the tabs it opens (e.g. update title, pin/unpin)

本次提交将页签对象添加到 `init` 方法的上下文中  
This commit adds the tab object to the context of the `init` method.
