### PR TITLE
Improve the sequence of pluign submenu item in title icon menu

### DIFF
--- a/app/src/protyle/header/openTitleMenu.ts
+++ b/app/src/protyle/header/openTitleMenu.ts
@@ -151,17 +151,6 @@ export const openTitleMenu = (protyle: IProtyle, position: {
             submenu: riffCardMenu,
         }).element);
 
-        if (protyle?.app?.plugins) {
-            emitOpenMenu({
-                plugins: protyle.app.plugins,
-                type: "click-editortitleicon",
-                detail: {
-                    protyle,
-                    data: response.data,
-                },
-                separatorPosition: "top",
-            });
-        }
         window.siyuan.menus.menu.append(new MenuItem({
             label: window.siyuan.languages.search,
             icon: "iconSearch",
@@ -261,7 +250,19 @@ export const openTitleMenu = (protyle: IProtyle, position: {
         }
         genImportMenu(protyle.notebookId, protyle.path);
         window.siyuan.menus.menu.append(exportMd(protyle.block.showAll ? protyle.block.id : protyle.block.rootID));
-        window.siyuan.menus.menu.append(new MenuItem({type: "separator"}).element);
+
+        if (protyle?.app?.plugins) {
+            emitOpenMenu({
+                plugins: protyle.app.plugins,
+                type: "click-editortitleicon",
+                detail: {
+                    protyle,
+                    data: response.data,
+                },
+                separatorPosition: "top",
+            });
+        }
+        window.siyuan.menus.menu.append(new MenuItem({ type: "separator" }).element);
         window.siyuan.menus.menu.append(new MenuItem({
             iconHTML: Constants.ZWSP,
             type: "readonly",


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

#9195 中更改了部分菜单项的位置, 文档块菜单中的插件菜单项的位置应与其他块菜单统一(菜单中最后一项)

The position of the plug-in menu item in the document block menu should be consistent with the other block menus (the last item in the menu)

已经过测试 | Tested