### PR TITLE
Plugin `requrie` function supports loading node modules

### DIFF
--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -8,13 +8,17 @@ import {API} from "./API";
 import {getFrontend, isMobile, isWindow} from "../util/functions";
 import {Constants} from "../constants";
 
-const getObject = (key: string) => {
-    const api = {
-        siyuan: API
-    };
-    // @ts-ignore
-    return api[key];
+const modules = {
+    siyuan: API
 };
+const requireFunc = (key: string) => {
+    // @ts-ignore
+    return modules[key]
+        ?? window.require?.(key);
+};
+if (window.require instanceof Function) {
+    requireFunc.__proto__ = window.require;
+}
 
 const runCode = (code: string, sourceURL: string) => {
     return window.eval("(function anonymous(require, module, exports){".concat(code, "\n})\n//# sourceURL=").concat(sourceURL, "\n"));
@@ -40,7 +44,7 @@ const loadPluginJS = async (app: App, item: IPluginData) => {
     const exportsObj: { [key: string]: any } = {};
     const moduleObj = {exports: exportsObj};
     try {
-        runCode(item.js, "plugin:" + encodeURIComponent(item.name))(getObject, moduleObj, exportsObj);
+        runCode(item.js, "plugin:" + encodeURIComponent(item.name))(requireFunc, moduleObj, exportsObj);
     } catch (e) {
         console.error(`plugin ${item.name} run error:`, e);
         return;


### PR DESCRIPTION
* [x] Please commit to the dev branch

插件的入口的 `require` 方法支持回退至 `window.require` 方法, 以便于 `webpack`, `vite` 或 `rollup` 等构建工具直接构建可在桌面端运行的插件
The `require` method of the plugin's entry allows to fall back to the `window.require` method, so that build tools such as `webpack`, `vite` or `rollup` can directly build plugins that can run on the desktop