### PR TITLE
:art: add database ord

### DIFF
--- a/app/appearance/langs/en_US.json
+++ b/app/appearance/langs/en_US.json
@@ -1,6 +1,7 @@
 {
   "unbindBlock": "Unbind block",
   "showTitle": "Show database title",
+  "showRowNumber": "Show line number",
   "fillCreated": "Default fill created time",
   "removeCard": "Remove flashcard",
   "updateLayout": "Update layout",

--- a/app/appearance/langs/es_ES.json
+++ b/app/appearance/langs/es_ES.json
@@ -1,6 +1,7 @@
 {
   "unbindBlock": "Desvincular bloque",
   "showTitle": "Mostrar título de la base de datos",
+  "showRowNumber": "Mostrar número de línea",
   "fillCreated": "Hora de creación del relleno predeterminado",
   "removeCard": "Eliminar tarjeta flash",
   "updateLayout": "Actualizar diseño",

--- a/app/appearance/langs/fr_FR.json
+++ b/app/appearance/langs/fr_FR.json
@@ -1,6 +1,7 @@
 {
   "unbindBlock": "Dissocier le bloc",
   "showTitle": "Afficher le titre de la base de données",
+  "showRowNumber": "Afficher le numéro de ligne",
   "fillCreated": "Heure de création de remplissage par défaut",
   "removeCard": "Supprimer la flashcard",
   "updateLayout": "Mettre à jour la mise en page",

--- a/app/appearance/langs/zh_CHT.json
+++ b/app/appearance/langs/zh_CHT.json
@@ -1,6 +1,7 @@
 {
   "unbindBlock": "取消綁定區塊",
   "showTitle": "顯示資料庫標題",
+  "showRowNumber": "顯示行號",
   "fillCreated": "預設填滿創建時間",
   "removeCard": "移除閃卡",
   "updateLayout": "更新版面配置",

--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -1,6 +1,7 @@
 {
   "unbindBlock": "取消绑定块",
   "showTitle": "显示数据库标题",
+  "showRowNumber": "显示行号",
   "fillCreated": "默认填充创建时间",
   "removeCard": "移除闪卡",
   "updateLayout": "更新布局",

--- a/app/src/protyle/render/av/action.ts
+++ b/app/src/protyle/render/av/action.ts
@@ -242,7 +242,7 @@ export const avClick = (protyle: IProtyle, event: MouseEvent & { target: HTMLEle
         } else if (target.classList.contains("av__cell")) {
             if (!hasClosestByClassName(target, "av__row--header")) {
                 const scrollElement = hasClosestByClassName(target, "av__scroll");
-                if (!scrollElement || target.querySelector(".av__pulse")) {
+                if (!scrollElement || target.querySelector(".av__pulse") || target?.classList?.contains("av__ord_col_only")) {
                     return;
                 }
                 const rowElement = hasClosestByClassName(target, "av__row");

--- a/app/src/protyle/render/av/col.ts
+++ b/app/src/protyle/render/av/col.ts
@@ -608,6 +608,65 @@ export const showColMenu = (protyle: IProtyle, blockElement: Element, cellElemen
     const avID = blockElement.getAttribute("data-av-id");
     const blockID = blockElement.getAttribute("data-node-id");
     const oldValue = cellElement.querySelector(".av__celltext").textContent.trim();
+    const isAvOrdCol = cellElement.getAttribute("data-only-av-ord");
+        // TODO found that the underlying cause lies in the excessive intrusion of code
+    // only need:
+    // 1. iconInsertLeft
+    // 2. iconInsertRight
+    // 3. iconEyeoff
+    if (isAvOrdCol) {
+        const menu = new Menu("av-header-cell");
+        menu.addItem({
+            icon: "iconInsertLeft",
+            label: window.siyuan.languages.insertColumnLeft,
+            click() {
+                const addMenu = addCol(protyle, blockElement, cellElement.previousElementSibling?.getAttribute("data-col-id") || "");
+                const addRect = cellElement.getBoundingClientRect();
+                addMenu.open({
+                    x: addRect.left,
+                    y: addRect.bottom,
+                    h: addRect.height
+                });
+            }
+        });
+        menu.addItem({
+            icon: "iconInsertRight",
+            label: window.siyuan.languages.insertColumnRight,
+            click() {
+                const addMenu = addCol(protyle, blockElement, cellElement.getAttribute("data-col-id") || "");
+                const addRect = cellElement.getBoundingClientRect();
+                addMenu.open({
+                    x: addRect.left,
+                    y: addRect.bottom,
+                    h: addRect.height
+                });
+            }
+        });
+        menu.addItem({
+            icon: "iconEyeoff",
+            label: window.siyuan.languages.hide,
+            click() {
+                transaction(protyle, [{
+                action: "showAttrViewLineNumber",
+                avID,
+                blockID,
+                data: true
+            }], [{
+                action: "showAttrViewLineNumber",
+                avID,
+                blockID,
+                data: false
+            }]);
+            }
+        });
+        const cellRect = cellElement.getBoundingClientRect();
+        menu.open({
+            x: cellRect.left,
+            y: cellRect.bottom,
+            h: cellRect.height
+        });
+        return;
+    }
     const menu = new Menu("av-header-cell", () => {
         const newValue = (menu.element.querySelector(".b3-text-field") as HTMLInputElement).value;
         if (newValue === oldValue) {

--- a/app/src/protyle/render/av/openMenuPanel.ts
+++ b/app/src/protyle/render/av/openMenuPanel.ts
@@ -463,6 +463,7 @@ export const openMenuPanel = (options: {
             }
             let target = event.target as HTMLElement;
             while (target && !target.isSameNode(avPanelElement) || type) {
+                // TODO FIXME 如果 type 为 True, target 可能为 Falsy，会导致报错中断
                 type = target.dataset.type || type;
                 if (type === "close") {
                     if (!options.protyle.toolbar.subElement.classList.contains("fn__none")) {

--- a/app/src/protyle/render/av/render.ts
+++ b/app/src/protyle/render/av/render.ts
@@ -114,6 +114,11 @@ export const avRender = (element: Element, protyle: IProtyle, cb?: () => void, v
                     tableHTML = '<div class="av__row av__row--header"><div class="av__colsticky"><div class="av__firstcol"><svg><use xlink:href="#iconUncheck"></use></svg></div>';
                     calcHTML = '<div class="av__colsticky">';
                 }
+                // TODO 添加行好列，根据 showAttrViewLineNumber 决定是否显示 class
+                if (data.showAttrViewLineNumber) {
+                    tableHTML += '<div class="av__cell av__cell--header av__colsticky av__ord_col_only" style="left: 24px; width: 48px; background-color: var(--av-background)" data-only-av-ord="true" data-pin="true" draggable="false" data-dtype="number"><span class="av__celltext fn__flex-1">&nbsp;</span></div>';
+                }
+
                 data.columns.forEach((column: IAVColumn, index: number) => {
                     if (column.hidden) {
                         return;
@@ -142,12 +147,17 @@ style="width: ${index === 0 ? ((parseInt(column.width || "200") + 24) + "px") : 
 </div>
 </div>`;
                 // body
-                data.rows.forEach((row: IAVRow) => {
+                data.rows.forEach((row: IAVRow, rowIndex) => {
                     tableHTML += `<div class="av__row" data-id="${row.id}">`;
                     if (pinIndex > -1) {
                         tableHTML += '<div class="av__colsticky"><div class="av__firstcol"><svg><use xlink:href="#iconUncheck"></use></svg></div>';
                     } else {
                         tableHTML += '<div class="av__firstcol av__colsticky"><svg><use xlink:href="#iconUncheck"></use></svg></div>';
+                    }
+
+                    // TODO 添加行好列，根据 showAttrViewLineNumber 决定是否显示 class
+                    if (data.showAttrViewLineNumber) {
+                        tableHTML += `<div class="av__cell av__colsticky av__ord_col_only" style="left: 24px; width: 48px; background-color: var(--av-background)" data-only-av-ord="true" draggable="false"><span class="av__celltext fn__flex-1">${rowIndex + 1}</span></div>`;
                     }
 
                     row.cells.forEach((cell, index) => {

--- a/app/src/protyle/render/av/view.ts
+++ b/app/src/protyle/render/av/view.ts
@@ -151,6 +151,39 @@ export const bindViewEvent = (options: {
             options.blockElement.querySelector(".av__title").classList.remove("av__title--hide");
         }
     });
+    // toggle line number
+    const toggleLineNumberElement = options.menuElement.querySelector('.b3-switch[data-type="toggle-view-line-number"]') as HTMLInputElement;
+    toggleLineNumberElement.addEventListener("change", () => {
+        const avID = options.blockElement.getAttribute("data-av-id");
+        const blockID = options.blockElement.getAttribute("data-node-id");
+        if (toggleLineNumberElement.checked) {
+            // hide line number column
+            transaction(options.protyle, [{
+                action: "showAttrViewLineNumber",
+                avID,
+                blockID,
+                data: true
+            }], [{
+                action: "showAttrViewLineNumber",
+                avID,
+                blockID,
+                data: false
+            }]);
+        } else {
+            // show line number column
+            transaction(options.protyle, [{
+                action: "showAttrViewLineNumber",
+                avID,
+                blockID,
+                data: false
+            }], [{
+                action: "showAttrViewLineNumber",
+                avID,
+                blockID,
+                data: true
+            }]);
+        }
+    });
 };
 
 export const getViewHTML = (data: IAVTable) => {
@@ -193,6 +226,12 @@ export const getViewHTML = (data: IAVTable) => {
     <span class="fn__flex-center">${window.siyuan.languages.showTitle}</span>
     <span class="fn__space fn__flex-1"></span>
     <input data-type="toggle-view-title" type="checkbox" class="b3-switch b3-switch--menu" ${data.hideAttrViewName ? "" : "checked"}>
+</label>
+<label class="b3-menu__item">
+    <svg class="b3-menu__icon"></svg>
+    <span class="fn__flex-center">${window.siyuan.languages.showRowNumber}</span>
+    <span class="fn__space fn__flex-1"></span>
+    <input data-type="toggle-view-line-number" type="checkbox" class="b3-switch b3-switch--menu" ${data.showAttrViewLineNumber ? "checked" : ""}>
 </label>
 <button class="b3-menu__separator"></button>
 <button class="b3-menu__item" data-type="duplicate-view">

--- a/app/src/protyle/wysiwyg/transaction.ts
+++ b/app/src/protyle/wysiwyg/transaction.ts
@@ -746,7 +746,7 @@ export const onTransaction = (protyle: IProtyle, operation: IOperation, isUndo: 
         "setAttrViewSorts", "setAttrViewColCalc", "removeAttrViewCol", "updateAttrViewColNumberFormat", "removeAttrViewBlock",
         "replaceAttrViewBlock", "updateAttrViewColTemplate", "setAttrViewColPin", "addAttrViewView", "setAttrViewColIcon",
         "removeAttrViewView", "setAttrViewViewName", "setAttrViewViewIcon", "duplicateAttrViewView", "sortAttrViewView",
-        "updateAttrViewColRelation", "setAttrViewPageSize", "updateAttrViewColRollup"].includes(operation.action)) {
+        "updateAttrViewColRelation", "setAttrViewPageSize", "updateAttrViewColRollup", "showAttrViewLineNumber"].includes(operation.action)) {
         refreshAV(protyle, operation);
         return;
     }

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -49,6 +49,7 @@ type TOperation =
     | "moveOutlineHeading"
     | "updateAttrViewColRollup"
     | "hideAttrViewName"
+    | "showAttrViewLineNumber"
     | "setAttrViewColDate"
 type TBazaarType = "templates" | "icons" | "widgets" | "themes" | "plugins"
 type TCardType = "doc" | "notebook" | "all"
@@ -772,6 +773,7 @@ interface IAVView {
     type: string
     icon: string
     hideAttrViewName: boolean
+    showAttrViewLineNumber: boolean
 }
 
 interface IAVTable extends IAVView {

--- a/app/src/types/protyle.d.ts
+++ b/app/src/types/protyle.d.ts
@@ -464,7 +464,7 @@ interface IProtyle {
     gutter?: import("../protyle/gutter").Gutter,
     breadcrumb?: import("../protyle/breadcrumb").Breadcrumb,
     title?: import("../protyle/header/Title").Title,
-    background?: import("../protyle/header/background").Background,
+    background?: import("../protyle/header/Background").Background,
     contentElement?: HTMLElement,
     options: IOptions;
     lute?: Lute;

--- a/kernel/api/av.go
+++ b/kernel/api/av.go
@@ -345,11 +345,12 @@ func renderSnapshotAttributeView(c *gin.Context) {
 	var views []map[string]interface{}
 	for _, v := range attrView.Views {
 		view := map[string]interface{}{
-			"id":               v.ID,
-			"icon":             v.Icon,
-			"name":             v.Name,
-			"hideAttrViewName": v.HideAttrViewName,
-			"type":             v.LayoutType,
+			"id":                      v.ID,
+			"icon":                    v.Icon,
+			"name":                    v.Name,
+			"hideAttrViewName":        v.HideAttrViewName,
+			"showAttrViewLineNumber ": v.ShowAttrViewLineNumber,
+			"type":                    v.LayoutType,
 		}
 
 		views = append(views, view)
@@ -387,11 +388,12 @@ func renderHistoryAttributeView(c *gin.Context) {
 	var views []map[string]interface{}
 	for _, v := range attrView.Views {
 		view := map[string]interface{}{
-			"id":               v.ID,
-			"icon":             v.Icon,
-			"name":             v.Name,
-			"hideAttrViewName": v.HideAttrViewName,
-			"type":             v.LayoutType,
+			"id":                     v.ID,
+			"icon":                   v.Icon,
+			"name":                   v.Name,
+			"hideAttrViewName":       v.HideAttrViewName,
+			"showAttrViewLineNumber": v.ShowAttrViewLineNumber,
+			"type":                   v.LayoutType,
 		}
 
 		views = append(views, view)
@@ -451,11 +453,12 @@ func renderAttributeView(c *gin.Context) {
 	var views []map[string]interface{}
 	for _, v := range attrView.Views {
 		view := map[string]interface{}{
-			"id":               v.ID,
-			"icon":             v.Icon,
-			"name":             v.Name,
-			"hideAttrViewName": v.HideAttrViewName,
-			"type":             v.LayoutType,
+			"id":                     v.ID,
+			"icon":                   v.Icon,
+			"name":                   v.Name,
+			"hideAttrViewName":       v.HideAttrViewName,
+			"showAttrViewLineNumber": v.ShowAttrViewLineNumber,
+			"type":                   v.LayoutType,
 		}
 
 		views = append(views, view)

--- a/kernel/av/av.go
+++ b/kernel/av/av.go
@@ -147,10 +147,11 @@ type SelectOption struct {
 
 // View 描述了视图的结构。
 type View struct {
-	ID               string `json:"id"`               // 视图 ID
-	Icon             string `json:"icon"`             // 视图图标
-	Name             string `json:"name"`             // 视图名称
-	HideAttrViewName bool   `json:"hideAttrViewName"` // 是否隐藏属性视图名称
+	ID                     string `json:"id"`                     // 视图 ID
+	Icon                   string `json:"icon"`                   // 视图图标
+	Name                   string `json:"name"`                   // 视图名称
+	HideAttrViewName       bool   `json:"hideAttrViewName"`       // 是否隐藏属性视图名称
+	ShowAttrViewLineNumber bool   `json:"showAttrViewLineNumber"` // 是否显示属性视图行号
 
 	LayoutType LayoutType   `json:"type"`            // 当前布局类型
 	Table      *LayoutTable `json:"table,omitempty"` // 表格布局

--- a/kernel/av/table.go
+++ b/kernel/av/table.go
@@ -80,16 +80,17 @@ const (
 
 // Table 描述了表格实例的结构。
 type Table struct {
-	ID               string         `json:"id"`               // 表格布局 ID
-	Icon             string         `json:"icon"`             // 表格图标
-	Name             string         `json:"name"`             // 表格名称
-	HideAttrViewName bool           `json:"hideAttrViewName"` // 是否隐藏属性视图名称
-	Filters          []*ViewFilter  `json:"filters"`          // 过滤规则
-	Sorts            []*ViewSort    `json:"sorts"`            // 排序规则
-	Columns          []*TableColumn `json:"columns"`          // 表格列
-	Rows             []*TableRow    `json:"rows"`             // 表格行
-	RowCount         int            `json:"rowCount"`         // 表格总行数
-	PageSize         int            `json:"pageSize"`         // 每页行数
+	ID                     string         `json:"id"`                     // 表格布局 ID
+	Icon                   string         `json:"icon"`                   // 表格图标
+	Name                   string         `json:"name"`                   // 表格名称
+	HideAttrViewName       bool           `json:"hideAttrViewName"`       // 是否隐藏属性视图名称
+	ShowAttrViewLineNumber bool           `json:"showAttrViewLineNumber"` // 是否显示属性行号
+	Filters                []*ViewFilter  `json:"filters"`                // 过滤规则
+	Sorts                  []*ViewSort    `json:"sorts"`                  // 排序规则
+	Columns                []*TableColumn `json:"columns"`                // 表格列
+	Rows                   []*TableRow    `json:"rows"`                   // 表格行
+	RowCount               int            `json:"rowCount"`               // 表格总行数
+	PageSize               int            `json:"pageSize"`               // 每页行数
 }
 
 type TableColumn struct {

--- a/kernel/model/transaction.go
+++ b/kernel/model/transaction.go
@@ -292,6 +292,8 @@ func performTx(tx *Transaction) (ret *TxErr) {
 			ret = tx.doUpdateAttrViewColRollup(op)
 		case "hideAttrViewName":
 			ret = tx.doHideAttrViewName(op)
+		case "showAttrViewLineNumber":
+			ret = tx.doShowAttrViewLineNumber(op)
 		case "setAttrViewColDate":
 			ret = tx.doSetAttrViewColDate(op)
 		}

--- a/kernel/treenode/node.go
+++ b/kernel/treenode/node.go
@@ -18,12 +18,13 @@ package treenode
 
 import (
 	"bytes"
-	"github.com/siyuan-note/siyuan/kernel/av"
-	"github.com/siyuan-note/siyuan/kernel/cache"
 	"strings"
 	"sync"
 	"text/template"
 	"time"
+
+	"github.com/siyuan-note/siyuan/kernel/av"
+	"github.com/siyuan-note/siyuan/kernel/cache"
 
 	"github.com/88250/gulu"
 	"github.com/88250/lute"
@@ -609,12 +610,13 @@ func getAttributeViewContent(avID string) (content string) {
 
 func renderAttributeViewTable(attrView *av.AttributeView, view *av.View) (ret *av.Table, err error) {
 	ret = &av.Table{
-		ID:               view.ID,
-		Icon:             view.Icon,
-		Name:             view.Name,
-		HideAttrViewName: view.HideAttrViewName,
-		Columns:          []*av.TableColumn{},
-		Rows:             []*av.TableRow{},
+		ID:                     view.ID,
+		Icon:                   view.Icon,
+		Name:                   view.Name,
+		HideAttrViewName:       view.HideAttrViewName,
+		ShowAttrViewLineNumber: view.ShowAttrViewLineNumber,
+		Columns:                []*av.TableColumn{},
+		Rows:                   []*av.TableRow{},
 	}
 
 	// 组装列


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

有两种大方向实现：
1. 只保留属性配置（是否显示行号），其他全部交给前端处理
2. 后端保存列配置信息，这个方向又有两个实现
    - 直接预设一个列（类似创建时间，更新时间）
    - 预设一个不可编辑的列类型由用户创建，内容渲染可以和模板保持一致

这个 PR 是第一种，相对来说简单，对后端入侵小。缺点是这个列宽度无法编辑，需要通过 css 进行编辑

#10574 