### PR TITLE
Authentication supports query parameters `token`

### DIFF
--- a/kernel/model/session.go
+++ b/kernel/model/session.go
@@ -195,7 +195,7 @@ func CheckAuth(c *gin.Context) {
 		return
 	}
 
-	// 通过 API token
+	// 通过 API token (header: Authorization)
 	if authHeader := c.GetHeader("Authorization"); "" != authHeader {
 		if strings.HasPrefix(authHeader, "Token ") {
 			token := strings.TrimPrefix(authHeader, "Token ")
@@ -208,6 +208,18 @@ func CheckAuth(c *gin.Context) {
 			c.Abort()
 			return
 		}
+	}
+
+	// 通过 API token (query-params: token)
+	if token := c.Query("token"); "" != token {
+		if Conf.Api.Token == token {
+			c.Next()
+			return
+		}
+
+		c.JSON(401, map[string]interface{}{"code": -1, "msg": "Auth failed"})
+		c.Abort()
+		return
 	}
 
 	if "/check-auth" == c.Request.URL.Path { // 跳过访问授权页


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

支持使用查询参数 `token` 进行鉴权
Using the query parameter `token` for authentication

使用场景:
- 浏览器 `WebSocket` 接口无法自定义请求头, 需要使用查询参数 `?foo=bar&token=xxx` 设置 `token` 字段
  The browser `WebSocket` interface cannot customize the request header, and the `token` field needs to be set using the query parameter `?foo=bar&token=xxx`
  - REF: [WebSocket() - Web API 接口参考 | MDN](https://developer.mozilla.org/zh-CN/docs/Web/API/WebSocket/WebSocket)