### PR TITLE
Add  `ICommand.langText` for  plugin

### DIFF
--- a/app/src/config/keymap.ts
+++ b/app/src/config/keymap.ts
@@ -39,7 +39,7 @@ export const keymap = {
             item.commands.forEach(command => {
                 const keyValue = updateHotkeyTip(command.customHotkey);
                 commandHTML += `<label class="b3-list-item b3-list-item--narrow b3-list-item--hide-action">
-    <span class="b3-list-item__text">${command.langText || item.i18n[command.langKey]}</span>
+    <span class="b3-list-item__text">${command.langText || item.i18n[command.langKey] || command.langKey}</span>
     <span data-type="reset" class="b3-list-item__action b3-tooltips b3-tooltips__w" aria-label="${window.siyuan.languages.reset}">
         <svg><use xlink:href="#iconUndo"></use></svg>
     </span>

--- a/app/src/config/keymap.ts
+++ b/app/src/config/keymap.ts
@@ -39,7 +39,7 @@ export const keymap = {
             item.commands.forEach(command => {
                 const keyValue = updateHotkeyTip(command.customHotkey);
                 commandHTML += `<label class="b3-list-item b3-list-item--narrow b3-list-item--hide-action">
-    <span class="b3-list-item__text">${item.i18n[command.langKey]}</span>
+    <span class="b3-list-item__text">${command.langText || item.i18n[command.langKey]}</span>
     <span data-type="reset" class="b3-list-item__action b3-tooltips b3-tooltips__w" aria-label="${window.siyuan.languages.reset}">
         <svg><use xlink:href="#iconUndo"></use></svg>
     </span>

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -326,7 +326,8 @@ interface IDockTab {
 }
 
 interface ICommand {
-    langKey: string, // 多语言 key
+    langKey: string, // 用于区分不同快捷键的 key, 同时作为 i18n 的字段名
+    langText?: string, // 显示的文本, 指定后不再使用 langKey 对应的 i18n 文本
     hotkey: string,
     customHotkey?: string,
     callback?: () => void


### PR DESCRIPTION
* [x] Please commit to the dev branch

插件注册快捷键时支持自定义描述文本  
Custom description text is supported when the plug-in registers command

已通过测试, 并向后兼容  
Tested and backward compatible

REF: https://github.com/siyuan-note/petal/pull/9