### PR TITLE
KaTex macro definition setting do not check spelling

### DIFF
--- a/app/src/config/editor.ts
+++ b/app/src/config/editor.ts
@@ -253,7 +253,7 @@ export const editor = {
         ${window.siyuan.languages.katexMacros}
         <div class="b3-label__text">${window.siyuan.languages.katexMacrosTip}</div>
         <div class="fn__hr"></div>
-        <textarea class="b3-text-field fn__block" id="katexMacros">${window.siyuan.config.editor.katexMacros}</textarea>
+        <textarea class="b3-text-field fn__block" id="katexMacros" spellcheck="false">${window.siyuan.config.editor.katexMacros}</textarea>
     </div>
 </label>`;
     },


### PR DESCRIPTION
katex宏定义的设置项处，使用拼写检查是没有必要的

* [ ] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly
