### PR TITLE
When maxListCount limit is not reached, the wrong pop-up box prompts a maxListCount error

### DIFF
--- a/kernel/model/file.go
+++ b/kernel/model/file.go
@@ -387,6 +387,7 @@ func ListDocTree(boxID, path string, sortMode int, flashcard bool, maxListCount 
 			return fileTreeFiles[i].Sort < fileTreeFiles[j].Sort
 		})
 		ret = append(ret, fileTreeFiles...)
+		totals = len(ret)
 		if maxListCount < len(ret) {
 			ret = ret[:maxListCount]
 		}
@@ -414,6 +415,7 @@ func ListDocTree(boxID, path string, sortMode int, flashcard bool, maxListCount 
 		ret = append(ret, docs...)
 	}
 
+	totals = len(ret)
 	if maxListCount < len(ret) {
 		ret = ret[:maxListCount]
 	}


### PR DESCRIPTION
bugfix: When maxListCount limit is not reached, the wrong pop-up box prompts a maxListCount error

box.Ls(path) will count the same document repeatedly (x/x.sy).
Before checking maxListCount limit, assign len(ret) to the totals variable so that it only represents the number of .sy documents