### PR TITLE
Support for h2c (HTTP/2 over cleartext)

### DIFF
--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -50,6 +50,7 @@ var cookieStore = cookie.NewStore([]byte("ATN51UlxVq1Gcvdf"))
 func Serve(fastMode bool) {
 	gin.SetMode(gin.ReleaseMode)
 	ginServer := gin.New()
+	ginServer.UseH2C = true
 	ginServer.MaxMultipartMemory = 1024 * 1024 * 32 // 插入较大的资源文件时内存占用较大 https://github.com/siyuan-note/siyuan/issues/5023
 	ginServer.Use(
 		model.ControlConcurrency, // 请求串行化 Concurrency control when requesting the kernel API https://github.com/siyuan-note/siyuan/issues/9939
@@ -135,7 +136,7 @@ func Serve(fastMode bool) {
 
 	go util.HookUILoaded()
 
-	if err = http.Serve(ln, ginServer); nil != err {
+	if err = http.Serve(ln, ginServer.Handler()); nil != err {
 		if !fastMode {
 			logging.LogErrorf("boot kernel failed: %s", err)
 			os.Exit(logging.ExitCodeUnavailablePort)


### PR DESCRIPTION
* [x] Please commit to the dev branch

提供对 [h2c (HTTP/2 over cleartext)](https://httpwg.org/specs/rfc7540.html#discover-http) 的支持
Provides support for [h2c (HTTP/2 over cleartext)](https://httpwg.org/specs/rfc7540.html#discover-http).

虽然目前主流的浏览器大都仅支持 [h2 (HTTP/2 over TLS)](https://httpwg.org/specs/rfc7540.html#discover-https) 方案, 但是如果内核支持 `h2c`, 那么也能提高 `Nginx` 等 Web 服务器反向代理的效率
Although most mainstream browsers only support [h2 (HTTP/2 over TLS)](https://httpwg.org/specs/rfc7540.html#discover-https), if the kernel supports `h2c`, it can also improve the efficiency of reverse proxies for web servers such as `Nginx`.

兼容 `HTTP/1.1`
Compatible with `HTTP/1.1`

REF: https://github.com/gin-gonic/gin/pull/1398

已测试 | TESTED