### PR TITLE
Rename `iFrameBlock` to `iframeBlock`

### DIFF
--- a/app/src/config/query.ts
+++ b/app/src/config/query.ts
@@ -148,7 +148,7 @@ export const query = {
                 IFrame
             </div>
             <span class="fn__space"></span>
-            <input class="b3-switch" id="iFrameBlock" type="checkbox"${window.siyuan.config.search.iFrameBlock ? " checked" : ""}/>
+            <input class="b3-switch" id="iframeBlock" type="checkbox"${window.siyuan.config.search.iframeBlock ? " checked" : ""}/>
         </label>
         <label class="fn__flex">
             <svg class="svg"><use xlink:href="#iconBoth"></use></svg>
@@ -317,7 +317,7 @@ export const query = {
                     databaseBlock: (query.element.querySelector("#databaseBlock") as HTMLInputElement).checked,
                     audioBlock: (query.element.querySelector("#audioBlock") as HTMLInputElement).checked,
                     videoBlock: (query.element.querySelector("#videoBlock") as HTMLInputElement).checked,
-                    iFrameBlock: (query.element.querySelector("#iFrameBlock") as HTMLInputElement).checked,
+                    iframeBlock: (query.element.querySelector("#iframeBlock") as HTMLInputElement).checked,
                     widgetBlock: (query.element.querySelector("#widgetBlock") as HTMLInputElement).checked,
                     mathBlock: (query.element.querySelector("#mathBlock") as HTMLInputElement).checked,
                     table: (query.element.querySelector("#table") as HTMLInputElement).checked,

--- a/app/src/search/getDefault.ts
+++ b/app/src/search/getDefault.ts
@@ -3,7 +3,7 @@ export const getDefaultType = () => {
     return {
         audioBlock: window.siyuan.config.search.audioBlock,
         videoBlock: window.siyuan.config.search.videoBlock,
-        iFrameBlock: window.siyuan.config.search.iFrameBlock,
+        iframeBlock: window.siyuan.config.search.iframeBlock,
         widgetBlock: window.siyuan.config.search.widgetBlock,
         document: window.siyuan.config.search.document,
         heading: window.siyuan.config.search.heading,

--- a/app/src/search/menu.ts
+++ b/app/src/search/menu.ts
@@ -155,7 +155,7 @@ export const filterMenu = (config: Config.IUILayoutTabSearchConfig, cb: () => vo
             IFrame
         </div>
         <span class="fn__space"></span>
-        <input class="b3-switch fn__flex-center" data-type="iFrameBlock" type="checkbox"${config.types.iFrameBlock ? " checked" : ""}>
+        <input class="b3-switch fn__flex-center" data-type="iframeBlock" type="checkbox"${config.types.iframeBlock ? " checked" : ""}>
     </label>
     <label class="fn__flex b3-label">
         <svg class="ft__on-surface svg fn__flex-center"><use xlink:href="#iconBoth"></use></svg>

--- a/app/src/types/config.d.ts
+++ b/app/src/types/config.d.ts
@@ -1081,7 +1081,7 @@ declare namespace Config {
         /**
          * Whether to search in iframe blocks
          */
-        iFrameBlock: boolean;
+        iframeBlock: boolean;
         /**
          * Whether to search resource file paths
          */
@@ -2111,7 +2111,7 @@ declare namespace Config {
          * Search results contain iframe blocks
          * @default false
          */
-        iFrameBlock: boolean;
+        iframeBlock: boolean;
         /**
          * Search results contain list blocks
          * @default false

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -273,7 +273,7 @@ interface ISearchOption {
 interface ISearchType {
     audioBlock: boolean
     videoBlock: boolean
-    iFrameBlock: boolean
+    iframeBlock: boolean
     widgetBlock: boolean
     mathBlock: boolean
     table: boolean

--- a/kernel/model/search.go
+++ b/kernel/model/search.go
@@ -973,7 +973,7 @@ func buildTypeFilter(types map[string]bool) string {
 		s.DatabaseBlock = types["databaseBlock"]
 		s.AudioBlock = types["audioBlock"]
 		s.VideoBlock = types["videoBlock"]
-		s.IFrameBlock = types["iFrameBlock"]
+		s.IFrameBlock = types["iframeBlock"]
 		s.WidgetBlock = types["widgetBlock"]
 	} else {
 		s.Document = Conf.Search.Document


### PR DESCRIPTION
* [x] Please commit to the dev branch

混用了属性名 `iFrameBlock` 与 `iframeBlock` 导致部分 API 相关属性无法获取/设置, 现统一为 `iframeBlock`

已经过测试