### PR TITLE
Enable HTML-related features in KaTeX

### DIFF
--- a/app/src/protyle/render/mathRender.ts
+++ b/app/src/protyle/render/mathRender.ts
@@ -8,7 +8,8 @@ declare const katex: {
     renderToString(math: string, option: {
         displayMode: boolean;
         output: string;
-        macros: IObject
+        macros: IObject;
+        trust: boolean;
     }): string;
 };
 
@@ -45,7 +46,8 @@ export const mathRender = (element: Element, cdn = Constants.PROTYLE_CDN, maxWid
                     renderElement.innerHTML = katex.renderToString(Lute.UnEscapeHTMLStr(mathElement.getAttribute("data-content")), {
                         displayMode: mathElement.tagName === "DIV",
                         output: "html",
-                        macros
+                        macros,
+                        trust: true, // REF: https://katex.org/docs/supported#html
                     });
                     renderElement.classList.remove("ft__error");
                     const blockElement = hasClosestBlock(mathElement);


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

将 `katex.options.trust` 设置为 `true` 以开启 KaTeX 中 HTML 相关功能  
Set `katex.options.trust` to `true` to enable HTML-related features in KaTeX

REF: [katex.options.trust](https://katex.org/docs/options#:~:text=as%20in%20LaTeX.-,trust,-%3A%20boolean%20or)
REF: [katex: HTML](https://katex.org/docs/supported#html)