### PR TITLE
Set the maximum message size of WebSocket broadcast to 128 MiB

### DIFF
--- a/kernel/api/broadcast.go
+++ b/kernel/api/broadcast.go
@@ -61,6 +61,7 @@ func broadcast(c *gin.Context) {
 	} else {
 		// channel not found, create a new one
 		broadcastChannel := melody.New()
+		broadcastChannel.Config.MaxMessageSize = 1024 * 1024 * 128 // 128 MiB
 		BroadcastChannels.Store(channel, broadcastChannel)
 		subscribe(c, broadcastChannel, channel)
 


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For contributing new features, please supplement and improve the corresponding user guide documents

当前 API `/ws/broadcast` 提供的 WebSocket 广播消息大小上限为 `512 Byte`, 难以满足需要, 现调整为 `128 MiB`