### PR TITLE
Improve kernel API `/api/notebook/*`

### DIFF
--- a/kernel/api/notebook.go
+++ b/kernel/api/notebook.go
@@ -150,13 +150,20 @@ func createNotebook(c *gin.Context) {
 		return
 	}
 
+	box := model.Conf.Box(id)
+	if nil == box {
+		ret.Code = -2
+		ret.Msg = "opened notebook [" + id + "] not found"
+		return
+	}
+
 	ret.Data = map[string]interface{}{
-		"notebook": model.Conf.Box(id),
+		"notebook": box,
 	}
 
 	evt := util.NewCmdResult("createnotebook", 0, util.PushModeBroadcast)
 	evt.Data = map[string]interface{}{
-		"box":     model.Conf.Box(id),
+		"box":     box,
 		"existed": existed,
 	}
 	util.PushEvent(evt)
@@ -194,9 +201,16 @@ func openNotebook(c *gin.Context) {
 		return
 	}
 
+	box := model.Conf.Box(notebook)
+	if nil == box {
+		ret.Code = -2
+		ret.Msg = "opened notebook [" + notebook + "] not found"
+		return
+	}
+
 	evt := util.NewCmdResult("mount", 0, util.PushModeBroadcast)
 	evt.Data = map[string]interface{}{
-		"box":     model.Conf.Box(notebook),
+		"box":     box,
 		"existed": existed,
 	}
 	evt.Callback = arg["callback"]
@@ -233,7 +247,13 @@ func getNotebookConf(c *gin.Context) {
 		return
 	}
 
-	box := model.Conf.Box(notebook)
+	box := model.Conf.GetBox(notebook)
+	if nil == box {
+		ret.Code = -2
+		ret.Msg = "notebook [" + notebook + "] not found"
+		return
+	}
+
 	ret.Data = map[string]interface{}{
 		"box":  box.ID,
 		"name": box.Name,
@@ -255,7 +275,12 @@ func setNotebookConf(c *gin.Context) {
 		return
 	}
 
-	box := model.Conf.Box(notebook)
+	box := model.Conf.GetBox(notebook)
+	if nil == box {
+		ret.Code = -2
+		ret.Msg = "notebook [" + notebook + "] not found"
+		return
+	}
 
 	param, err := gulu.JSON.MarshalJSON(arg["conf"])
 	if nil != err {

--- a/kernel/api/notebook.go
+++ b/kernel/api/notebook.go
@@ -152,7 +152,7 @@ func createNotebook(c *gin.Context) {
 
 	box := model.Conf.Box(id)
 	if nil == box {
-		ret.Code = -2
+		ret.Code = -1
 		ret.Msg = "opened notebook [" + id + "] not found"
 		return
 	}
@@ -203,7 +203,7 @@ func openNotebook(c *gin.Context) {
 
 	box := model.Conf.Box(notebook)
 	if nil == box {
-		ret.Code = -2
+		ret.Code = -1
 		ret.Msg = "opened notebook [" + notebook + "] not found"
 		return
 	}
@@ -249,7 +249,7 @@ func getNotebookConf(c *gin.Context) {
 
 	box := model.Conf.GetBox(notebook)
 	if nil == box {
-		ret.Code = -2
+		ret.Code = -1
 		ret.Msg = "notebook [" + notebook + "] not found"
 		return
 	}
@@ -277,7 +277,7 @@ func setNotebookConf(c *gin.Context) {
 
 	box := model.Conf.GetBox(notebook)
 	if nil == box {
-		ret.Code = -2
+		ret.Code = -1
 		ret.Msg = "notebook [" + notebook + "] not found"
 		return
 	}

--- a/kernel/model/conf.go
+++ b/kernel/model/conf.go
@@ -649,6 +649,15 @@ func (conf *AppConf) Box(boxID string) *Box {
 	return nil
 }
 
+func (conf *AppConf) GetBox(boxID string) *Box {
+	for _, box := range conf.GetBoxes() {
+		if box.ID == boxID {
+			return box
+		}
+	}
+	return nil
+}
+
 func (conf *AppConf) BoxNames(boxIDs []string) (ret map[string]string) {
 	ret = map[string]string{}
 


### PR DESCRIPTION
* [x] Please commit to the dev branch


改进笔记本相关 API, 兼容指定的笔记本 ID 不存在对应笔记本的情况
Improve notebook-related APIs to be compatible with the situation where the specified notebook ID does not exist in the corresponding notebook

- `/api/notebook/getNotebookConf`
- `/api/notebook/setNotebookConf`
- `/api/notebook/createNotebook`
- `/api/notebook/openNotebook`

**TESTED**