### PR TITLE
fix issue of accessing undefined `tab.headElement`

### DIFF
--- a/app/src/layout/dock/Custom.ts
+++ b/app/src/layout/dock/Custom.ts
@@ -24,7 +24,7 @@ export class Custom extends Model {
     }) {
         super({app: options.app, id: options.tab.id});
         if (window.siyuan.config.fileTree.openFilesUseCurrentTab) {
-            options.tab.headElement.classList.add("item--unupdate");
+            options.tab.headElement?.classList.add("item--unupdate");
         }
 
         this.element = options.tab.panelElement;


### PR DESCRIPTION
* [x] Please commit to the dev branch

当激活插件创建的 dock 时, 由于创建的 `tab` 没有设置 `title` 或者 `icon`, 导致没有初始化 `headElement`, 如下所示
https://github.com/siyuan-note/siyuan/blob/d2b347212090ab779e6b8f290ec4a91a7e6b30af/app/src/layout/dock/index.ts#L430-L443

https://github.com/siyuan-note/siyuan/blob/d2b347212090ab779e6b8f290ec4a91a7e6b30af/app/src/layout/Tab.ts#L31-L122

这会造成在执行 `tab.callback` 中 `item.docks[type].model({tab});` 时在下方位置调用了 `Custom` 的构造函数
https://github.com/siyuan-note/siyuan/blob/d2b347212090ab779e6b8f290ec4a91a7e6b30af/app/src/plugin/index.ts#L178-L197

此时发生对未初始化的 `tab.headElement` 访问, 如下所示
https://github.com/siyuan-note/siyuan/blob/d2b347212090ab779e6b8f290ec4a91a7e6b30af/app/src/layout/dock/Custom.ts#L26-L28

因此需要在此处额外进行判断