### PR TITLE
Custom doc block menu moved to block secondary menu

### DIFF
--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -723,6 +723,7 @@ export class Gutter {
                 }
             }).element);
         }
+
         const pluginSubMenu = new subMenu();
         protyle.app?.plugins?.forEach((plugin) => {
             plugin.eventBus.emit("click-blockicon", {
@@ -739,6 +740,7 @@ export class Gutter {
                 submenu: pluginSubMenu.menus,
             }).element);
         }
+
         return window.siyuan.menus.menu;
     }
 

--- a/app/src/protyle/header/Title.ts
+++ b/app/src/protyle/header/Title.ts
@@ -5,7 +5,7 @@ import {
 } from "../util/selection";
 import {fetchPost} from "../../util/fetch";
 import {replaceFileName, validateName} from "../../editor/rename";
-import {MenuItem} from "../../menus/Menu";
+import {MenuItem, subMenu} from "../../menus/Menu";
 import {
     copySubMenu,
     movePathToMenu,
@@ -400,6 +400,24 @@ export class Title {
                 icon: "iconRiffCard",
                 submenu: riffCardMenu,
             }).element);
+
+            const pluginSubMenu = new subMenu();
+            protyle.app?.plugins?.forEach((plugin) => {
+                plugin.eventBus.emit("click-editortitleicon", {
+                    protyle,
+                    menu: pluginSubMenu,
+                    data: response.data,
+                });
+            });
+            if (pluginSubMenu.menus.length > 0) {
+                window.siyuan.menus.menu.append(new MenuItem({ type: "separator" }).element);
+                window.siyuan.menus.menu.append(new MenuItem({
+                    label: window.siyuan.languages.plugin,
+                    type: "submenu",
+                    submenu: pluginSubMenu.menus,
+                }).element);
+            }
+
             window.siyuan.menus.menu.append(new MenuItem({type: "separator"}).element);
             window.siyuan.menus.menu.append(new MenuItem({
                 iconHTML: Constants.ZWSP,
@@ -408,13 +426,6 @@ export class Title {
 ${window.siyuan.languages.createdAt} ${dayjs(response.data.ial.id.substr(0, 14)).format("YYYY-MM-DD HH:mm:ss")}`
             }).element);
             window.siyuan.menus.menu.popup(position);
-            protyle.app?.plugins?.forEach((plugin) => {
-                plugin.eventBus.emit("click-editortitleicon", {
-                    protyle,
-                    menu: window.siyuan.menus.menu,
-                    data: response.data,
-                });
-            });
         });
     }
 


### PR DESCRIPTION
* [x] Please commit to the dev branch

REF https://github.com/siyuan-note/siyuan/issues/8419#issuecomment-1573768662

将文档块块菜单中插件添加的自定义菜单项移动到次级菜单中  
Moves custom menu items added by the plug-in in the document block menu to the secondary menu
