### PR TITLE
Kernel API `/api/file/readDir` support for returning symbolic link information

### DIFF
--- a/API.md
+++ b/API.md
@@ -1076,10 +1076,12 @@ View API token in <kbd>Settings - About</kbd>, request header: `Authorization: T
     "data": [
         {
             "isDir": true,
+            "isSymlink": false,
             "name": "20210808180320-abz7w6k"
         },
         {
             "isDir": false,
+            "isSymlink": false,
             "name": "20210808180320-abz7w6k.sy"
         }
     ]

--- a/API_zh_CN.md
+++ b/API_zh_CN.md
@@ -1068,10 +1068,12 @@
     "data": [
         {
             "isDir": true,
+            "isSymlink": false,
             "name": "20210808180320-abz7w6k"
         },
         {
             "isDir": false,
+            "isSymlink": false,
             "name": "20210808180320-abz7w6k.sy"
         }
     ]

--- a/kernel/api/file.go
+++ b/kernel/api/file.go
@@ -172,9 +172,17 @@ func readDir(c *gin.Context) {
 
 	files := []map[string]interface{}{}
 	for _, entry := range entries {
+		path := filepath.Join(dirPath, entry.Name())
+		info, err = os.Stat(path)
+		if nil != err {
+			logging.LogErrorf("stat [%s] failed: %s", path, err)
+			ret.Code = 500
+			ret.Msg = err.Error()
+			return
+		}
 		files = append(files, map[string]interface{}{
 			"name":      entry.Name(),
-			"isDir":     entry.IsDir(),
+			"isDir":     info.IsDir(),
 			"isSymlink": util.IsSymlink(entry),
 		})
 	}

--- a/kernel/api/file.go
+++ b/kernel/api/file.go
@@ -173,8 +173,9 @@ func readDir(c *gin.Context) {
 	files := []map[string]interface{}{}
 	for _, entry := range entries {
 		files = append(files, map[string]interface{}{
-			"name":  entry.Name(),
-			"isDir": entry.IsDir(),
+			"name":      entry.Name(),
+			"isDir":     entry.IsDir(),
+			"isSymlink": util.IsSymlink(entry),
 		})
 	}
 

--- a/kernel/util/file.go
+++ b/kernel/util/file.go
@@ -43,8 +43,12 @@ func IsEmptyDir(p string) bool {
 	return 1 > len(files)
 }
 
+func IsSymlink(dir fs.DirEntry) bool {
+	return dir.Type() == fs.ModeSymlink
+}
+
 func IsDirRegularOrSymlink(dir fs.DirEntry) bool {
-	return dir.IsDir() || dir.Type() == fs.ModeSymlink
+	return dir.IsDir() || IsSymlink(dir)
 }
 
 func IsPathRegularDirOrSymlinkDir(path string) bool {


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For contributing new features, please supplement and improve the corresponding user guide documents

- directory symlink: `isDir: true, isSymlink: true`
- directory normal: `isDir: true, isSymlink: false`
- file symlink: `isDir: false, isSymlink: true`
- file normal: `isDir: false, isSymlink: false`