### PR TITLE
Add header `Access-Control-Max-Age` for OPTIONS requests

### DIFF
--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -530,6 +530,7 @@ func corsMiddleware() gin.HandlerFunc {
 		c.Header("Access-Control-Allow-Private-Network", "true")
 
 		if c.Request.Method == "OPTIONS" {
+			c.Header("Access-Control-Max-Age", 600)
 			c.AbortWithStatus(204)
 			return
 		}


### PR DESCRIPTION
Update serve.go

避免每次请求都发送预检请求。

对于 OceanPress 这类工具而言，能够获得更快的速度
