### PR TITLE
Can't open block menu when the cursor is located in an empty code block

### DIFF
--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -555,12 +555,17 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                 // https://github.com/siyuan-note/siyuan/issues/5185
                 if (range.startOffset === 0 && range.startContainer.nodeType === 3) {
                     const previousSibling = hasPreviousSibling(range.startContainer) as HTMLElement;
-                    if (previousSibling && previousSibling.nodeType !== 3 && previousSibling.getAttribute("data-type").indexOf("inline-math") > -1) {
+                    if (previousSibling &&
+                        previousSibling.nodeType !== 3 &&
+                        previousSibling.getAttribute("data-type")?.indexOf("inline-math") > -1
+                    ) {
                         protyle.toolbar.showRender(protyle, previousSibling);
                         return;
                     } else if (!previousSibling &&
-                        range.startContainer.parentElement.previousSibling && range.startContainer.parentElement.previousSibling.isSameNode(range.startContainer.parentElement.previousElementSibling) &&
-                        range.startContainer.parentElement.previousElementSibling.getAttribute("data-type").indexOf("inline-math") > -1) {
+                        range.startContainer.parentElement.previousSibling &&
+                        range.startContainer.parentElement.previousSibling.isSameNode(range.startContainer.parentElement.previousElementSibling) &&
+                        range.startContainer.parentElement.previousElementSibling.getAttribute("data-type")?.indexOf("inline-math") > -1
+                    ) {
                         protyle.toolbar.showRender(protyle, range.startContainer.parentElement.previousElementSibling);
                         return;
                     }


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [x] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

问题描述: 当光标在空的代码块中时无法使用 <kbd>Ctrl + /</kbd> 打开块菜单
Issue: Unable to open the block menu with <kbd>Ctrl + /</kbd> when the cursor is in an empty code block

问题原因 | The cause of the problem
`element.getAttribute("data-type")` 可能返回 `null`, 因此需要使用 `?.` 以判断其是否有效

**已经过测试 | Tested**