### PR TITLE
Unify document icon font family to `--b3-font-family-emoji`

### DIFF
--- a/app/src/assets/scss/business/_layout.scss
+++ b/app/src/assets/scss/business/_layout.scss
@@ -282,6 +282,7 @@
           padding: 4px 0 4px 8px;
           line-height: 22px;
           flex-shrink: 0;
+          font-family: var(--b3-font-family-emoji);
 
           & > img,
           & > svg {
@@ -298,6 +299,7 @@
           height: 14px;
           width: 14px;
           flex-shrink: 0;
+          font-family: var(--b3-font-family-emoji);
         }
 
         &__text {

--- a/app/src/assets/scss/component/_list.scss
+++ b/app/src/assets/scss/component/_list.scss
@@ -123,6 +123,7 @@
 
       text-align: center;
       font-size: 16px;
+      font-family: var(--b3-font-family-emoji);
       margin-right: 4px;
       line-height: 22px;
       transition: var(--b3-transition);
@@ -155,6 +156,7 @@
       width: 14px;
       line-height: 14px;
       font-size: 12px;
+      font-family: var(--b3-font-family-emoji);
 
       // doc icon in the bookmark panel
       svg {


### PR DESCRIPTION
* [x] Please commit to the dev branch

文档图标选择菜单中 emojis 的样式与实际应用的样式不一致, 需要将其字体统一为 `--b3-font-family-emoji` 设置的字体  
The style of the emojis in the document icon selection menu is inconsistent with the actual applied style, and its font needs to be unified to the font set by `--b3-font-family-emoji`