### PR TITLE
Remove invalid requests during boot

### DIFF
--- a/app/electron/boot.html
+++ b/app/electron/boot.html
@@ -30,10 +30,6 @@
          style="color: #9aa0a6;text-overflow: ellipsis;white-space: nowrap;overflow: hidden;padding: 8px;height: 16px;line-height: 16px;"></div>
 </div>
 <script>
-    const sleep = (ms) => {
-        return new Promise(resolve => setTimeout(resolve, ms))
-    }
-
     const getSearch = (key) => {
         if (window.location.search.indexOf('?') === -1) {
             return ''
@@ -49,36 +45,9 @@
         })
         return value
     }
-
-    const redirect = () => {
-        const uri = 'http://127.0.0.1:' + location.port
-        if (navigator.userAgent.match(/Android/i))
-            document.location = uri
-        else
-            window.location.replace(uri)
-    }
     (async () => {
         const v = getSearch('v')
         document.getElementById('details').textContent = "v" + v + ' Booting kernel...'
-        let progressing = false
-        while (!progressing) {
-            try {
-                const progressResult = await fetch('http://127.0.0.1:' + location.port + '/api/system/bootProgress')
-                const progressData = await progressResult.json()
-                document.getElementById('progress').style.width = progressData.data.progress + '%'
-                document.getElementById('details').textContent = progressData.data.details
-                if (progressData.data.progress >= 100) {
-                    progressing = true
-                    if (navigator.userAgent.indexOf('Electron') === -1) {
-                        redirect()
-                    }
-                } else {
-                    await sleep(100)
-                }
-            } catch (e) {
-                await sleep(100)
-            }
-        }
     })()
 </script>
 </body>


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For contributing new features, please supplement and improve the corresponding user guide documents
* [x] For bug fixes, please describe the problem and solution via code comments
* [x] For text improvements (such as typos and wording adjustments), please submit directly

上文： [思源笔记前端启动时会对 80 端口发送 /api/system/bootProgress 请求](https://ld246.com/article/1703163367160)

我发现[在kernel启动过程中](https://github.com/siyuan-note/siyuan/blob/f6651fbc0ffd4c4ac9f8ed32337523d3c8a02732/app/electron/main.js#L427)，`app/electron/boot.html` 就是作为占位页面存在的，在kernel启动之后就会被替换成 `*/appearance/boot/index.html`。所以在 `boot.html` 中获取的 `location.port` 是空值，会导致前端一直请求 80 端口，移除这个页面的循环请求不会影响启动进程的显示。
