### PR TITLE
Improve kernel API `/api/network/forwardProxy`

### DIFF
--- a/API.md
+++ b/API.md
@@ -1288,7 +1288,9 @@ View API token in <kbd>Settings - About</kbd>, request header: `Authorization: T
             "Cookie": ""
         }
     ],
-    "payload": {}
+    "payload": {},
+    "payloadEncoding": "text",
+    "responseEncoding": "text"
   }
   ```
 
@@ -1298,6 +1300,22 @@ View API token in <kbd>Settings - About</kbd>, request header: `Authorization: T
     * `contentType`: Content-Type, default is `application/json`
     * `headers`: HTTP headers
     * `payload`: HTTP payload, object or string
+    * `payloadEncoding`: The encoding scheme used by `pyaload`, default is `text`, optional values are as follows
+
+        * `text`
+        * `base64` | `base64-std`
+        * `base64-url`
+        * `base32` | `base32-std`
+        * `base32-hex`
+        * `hex`
+    * `responseEncoding`: The encoding scheme used by `body` in response data, default is `text`, optional values are as follows
+
+        * `text`
+        * `base64` | `base64-std`
+        * `base64-url`
+        * `base32` | `base32-std`
+        * `base32-hex`
+        * `hex`
 * Return value
 
   ```json
@@ -1306,6 +1324,7 @@ View API token in <kbd>Settings - About</kbd>, request header: `Authorization: T
     "msg": "",
     "data": {
       "body": "",
+      "bodyEncoding": "text",
       "contentType": "text/html",
       "elapsed": 1976,
       "headers": {
@@ -1315,6 +1334,15 @@ View API token in <kbd>Settings - About</kbd>, request header: `Authorization: T
     }
   }
   ```
+
+    * `bodyEncoding`：The encoding scheme used by `body`, is consistent with field `responseEncoding` in request, default is `text`, optional values are as follows
+
+        * `text`
+        * `base64` | `base64-std`
+        * `base64-url`
+        * `base32` | `base32-std`
+        * `base32-hex`
+        * `hex`
 
 ## System
 

--- a/API_zh_CN.md
+++ b/API_zh_CN.md
@@ -1278,7 +1278,9 @@
             "Cookie": ""
         }
     ],
-    "payload": {}
+    "payload": {},
+    "payloadEncoding": "text",
+    "responseEncoding": "text"
   }
   ```
 
@@ -1288,6 +1290,22 @@
     * `contentType`：HTTP Content-Type，默认为 `application/json`
     * `headers`：HTTP 请求标头
     * `payload`：HTTP 请求体，对象或者是字符串
+    * `payloadEncoding`：`pyaload` 所使用的编码方案，默认为 `text`，可选值如下所示
+
+        * `text`
+        * `base64` | `base64-std`
+        * `base64-url`
+        * `base32` | `base32-std`
+        * `base32-hex`
+        * `hex`
+    * `responseEncoding`：响应数据中 `body` 字段所使用的编码方案，默认为 `text`，可选值如下所示
+
+        * `text`
+        * `base64` | `base64-std`
+        * `base64-url`
+        * `base32` | `base32-std`
+        * `base32-hex`
+        * `hex`
 * 返回值
 
   ```json
@@ -1296,6 +1314,7 @@
     "msg": "",
     "data": {
       "body": "",
+      "bodyEncoding": "text",
       "contentType": "text/html",
       "elapsed": 1976,
       "headers": {
@@ -1305,6 +1324,15 @@
     }
   }
   ```
+
+    * `bodyEncoding`：`body` 所使用的编码方案，与请求中 `responseEncoding` 字段一致，默认为 `text`，可能的值如下所示
+
+        * `text`
+        * `base64` | `base64-std`
+        * `base64-url`
+        * `base32` | `base32-std`
+        * `base32-hex`
+        * `hex`
 
 ## 系统
 


### PR DESCRIPTION
* [X] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [X] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

gin 进行 `json` 序列化时会将非 `UTF-8` 字符替换为 `\ufffd` 导致 API `/api/network/forwardProxy` 无法获取正确的二进制响应体

- REF: https://github.com/bytedance/sonic/pull/357
- REF: https://github.com/gin-gonic/gin/pull/3508

本次改进如下所示
- API 请求体添加参数 `payloadEncoding` 与 `responseEncoding`
  - 请求体 `payload` 使用 `payloadEncoding` 指定的编码方案
  - 响应体 `body` 使用 `responseEncoding` 指定的编码方案
- API 响应体添加参数 `bodyEncoding`
  - 响应体 `body` 使用 `bodyEncoding` 指定的编码方案
  - `bodyEncoding` 与请求体中的 `payloadEncoding` 保持一致

已经过测试