### PR TITLE
Turn off math warnings in Chinese

### DIFF
--- a/app/src/protyle/render/mathRender.ts
+++ b/app/src/protyle/render/mathRender.ts
@@ -10,6 +10,7 @@ declare const katex: {
         output: string;
         macros: IObject;
         trust: boolean;
+        strict: (errorCode:string) =>  'ignore' | 'warn';
     }): string;
 };
 
@@ -48,6 +49,7 @@ export const mathRender = (element: Element, cdn = Constants.PROTYLE_CDN, maxWid
                         output: "html",
                         macros,
                         trust: true, // REF: https://katex.org/docs/supported#html
+                        strict: (errorCode) => errorCode === 'unicodeTextInMathMode' ? 'ignore' : 'warn',
                     });
                     renderElement.classList.remove("ft__error");
                     const blockElement = hasClosestBlock(mathElement);


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For contributing new features, please supplement and improve the corresponding user guide documents
* [x] For bug fixes, please describe the problem and solution via code comments
* [x] For text improvements (such as typos and wording adjustments), please submit directly

如果数学公式中使用中文，会产生大量警告，通过设置`options`的`strict mode`，其默认为`warn`，单独屏蔽错误码为`unicodeTextInMathMode`的情况，因为在数学模式下使用 Unicode 文本字符会警告，将其设置为`ignore`以消除，同时不影响其他错误输出，当然，也可以直接设置为`strict:false`，但不够稳妥

- REF：[Katex options](https://katex.org/docs/options#:~:text=strict)