### PR TITLE
Plugin shortcut key setting list cannot fold

### DIFF
--- a/app/src/config/keymap.ts
+++ b/app/src/config/keymap.ts
@@ -51,7 +51,7 @@ export const keymap = {
 </label>`;
             });
             if (commandHTML) {
-                pluginHtml += `<div class="b3-list__panel">
+                pluginHtml += `
     <div class="b3-list-item b3-list-item--narrow toggle">
         <span class="b3-list-item__toggle b3-list-item__toggle--hl">
             <svg class="b3-list-item__arrow"><use xlink:href="#iconRight"></use></svg>
@@ -61,7 +61,7 @@ export const keymap = {
     <div class="fn__none b3-list__panel">
         ${commandHTML}
     </div>
-</div>`;
+`;
             }
         });
         if (pluginHtml) {
@@ -72,7 +72,9 @@ export const keymap = {
         </span>
         <span class="b3-list-item__text ft__on-surface">${window.siyuan.languages.plugin}</span>
     </div>
-    ${pluginHtml}
+    <div class="b3-list__panel">
+        ${pluginHtml}
+    </div>
 </div>`;
         }
         return `<label class="fn__flex b3-label config__item">


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [x] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

快捷键设置面板中的插件快捷键列表仅能折叠第一项  
The list of plug-in shortcuts in the shortcut settings panel can only collapse the first item.

造成该问题的原因是 `.b3-list__panel` 元素的层级错误  
The problem is caused by the wrong level of the `.b3-list__panel` element.