### PR TITLE
:recycle: Upgrade @electron/remote v2.1.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -74,6 +74,6 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@electron/remote": "^2.0.12"
+    "@electron/remote": "^2.1.1"
   }
 }


### PR DESCRIPTION
* [X] Please commit to the dev branch
* [X] For bug fixes, please describe the problem and solution via code comments

## Issue

## 问题描述

REF [https://github.com/siyuan-note/siyuan/issues/10145](https://github.com/siyuan-note/siyuan/issues/10145)

The issue stems from the upgrade of `Electron 28`, and the alterations within `Electron 28` have repercussions on `@electron/remote`. Failure to undergo the upgrade will render inoperable all code dependent on `@electron/remote`.

该问题由 `Electron  28` 的升级引起，`Electron  28` 的 变更影响了 `@electron/remote` 。如果未升级，所有依赖 @electron/remote 的代码都将无法工作。

## Solution

## 解决方案

According to the official guidelines, in order to ensure compatibility with `Electron 28`, it is imperative to upgrade `@electron/remote` to version `2.1.1`. For further elucidation, kindly peruse [https://github.com/electron/remote/pull/171](https://github.com/electron/remote/pull/171).

根据官方指南，为确保与 `Electron 28` 兼容，必须将 `@electron/remote` 更新到 `2.1.1` 版本。有关详细信息，请参阅 [https://github.com/electron/remote/pull/171](https://github.com/electron/remote/pull/171) 。
