### PR TITLE
Fix the style of settings-assets-tabs

### DIFF
--- a/app/src/config/image.ts
+++ b/app/src/config/image.ts
@@ -15,14 +15,14 @@ export const image = {
         return `<div class="fn__flex-column" style="height: 100%">
     <div class="layout-tab-bar fn__flex">
         <div class="item item--full item--focus" data-type="remove">
-            <div class="fn__flex-1"></div>
-            ${window.siyuan.languages.unreferencedAssets}
-            <div class="fn__flex-1"></div>
+            <span class="fn__flex-1"></span>
+            <span class="item__text">${window.siyuan.languages.unreferencedAssets}</span>
+            <span class="fn__flex-1"></span>
         </div>
         <div class="item item--full" data-type="missing">
-            <div class="fn__flex-1"></div>
-            ${window.siyuan.languages.missingAssets}
-            <div class="fn__flex-1"></div>
+            <span class="fn__flex-1"></span>
+            <span class="item__text">${window.siyuan.languages.missingAssets}</span>
+            <span class="fn__flex-1"></span>
         </div>
     </div>
     <div class="fn__flex-1">


### PR DESCRIPTION
* [x] Please commit to the dev branch

设置面板中资源文件子面板中标签页的样式与其他子面板标签页样式保持一致  
The styles of tabs in the Assets sub-panel in the Settings panel match the styles of other sub-panel tabs
