### PR TITLE
Add Kernel API for WebSocket message broadcast

### DIFF
--- a/kernel/api/broadcast.go
+++ b/kernel/api/broadcast.go
@@ -1,0 +1,143 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/88250/gulu"
+	"github.com/gin-gonic/gin"
+	"github.com/olahol/melody"
+	"github.com/siyuan-note/logging"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+var (
+	BroadcastChannels = sync.Map{}
+)
+
+/*
+broadcast create a broadcast channel WebSocket connection
+
+@param
+
+	query.channel: channel name
+
+@example
+
+	ws://localhost:6806/ws/broadcast?channel=test
+*/
+func broadcast(c *gin.Context) {
+	var (
+		channel          string = c.Query("channel")
+		broadcastChannel *melody.Melody
+	)
+
+	if _broadcastChannel, exist := BroadcastChannels.Load(channel); exist {
+		// channel exists, use it
+		broadcastChannel = _broadcastChannel.(*melody.Melody)
+	} else {
+		// channel not found, create a new one
+		broadcastChannel := melody.New()
+		BroadcastChannels.Store(channel, broadcastChannel)
+
+		// broadcast string message to other session
+		broadcastChannel.HandleMessage(func(s *melody.Session, msg []byte) {
+			broadcastChannel.BroadcastOthers(msg, s)
+		})
+
+		// broadcast binary message to other session
+		broadcastChannel.HandleMessageBinary(func(s *melody.Session, msg []byte) {
+			broadcastChannel.BroadcastBinaryOthers(msg, s)
+		})
+
+		// recycling
+		broadcastChannel.HandleClose(func(s *melody.Session, status int, reason string) error {
+			channel := s.Keys["channel"].(string)
+			logging.LogInfof("close broadcast session in channel [%s] with status code %d: %s", channel, status, reason)
+
+			count := broadcastChannel.Len()
+			if count == 0 {
+				BroadcastChannels.Delete(channel)
+				logging.LogInfof("dispose broadcast channel [%s]", channel)
+			}
+			return nil
+		})
+	}
+
+	// create a new websocket connect
+	if err := broadcastChannel.HandleRequestWithKeys(
+		c.Writer,
+		c.Request,
+		map[string]interface{}{
+			"channel": channel,
+		},
+	); nil != err {
+		logging.LogErrorf("create broadcast channel failed: %s", err)
+		return
+	}
+}
+
+/*
+postMessage send string message to a broadcast channel
+
+@param
+
+	body.channel: channel name
+	body.message: message payload
+
+@returns
+
+	body.data.count: indicate how many clients received the message
+*/
+func postMessage(c *gin.Context) {
+	ret := gulu.Ret.NewResult()
+	defer c.JSON(http.StatusOK, ret)
+
+	arg, ok := util.JsonArg(c, ret)
+	if !ok {
+		return
+	}
+
+	channel := arg["channel"].(string)
+	message := arg["message"].(string)
+
+	if _broadcastChannel, ok := BroadcastChannels.Load(channel); !ok {
+		err := fmt.Errorf("broadcast channel [%s] not found", channel)
+		logging.LogWarnf(err.Error())
+
+		ret.Code = -1
+		ret.Msg = err.Error()
+		return
+	} else {
+		var broadcastChannel = _broadcastChannel.(*melody.Melody)
+		if err := broadcastChannel.Broadcast([]byte(message)); nil != err {
+			logging.LogErrorf("broadcast message failed: %s", err)
+
+			ret.Code = -2
+			ret.Msg = err.Error()
+			return
+		}
+
+		count := broadcastChannel.Len()
+		ret.Data = map[string]interface{}{
+			"count": count,
+		}
+	}
+}

--- a/kernel/api/broadcast.go
+++ b/kernel/api/broadcast.go
@@ -28,6 +28,11 @@ import (
 	"github.com/siyuan-note/siyuan/kernel/util"
 )
 
+type Channel struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
 var (
 	BroadcastChannels = sync.Map{}
 )
@@ -178,5 +183,33 @@ func getListenerCount(c *gin.Context) {
 		ret.Data = map[string]interface{}{
 			"count": count,
 		}
+	}
+}
+
+/*
+getChannels gets the channel name and lintener number of all broadcast chanel
+
+@returns
+
+	body.data.channels: {
+		name: channel name
+		count: listener count
+	}[]
+*/
+func getChannels(c *gin.Context) {
+	ret := gulu.Ret.NewResult()
+	defer c.JSON(http.StatusOK, ret)
+
+	var channels []*Channel
+	BroadcastChannels.Range(func(key, value any) bool {
+		broadcastChannel := value.(*melody.Melody)
+		channels = append(channels, &Channel{
+			Name:  key.(string),
+			Count: broadcastChannel.Len(),
+		})
+		return true
+	})
+	ret.Data = map[string]interface{}{
+		"channels": channels,
 	}
 }

--- a/kernel/api/broadcast.go
+++ b/kernel/api/broadcast.go
@@ -104,7 +104,7 @@ postMessage send string message to a broadcast channel
 
 @returns
 
-	body.data.count: indicate how many clients received the message
+	body.data.count: indicate how many websocket session received the message
 */
 func postMessage(c *gin.Context) {
 	ret := gulu.Ret.NewResult()
@@ -134,6 +134,45 @@ func postMessage(c *gin.Context) {
 			ret.Msg = err.Error()
 			return
 		}
+
+		count := broadcastChannel.Len()
+		ret.Data = map[string]interface{}{
+			"count": count,
+		}
+	}
+}
+
+/*
+getListenerCount gets the number of broadcast listeners in a channel
+
+@param
+
+	body.channel: channel name
+
+@returns
+
+	body.data.count: indicate how many websocket session received the message
+*/
+func getListenerCount(c *gin.Context) {
+	ret := gulu.Ret.NewResult()
+	defer c.JSON(http.StatusOK, ret)
+
+	arg, ok := util.JsonArg(c, ret)
+	if !ok {
+		return
+	}
+
+	channel := arg["channel"].(string)
+
+	if _broadcastChannel, ok := BroadcastChannels.Load(channel); !ok {
+		err := fmt.Errorf("broadcast channel [%s] not found", channel)
+		logging.LogWarnf(err.Error())
+
+		ret.Code = -1
+		ret.Msg = err.Error()
+		return
+	} else {
+		var broadcastChannel = _broadcastChannel.(*melody.Melody)
 
 		count := broadcastChannel.Len()
 		ret.Data = map[string]interface{}{

--- a/kernel/api/broadcast.go
+++ b/kernel/api/broadcast.go
@@ -211,7 +211,7 @@ func getChannels(c *gin.Context) {
 	ret := gulu.Ret.NewResult()
 	defer c.JSON(http.StatusOK, ret)
 
-	var channels []*Channel
+	channels := []*Channel{}
 	BroadcastChannels.Range(func(key, value any) bool {
 		broadcastChannel := value.(*melody.Melody)
 		channels = append(channels, &Channel{

--- a/kernel/api/broadcast.go
+++ b/kernel/api/broadcast.go
@@ -160,7 +160,7 @@ getChannelInfo gets the information of a broadcast channel
 
 @param
 
-	body.channel: channel name
+	body.name: channel name
 
 @returns
 
@@ -175,10 +175,10 @@ func getChannelInfo(c *gin.Context) {
 		return
 	}
 
-	channel := arg["channel"].(string)
+	name := arg["name"].(string)
 
-	if _broadcastChannel, ok := BroadcastChannels.Load(channel); !ok {
-		err := fmt.Errorf("broadcast channel [%s] not found", channel)
+	if _broadcastChannel, ok := BroadcastChannels.Load(name); !ok {
+		err := fmt.Errorf("broadcast channel [%s] not found", name)
 		logging.LogWarnf(err.Error())
 
 		ret.Code = -1
@@ -190,7 +190,7 @@ func getChannelInfo(c *gin.Context) {
 		count := broadcastChannel.Len()
 		ret.Data = map[string]interface{}{
 			"channel": &Channel{
-				Name:  channel,
+				Name:  name,
 				Count: count,
 			},
 		}

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -376,5 +376,5 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("GET", "/ws/broadcast", model.CheckAuth, broadcast)
 	ginServer.Handle("GET", "/api/broadcast/channels", model.CheckAuth, getChannels)
 	ginServer.Handle("POST", "/api/broadcast/postMessage", model.CheckAuth, postMessage)
-	ginServer.Handle("POST", "/api/broadcast/getListenerCount", model.CheckAuth, getListenerCount)
+	ginServer.Handle("POST", "/api/broadcast/getChannelInfo", model.CheckAuth, getChannelInfo)
 }

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -375,4 +375,5 @@ func ServeAPI(ginServer *gin.Engine) {
 
 	ginServer.Handle("GET", "/ws/broadcast", model.CheckAuth, broadcast)
 	ginServer.Handle("POST", "/api/broadcast/postMessage", model.CheckAuth, postMessage)
+	ginServer.Handle("POST", "/api/broadcast/getListenerCount", model.CheckAuth, getListenerCount)
 }

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -372,4 +372,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/petal/setPetalEnabled", model.CheckAuth, model.CheckReadonly, setPetalEnabled)
 
 	ginServer.Handle("POST", "/api/network/forwardProxy", model.CheckAuth, model.CheckReadonly, forwardProxy)
+
+	ginServer.Handle("GET", "/ws/broadcast", model.CheckAuth, broadcast)
+	ginServer.Handle("POST", "/api/broadcast/postMessage", model.CheckAuth, postMessage)
 }

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -374,6 +374,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/network/forwardProxy", model.CheckAuth, model.CheckReadonly, forwardProxy)
 
 	ginServer.Handle("GET", "/ws/broadcast", model.CheckAuth, broadcast)
+	ginServer.Handle("GET", "/api/broadcast/channels", model.CheckAuth, getChannels)
 	ginServer.Handle("POST", "/api/broadcast/postMessage", model.CheckAuth, postMessage)
 	ginServer.Handle("POST", "/api/broadcast/getListenerCount", model.CheckAuth, getListenerCount)
 }


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

Add APIs for message broadcast

**Tested** on Windows 11

- `/ws/broadcast`: WebSocket
  - Push broadcast messages
  - Receive broadcast messages
  - **query params**
    - `channel`: broadcast channel name
  - **example**
    - `ws://127.0.0.1:6806/ws/broadcast?channel=your-channel-name`
- `/api/broadcast/channels`: GET request
  - Get all channels' info
  - **response body**
    - ```json
      {
          "code": 0,
          "msg": "",
          "data": {
              "channels": [
                  {
                      "name": "test-channel",
                      "count": 1
                  }
              ]
          }
      }
      ```
- `/api/broadcast/postMessage`: POST request
  - Push broadcast messages
  - **request body**
    - ```json
      {
          "channel": "your-channel-name",
          "message": "your-message-content"
      }
      ```
      - `channel`: the name of channel
      - `message`: the message will be broadcast
  - **response body**
    - ```json
      {
          "code": 0,
          "msg": "",
          "data": {
              "channel": {
                  "name": "your-channel-name",
                  "count": 1
              }
          }
      }
      ```
      - `data.channel.count`: the count of channel listener
    - ```json
      {
          "code": -1,
          "msg": "broadcast channel [your-channel-name] not found",
          "data": null
      }
      ```
    - ```json
      {
          "code": -2,
          "msg": "broadcast message failed: ...",
          "data": null
      }
      ```
- `/api/broadcast/getChannelInfo`: POST request
  - get the info of a channel
  - **request body**
    - ```json
      {
          "name": "your-channel-name"
      }
      ```
      - `name`: the name of channel
  - **response body**
    - ```json
      {
          "code": 0,
          "msg": "",
          "data": {
              "channel": {
                  "name": "your-channel-name",
                  "count": 1
              }
          }
      }
      ```
      - `data.channel.name`: the name of channel
      - `data.channel.count`: the count of channel listener
    - ```json
      {
          "code": -1,
          "msg": "broadcast channel [your-channel-name] not found",
          "data": null
      }