### PR TITLE
Add plugin event bus `open-siyuan-url-plugin` and `open-siyuan-url-block`

### DIFF
--- a/app/src/boot/onGetConfig.ts
+++ b/app/src/boot/onGetConfig.ts
@@ -257,6 +257,11 @@ export const initWindow = (app: App) => {
                 const pluginId = urlObj.pathname.split("/")[3];
                 if (pluginId) {
                     app.plugins.find(plugin => {
+                        // siyuan://plugins/plugin-name/foo?bar=baz
+                        if (pluginId.startsWith(plugin.name)) {
+                            plugin.eventBus.emit("open-siyuan-url-plugins", { url });
+                        }
+
                         // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
                         const match = Object.keys(plugin.models).find(key => {
                             if (key === pluginId) {
@@ -297,6 +302,12 @@ export const initWindow = (app: App) => {
                         });
                         ipcRenderer.send(Constants.SIYUAN_SHOW, getCurrentWindow().id);
                     }
+                    app.plugins.forEach(plugin => {
+                        plugin.eventBus.emit("open-siyuan-url-blocks", {
+                            url,
+                            exist: existResponse.data,
+                        });
+                    });
                 });
                 return;
             }

--- a/app/src/boot/onGetConfig.ts
+++ b/app/src/boot/onGetConfig.ts
@@ -249,35 +249,41 @@ export const initWindow = (app: App) => {
     currentWindow.on("blur", winOnBlur);
     if (!isWindow()) {
         ipcRenderer.on(Constants.SIYUAN_OPENURL, (event, url) => {
-            if (/^siyuan:\/\/plugins\//.test(url)) {
-                // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
-                const pluginId = url.replace("siyuan://plugins/", "").split("?")[0];
-                app.plugins.find(plugin => {
-                    const match = Object.keys(plugin.models).find(key => {
-                        if (key === pluginId) {
-                            let data = getSearch("data", url);
-                            try {
-                                data = JSON.parse(data || "{}");
-                            } catch (e) {
-                                console.log("Error open plugin tab with protocol:", e);
+            app.plugins.forEach(plugin => {
+                plugin.eventBus.emit("open-siyuan-url", { url });
+            });
+            if (url.startsWith("siyuan://plugins/")) {
+                const urlObj = new URL(url);
+                const pluginId = urlObj.pathname.split("/")[3];
+                if (pluginId) {
+                    app.plugins.find(plugin => {
+                        // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
+                        const match = Object.keys(plugin.models).find(key => {
+                            if (key === pluginId) {
+                                let data = getSearch("data", url);
+                                try {
+                                    data = JSON.parse(data || "{}");
+                                } catch (e) {
+                                    console.log("Error open plugin tab with protocol:", e);
+                                }
+                                openFile({
+                                    app,
+                                    custom: {
+                                        title: getSearch("title", url),
+                                        icon: getSearch("icon", url),
+                                        data,
+                                        fn: plugin.models[key]
+                                    },
+                                });
+                                return true;
                             }
-                            openFile({
-                                app,
-                                custom: {
-                                    title: getSearch("title", url),
-                                    icon: getSearch("icon", url),
-                                    data,
-                                    fn: plugin.models[key]
-                                },
-                            });
+                        });
+                        if (match) {
                             return true;
                         }
                     });
-                    if (match) {
-                        return true;
-                    }
-                });
-                return;
+                    return;
+                }
             }
             if (isSYProtocol(url)) {
                 const id = getIdFromSYProtocol(url);

--- a/app/src/boot/onGetConfig.ts
+++ b/app/src/boot/onGetConfig.ts
@@ -292,19 +292,22 @@ export const initWindow = (app: App) => {
             }
             if (isSYProtocol(url)) {
                 const id = getIdFromSYProtocol(url);
+                const focus = getSearch("focus", url) === "1";
                 fetchPost("/api/block/checkBlockExist", {id}, existResponse => {
                     if (existResponse.data) {
                         openFileById({
                             app,
                             id,
                             action: [Constants.CB_GET_FOCUS, Constants.CB_GET_CONTEXT],
-                            zoomIn: getSearch("focus", url) === "1"
+                            zoomIn: focus,
                         });
                         ipcRenderer.send(Constants.SIYUAN_SHOW, getCurrentWindow().id);
                     }
                     app.plugins.forEach(plugin => {
                         plugin.eventBus.emit("open-siyuan-url-blocks", {
                             url,
+                            id,
+                            focus,
                             exist: existResponse.data,
                         });
                     });

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -44,6 +44,7 @@ type TEventBus = "ws-main" |
     "open-noneditableblock" |
     "open-menu-blockref" | "open-menu-fileannotationref" | "open-menu-tag" | "open-menu-link" | "open-menu-image" |
     "open-menu-av" | "open-menu-content" | "open-menu-breadcrumbmore" |
+    "open-siyuan-url" |
     "input-search" |
     "loaded-protyle"
 type TAVCol =

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -44,9 +44,7 @@ type TEventBus = "ws-main" |
     "open-noneditableblock" |
     "open-menu-blockref" | "open-menu-fileannotationref" | "open-menu-tag" | "open-menu-link" | "open-menu-image" |
     "open-menu-av" | "open-menu-content" | "open-menu-breadcrumbmore" |
-    "open-siyuan-url" |
-    "open-siyuan-url-blocks" |
-    "open-siyuan-url-plugins" |
+    "open-siyuan-url" | "open-siyuan-url-blocks" | "open-siyuan-url-plugins" |
     "input-search" |
     "loaded-protyle"
 type TAVCol =

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -45,6 +45,8 @@ type TEventBus = "ws-main" |
     "open-menu-blockref" | "open-menu-fileannotationref" | "open-menu-tag" | "open-menu-link" | "open-menu-image" |
     "open-menu-av" | "open-menu-content" | "open-menu-breadcrumbmore" |
     "open-siyuan-url" |
+    "open-siyuan-url-blocks" |
+    "open-siyuan-url-plugins" |
     "input-search" |
     "loaded-protyle"
 type TAVCol =


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

Add some plugin event buses  
添加插件事件总线

- `open-siyuan-url`
  - 打开 `siyuan://foo`  
    open `siyuan://foo`
- `open-siyuan-url-blocks`
  - 打开 `siyuan://blocks/<块 ID>`  
    open `siyuan://blocks/<block ID>`
- `open-siyuan-url-plugins`
  - 打开 `siyuan://plugins/<插件名>`  
    open `siyuan://plugins/<plugin name>`
  - 仅派发给插件名对应的插件  
    This event only send to the plugin with the same name

已通过测试 (Windows 11)  
Tested passed (Windows 11)