### PR TITLE
Revert "Adjust the style of the first column of the attribute view"

### DIFF
--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -189,13 +189,10 @@
       display: flex;
 
       .b3-button {
+        margin: 3px 0 3px 24px;
         color: var(--b3-theme-on-surface);
         background-color: transparent;
         font-size: 75%;
-
-        > div {
-          background-color: transparent;
-        }
 
         &:hover,
         &:focus {
@@ -216,16 +213,6 @@
           &:hover {
             background-color: var(--b3-theme-background);
           }
-        }
-      }
-    }
-
-    &,
-    &--util,
-    &--footer {
-      &:hover {
-        .av__firstcol svg {
-          opacity: 1;
         }
       }
     }
@@ -263,10 +250,6 @@
 
     &.dragover__right {
       border-right-color: var(--b3-theme-primary-lighter);
-    }
-
-    &--add {
-      padding-left: 0.5em;
     }
 
     &--select {
@@ -338,13 +321,15 @@
   }
 
   &__firstcol {
-    border-right: 1px solid var(--b3-theme-surface-lighter);
-
     svg {
       @extend .av__checkbox;
-      padding: 9.5px 5px;
       opacity: 0;
+      padding: 9.5px 5px;
       cursor: pointer;
+    }
+
+    &:hover svg {
+      opacity: 1;
     }
   }
 

--- a/app/src/menus/protyle.ts
+++ b/app/src/menus/protyle.ts
@@ -1883,7 +1883,7 @@ export const setFold = (protyle: IProtyle, nodeElement: Element, isOpen?: boolea
         nodeElement.querySelectorAll(".img--select, .av__cell--select, .av__row--select").forEach((item: HTMLElement) => {
             if (item.classList.contains("av__row--select")) {
                 item.classList.remove("av__row--select");
-                item.querySelector(".av__check use").setAttribute("xlink:href", "#iconUncheck");
+                item.querySelector(".av__firstcol use").setAttribute("xlink:href", "#iconUncheck");
                 updateHeader(item);
             } else {
                 item.classList.remove("img--select", "av__cell--select");

--- a/app/src/protyle/render/av/action.ts
+++ b/app/src/protyle/render/av/action.ts
@@ -35,7 +35,7 @@ export const avClick = (protyle: IProtyle, event: MouseEvent & { target: HTMLEle
     if (event.shiftKey) {
         const rowElement = hasClosestByClassName(event.target, "av__row");
         if (rowElement && !rowElement.classList.contains("av__row--header")) {
-            selectRow(rowElement.querySelector(".av__check"), "toggle");
+            selectRow(rowElement.querySelector(".av__firstcol"), "toggle");
             return true;
         }
     }
@@ -159,7 +159,7 @@ export const avClick = (protyle: IProtyle, event: MouseEvent & { target: HTMLEle
             event.preventDefault();
             event.stopPropagation();
             return true;
-        } else if (target.classList.contains("av__check")) {
+        } else if (target.classList.contains("av__firstcol")) {
             window.siyuan.menus.menu.remove();
             selectRow(target, "toggle");
             event.preventDefault();
@@ -214,10 +214,10 @@ export const avClick = (protyle: IProtyle, event: MouseEvent & { target: HTMLEle
                 }
                 const type = getTypeByCellElement(target);
                 if (type === "updated" || type === "created" || (type === "block" && !target.getAttribute("data-detached"))) {
-                    selectRow(rowElement.querySelector(".av__check"), "toggle");
+                    selectRow(rowElement.querySelector(".av__firstcol"), "toggle");
                 } else {
                     scrollElement.querySelectorAll(".av__row--select").forEach(item => {
-                        item.querySelector(".av__check use").setAttribute("xlink:href", "#iconUncheck");
+                        item.querySelector(".av__firstcol use").setAttribute("xlink:href", "#iconUncheck");
                         item.classList.remove("av__row--select");
                     });
                     updateHeader(rowElement);
@@ -263,7 +263,7 @@ export const avContextmenu = (protyle: IProtyle, rowElement: HTMLElement, positi
         blockElement.querySelectorAll(".av__row--select").forEach(item => {
             item.classList.remove("av__row--select");
         });
-        blockElement.querySelectorAll(".av__check use").forEach(item => {
+        blockElement.querySelectorAll(".av__firstcol use").forEach(item => {
             item.setAttribute("xlink:href", "#iconUncheck");
         });
     }
@@ -273,7 +273,7 @@ export const avContextmenu = (protyle: IProtyle, rowElement: HTMLElement, positi
         return true;
     }
     rowElement.classList.add("av__row--select");
-    rowElement.querySelector(".av__check use").setAttribute("xlink:href", "#iconCheck");
+    rowElement.querySelector(".av__firstcol use").setAttribute("xlink:href", "#iconCheck");
     const rowElements = blockElement.querySelectorAll(".av__row--select:not(.av__row--header)");
     updateHeader(rowElement);
     if (!protyle.disabled) {

--- a/app/src/protyle/render/av/keydown.ts
+++ b/app/src/protyle/render/av/keydown.ts
@@ -25,7 +25,7 @@ export const avKeydown = (event: KeyboardEvent, nodeElement: HTMLElement, protyl
         }
         if (event.key === "Escape") {
             selectCellElement.classList.remove("av__cell--select");
-            selectRow(rowElement.querySelector(".av__check"), "select");
+            selectRow(rowElement.querySelector(".av__firstcol"), "select");
             event.preventDefault();
             return true;
         }
@@ -42,7 +42,7 @@ export const avKeydown = (event: KeyboardEvent, nodeElement: HTMLElement, protyl
         let newCellElement;
         if (event.key === "ArrowLeft" || matchHotKey("⇧⇥", event)) {
             const previousRowElement = rowElement.previousElementSibling;
-            if (selectCellElement.previousElementSibling && !selectCellElement.previousElementSibling.classList.contains("av__check")) {
+            if (selectCellElement.previousElementSibling && !selectCellElement.previousElementSibling.classList.contains("av__firstcol")) {
                 if (selectCellElement.previousElementSibling.classList.contains("av__cell")) {
                     newCellElement = selectCellElement.previousElementSibling;
                 } else {
@@ -129,7 +129,7 @@ export const avKeydown = (event: KeyboardEvent, nodeElement: HTMLElement, protyl
         }
         if (event.key === "Escape") {
             event.preventDefault();
-            selectRow(selectRowElements[0].querySelector(".av__check"), "unselectAll");
+            selectRow(selectRowElements[0].querySelector(".av__firstcol"), "unselectAll");
             return true;
         }
         if (event.key === "Backspace") {
@@ -138,7 +138,7 @@ export const avKeydown = (event: KeyboardEvent, nodeElement: HTMLElement, protyl
             return true;
         }
         if (event.key === "Enter") {
-            selectRow(selectRowElements[0].querySelector(".av__check"), "unselectAll");
+            selectRow(selectRowElements[0].querySelector(".av__firstcol"), "unselectAll");
             popTextCell(protyle, [selectRowElements[0].querySelector(".av__cell")]);
             event.preventDefault();
             return true;
@@ -146,9 +146,9 @@ export const avKeydown = (event: KeyboardEvent, nodeElement: HTMLElement, protyl
         // TODO event.shiftKey
         if (event.key === "ArrowUp") {
             const previousRowElement = selectRowElements[0].previousElementSibling;
-            selectRow(selectRowElements[0].querySelector(".av__check"), "unselectAll");
+            selectRow(selectRowElements[0].querySelector(".av__firstcol"), "unselectAll");
             if (previousRowElement && !previousRowElement.classList.contains("av__row--header")) {
-                selectRow(previousRowElement.querySelector(".av__check"), "select");
+                selectRow(previousRowElement.querySelector(".av__firstcol"), "select");
                 cellScrollIntoView(nodeElement, previousRowElement);
             } else {
                 nodeElement.classList.add("protyle-wysiwyg--select");
@@ -158,9 +158,9 @@ export const avKeydown = (event: KeyboardEvent, nodeElement: HTMLElement, protyl
         }
         if (event.key === "ArrowDown") {
             const nextRowElement = selectRowElements[selectRowElements.length - 1].nextElementSibling;
-            selectRow(selectRowElements[0].querySelector(".av__check"), "unselectAll");
+            selectRow(selectRowElements[0].querySelector(".av__firstcol"), "unselectAll");
             if (nextRowElement && !nextRowElement.classList.contains("av__row--util")) {
-                selectRow(nextRowElement.querySelector(".av__check"), "select");
+                selectRow(nextRowElement.querySelector(".av__firstcol"), "select");
                 cellScrollIntoView(nodeElement, nextRowElement);
             } else {
                 nodeElement.classList.add("protyle-wysiwyg--select");
@@ -171,3 +171,4 @@ export const avKeydown = (event: KeyboardEvent, nodeElement: HTMLElement, protyl
     }
     return false;
 };
+

--- a/app/src/protyle/render/av/render.ts
+++ b/app/src/protyle/render/av/render.ts
@@ -67,8 +67,8 @@ export const avRender = (element: Element, protyle: IProtyle, cb?: () => void, v
                     e.dataset.pageSize = data.pageSize.toString();
                 }
                 // header
-                let tableHTML = '<div class="av__row av__row--header"><div class="av__colsticky"><div class="av__firstcol"><svg class="av__check"><use xlink:href="#iconUncheck"></use></svg></div>';
-                let calcHTML = '<div class="av__colsticky"><div class="av__firstcol"><svg><use xlink:href="#iconMath"></use></svg></div>';
+                let tableHTML = '<div class="av__row av__row--header"><div class="av__firstcol av__colsticky"><svg><use xlink:href="#iconUncheck"></use></svg></div>';
+                let calcHTML = '<div style="width: 24px"></div>';
                 let pinIndex = -1;
                 let pinMaxIndex = -1;
                 let indexWidth = 0;
@@ -85,9 +85,9 @@ export const avRender = (element: Element, protyle: IProtyle, cb?: () => void, v
                     }
                 });
                 pinIndex = Math.min(pinIndex, pinMaxIndex);
-                if (pinIndex < 0) {
-                    tableHTML += '</div>';
-                    calcHTML += '</div>';
+                if (pinIndex > -1) {
+                    tableHTML = '<div class="av__row av__row--header"><div class="av__colsticky"><div class="av__firstcol"><svg><use xlink:href="#iconUncheck"></use></svg></div>';
+                    calcHTML = '<div class="av__colsticky"><div style="width: 24px"></div>';
                 }
                 data.columns.forEach((column: IAVColumn, index: number) => {
                     if (column.hidden) {
@@ -120,15 +120,11 @@ style="width: ${column.width || "200px"}">${getCalcValue(column) || '<svg><use x
 </div>`;
                 // body
                 data.rows.forEach((row: IAVRow) => {
-                    tableHTML += `<div class="av__row" data-id="${row.id}">
-<div class="av__colsticky">
-    <div class="av__firstcol">
-        <svg class="av__check"><use xlink:href="#iconUncheck"></use></svg>
-    </div>
-`;
-
-                    if (pinIndex < 0) {
-                        tableHTML += '</div>';
+                    tableHTML += `<div class="av__row" data-id="${row.id}">`;
+                    if (pinIndex > -1) {
+                        tableHTML += '<div class="av__colsticky"><div class="av__firstcol"><svg><use xlink:href="#iconUncheck"></use></svg></div>';
+                    } else {
+                        tableHTML += '<div class="av__firstcol av__colsticky"><svg><use xlink:href="#iconUncheck"></use></svg></div>';
                     }
 
                     row.cells.forEach((cell, index) => {
@@ -198,9 +194,6 @@ ${cell.color ? `color:${cell.color};` : ""}">${renderCell(cell.value, data.colum
             ${tableHTML}
             <div class="av__row--util">
                 <div class="av__colsticky">
-                    <div class="av__firstcol">
-                        <svg><use xlink:href="#iconAdd"></use></svg>
-                    </div>
                     <button class="b3-button" data-type="av-add-bottom">
                         <svg><use xlink:href="#iconAdd"></use></svg>
                         ${window.siyuan.languages.addAttr}

--- a/app/src/protyle/render/av/row.ts
+++ b/app/src/protyle/render/av/row.ts
@@ -13,7 +13,7 @@ export const selectRow = (checkElement: Element, type: "toggle" | "select" | "un
     const useElement = checkElement.querySelector("use");
     if (rowElement.classList.contains("av__row--header") || type === "unselectAll") {
         if ("#iconCheck" === useElement.getAttribute("xlink:href")) {
-            rowElement.parentElement.querySelectorAll(".av__check").forEach(item => {
+            rowElement.parentElement.querySelectorAll(".av__firstcol").forEach(item => {
                 item.querySelector("use").setAttribute("xlink:href", "#iconUncheck");
                 const rowItemElement = hasClosestByClassName(item, "av__row");
                 if (rowItemElement) {
@@ -21,7 +21,7 @@ export const selectRow = (checkElement: Element, type: "toggle" | "select" | "un
                 }
             });
         } else {
-            rowElement.parentElement.querySelectorAll(".av__check").forEach(item => {
+            rowElement.parentElement.querySelectorAll(".av__firstcol").forEach(item => {
                 item.querySelector("use").setAttribute("xlink:href", "#iconCheck");
                 const rowItemElement = hasClosestByClassName(item, "av__row");
                 if (rowItemElement) {

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -194,7 +194,7 @@ export class WYSIWYG {
         protyle.wysiwyg.element.querySelectorAll(".img--select, .av__cell--select, .av__row--select").forEach((item: HTMLElement) => {
             if (item.classList.contains("av__row--select") && !hasClosestByClassName(element, "av")) {
                 item.classList.remove("av__row--select");
-                item.querySelector(".av__check use").setAttribute("xlink:href", "#iconUncheck");
+                item.querySelector(".av__firstcol use").setAttribute("xlink:href", "#iconUncheck");
                 updateHeader(item);
             } else {
                 item.classList.remove("img--select", "av__cell--select");


### PR DESCRIPTION
Reverts siyuan-note/siyuan#9830

看了下修改后的结构应该是比较合理的，但由于修改了部分交互，基于以下原因建议还原已有交互后重新进行提交。非常感谢。

1.  鼠标浮动在行上时显示首例的勾选框会分散用户注意力，造成更多不必要的干扰。

https://github.com/siyuan-note/siyuan/assets/970828/d37b3f01-0c4c-4344-b765-084cee0291d6

2. 没有进行列计算时，最后一行的竖线比较突兀
<img width="1449" alt="image" src="https://github.com/siyuan-note/siyuan/assets/970828/85abeb5f-82be-453f-885b-1fbe40ac14e5">

3. 为了简洁，原有设计在第一列后没有竖线。但社区有用户提过像 wolai 一样提供所有的线条，为此建议使用主题或代码片段进行实现。
<img width="1511" alt="image" src="https://github.com/siyuan-note/siyuan/assets/970828/6234b909-21a9-4122-a45c-dc36c5d2d125">

4. 两个加号在一起比较奇怪
<img width="1397" alt="image" src="https://github.com/siyuan-note/siyuan/assets/970828/10a68e31-9768-451b-a53d-64f26ba388d3">

5. 按钮高亮样式过于粗壮
<img width="1443" alt="image" src="https://github.com/siyuan-note/siyuan/assets/970828/10f084da-a825-4aa4-be06-85164ecf32f4">

6. 这两个按钮不可以点击，但是鼠标移动上去会高亮，并且为点击手势
<img width="1477" alt="image" src="https://github.com/siyuan-note/siyuan/assets/970828/c5c4cec6-e8b6-4a7e-9388-04b38dbcbfa4">






