### PR TITLE
将数据库视图菜单中功能相同的「重命名」「设置」合并为「编辑视图」

### DIFF
--- a/app/appearance/langs/en_US.json
+++ b/app/appearance/langs/en_US.json
@@ -225,6 +225,7 @@
   "hide": "Hide",
   "wrap": "Wrap column",
   "edit": "Edit",
+  "editView": "Edit view",
   "incompatiblePluginTip": "This plugin is not supported on the current terminal",
   "incompatible": "Incompatible",
   "trust": "Trust",

--- a/app/appearance/langs/es_ES.json
+++ b/app/appearance/langs/es_ES.json
@@ -225,6 +225,7 @@
   "hide": "Ocultar",
   "wrap": "Columna de ajuste",
   "edit": "Editar",
+  "editView": "Vista de edición",
   "incompatiblePluginTip": "Este complemento no es compatible con el terminal actual",
   "incompatible": "Incompatible",
   "trust": "Confiar",

--- a/app/appearance/langs/fr_FR.json
+++ b/app/appearance/langs/fr_FR.json
@@ -225,6 +225,7 @@
   "hide": "Masquer",
   "wrap": "Reboucler la colonne",
   "edit": "Modifier",
+  "editView": "Vue d'édition",
   "incompatiblePluginTip": "Ce plugin n'est pas supporté sur le terminal actuel",
   "incompatible": "Incompatible",
   "trust": "Confiance",

--- a/app/appearance/langs/zh_CHT.json
+++ b/app/appearance/langs/zh_CHT.json
@@ -225,6 +225,7 @@
   "hide": "隱藏",
   "wrap": "換行",
   "edit": "編輯",
+  "editView": "編輯視圖",
   "incompatiblePluginTip": "該插件不支持在當前終端上使用",
   "incompatible": "不兼容",
   "trust": "信任",

--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -225,6 +225,7 @@
   "hide": "隐藏",
   "wrap": "换行",
   "edit": "编辑",
+  "editView": "编辑视图",
   "incompatiblePluginTip": "该插件不支持在当前终端上使用",
   "incompatible": "不兼容",
   "trust": "信任",

--- a/app/src/protyle/render/av/view.ts
+++ b/app/src/protyle/render/av/view.ts
@@ -13,7 +13,7 @@ export const openViewMenu = (options: { protyle: IProtyle, blockElement: HTMLEle
     }
     menu.addItem({
         icon: "iconEdit",
-        label: window.siyuan.languages.rename,
+        label: window.siyuan.languages.editView,
         click() {
             document.querySelector(".av__panel")?.remove();
             openMenuPanel({
@@ -26,19 +26,6 @@ export const openViewMenu = (options: { protyle: IProtyle, blockElement: HTMLEle
             });
         }
     });
-    menu.addItem({
-        icon: "iconSettings",
-        label: window.siyuan.languages.config,
-        click() {
-            document.querySelector(".av__panel")?.remove();
-            openMenuPanel({
-                protyle: options.protyle,
-                blockElement: options.blockElement,
-                type: "config"
-            });
-        }
-    });
-    menu.addSeparator();
     menu.addItem({
         icon: "iconCopy",
         label: window.siyuan.languages.duplicate,


### PR DESCRIPTION
原来无论点击「重命名」还是「设置」，都会打开同一个浮窗，是相同的行为。

合并了会更直观，用户不需要思考点击哪一个，不需要做选择，直接点就行了。

原来的视觉路线：

- 点击视图 → 看到重命名 → 我要重命名 → 点击重命名
- 点击视图 → 看到重命名 → 我不是要重命名，我要…… → 看到设置 → 点击设置

修改之后：

- 点击视图 → 看到编辑视图 → 我要重命名/…… → 点击编辑视图

![image](https://github.com/siyuan-note/siyuan/assets/78434827/e76caab2-9fd7-4aab-8b1f-4565bf7a12b6)

关联 #10889