### PR TITLE
Fix `name` attribute could not be visited in the plugin constructor

### DIFF
--- a/app/src/plugin/index.ts
+++ b/app/src/plugin/index.ts
@@ -67,6 +67,12 @@ export class Plugin {
         this.i18n = options.i18n;
         this.displayName = options.displayName;
         this.eventBus = new EventBus(options.name);
+
+        // https://github.com/siyuan-note/siyuan/issues/9943
+        Object.defineProperty(this, "name", {
+            value: options.name,
+            writable: false,
+        });
     }
 
     public onload() {

--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -64,11 +64,6 @@ const loadPluginJS = async (app: App, item: IPluginData) => {
         name: item.name,
         i18n: item.i18n
     });
-    // https://github.com/siyuan-note/siyuan/issues/9943
-    Object.defineProperty(plugin, "name", {
-        value: item.name,
-        writable: false,
-    });
     app.plugins.push(plugin);
     try {
         await plugin.onload();


### PR DESCRIPTION
修复在插件类构造函数中无法访问 `name` 属性的问题
Fixed the `name` attribute could not be visited in the plugin constructor.

REL: #9943