### PR TITLE
Use GitHub environment variables as template literals to reduce workflow maintenance and provide convenience for forked repositories.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,13 @@ on:
       - '*-dev*'
   workflow_dispatch:
 
+# ref https://docs.github.com/zh/actions/learn-github-actions/variables
+env:
+  repo_name_android: "siyuan-android"
+  repo_name: "siyuan"
+  repo_owner: "siyuan-note"
+  package_json: "app/package.json"
+
 jobs:
   create_release:
     name: Create Release
@@ -39,7 +46,7 @@ jobs:
         run: |
           echo "release_title=$(git show --format=%s --no-patch | head -1)" >> $GITHUB_OUTPUT
           echo "release_version=$(TZ=Asia/Shanghai date +'v%Y%m%d%H%M')" >> $GITHUB_OUTPUT
-          changelog=$(python scripts/parse-changelog.py -t ${{ github.ref }} -b ${{ steps.thislatestR.outputs.release }} siyuan-note/siyuan)
+          changelog=$(python scripts/parse-changelog.py -t ${{ github.ref }} -b ${{ steps.thislatestR.outputs.release }} ${{ env.repo_owner }}/${{ env.repo_name }})
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "release_body<<$EOF" >> $GITHUB_ENV
           echo "$changelog" >> $GITHUB_ENV
@@ -51,13 +58,13 @@ jobs:
         uses: sergeysova/jq-action@v2
         id: version
         with:
-          cmd: 'jq .version app/package.json -r'
+          cmd: 'jq .version ${{ env.package_json }} -r'
 
       - name: Extract packageManager from package.json
         uses: sergeysova/jq-action@v2
         id: packageManager
         with:
-            cmd: "jq .packageManager app/package.json -r"
+            cmd: "jq .packageManager ${{ env.package_json }} -r"
 
       - name: Create Release
         id: create_release
@@ -80,7 +87,8 @@ jobs:
           - os: ubuntu-20.04
             name: ubuntu build linux.AppImage
             kernel_path: "../app/kernel-linux/SiYuan-Kernel"
-            build_args: "-s -w -X github.com/siyuan-note/siyuan/kernel/util.Mode=prod"
+            build_args_prefix: "-s -w -X"
+            build_args_suffix: "Mode=prod"
             electron_args: "dist-linux"
             goos: "linux"
             goarch: "amd64"
@@ -88,7 +96,8 @@ jobs:
           - os: ubuntu-20.04
             name: ubuntu build linux.tar.gz
             kernel_path: "../app/kernel-linux/SiYuan-Kernel"
-            build_args: "-s -w -X github.com/siyuan-note/siyuan/kernel/util.Mode=prod"
+            build_args_prefix: "-s -w -X"
+            build_args_suffix: "Mode=prod"
             electron_args: "dist-linux"
             goos: "linux"
             goarch: "amd64"
@@ -96,7 +105,8 @@ jobs:
           - os: macos-latest
             name: macos build mac.dmg
             kernel_path: "../app/kernel-darwin/SiYuan-Kernel"
-            build_args: "-s -w -X github.com/siyuan-note/siyuan/kernel/util.Mode=prod"
+            build_args_prefix: "-s -w -X"
+            build_args_suffix: "Mode=prod"
             electron_args: "dist-darwin"
             goos: "darwin"
             goarch: "amd64"
@@ -104,7 +114,8 @@ jobs:
           - os: macos-latest
             name: macos build mac-arm64.dmg
             kernel_path: "../app/kernel-darwin-arm64/SiYuan-Kernel"
-            build_args: "-s -w -X github.com/siyuan-note/siyuan/kernel/util.Mode=prod"
+            build_args_prefix: "-s -w -X"
+            build_args_suffix: "Mode=prod"
             electron_args: "dist-darwin-arm64"
             goos: "darwin"
             goarch: "arm64"
@@ -112,7 +123,8 @@ jobs:
           - os: windows-latest
             name: windows build win.exe
             kernel_path: "../app/kernel/SiYuan-Kernel.exe"
-            build_args: "-s -w -H=windowsgui -X github.com/siyuan-note/siyuan/kernel/util.Mode=prod"
+            build_args_prefix: "-s -w -H=windowsgui -X"
+            build_args_suffix: "Mode=prod"
             electron_args: "dist"
             goos: "windows"
             gobin: "bin"
@@ -123,7 +135,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        path: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan
+        path: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}
 
     - name: Set up MingGW
       uses: msys2/setup-msys2@v2
@@ -132,20 +144,20 @@ jobs:
         install: p7zip mingw-w64-x86_64-lua
 
     - name: Set up TDM-GCC
-      run: msys2 -c "bash go/src/github.com/siyuan-note/siyuan/scripts/get-tdm-gcc.sh tdm https://github.com/jmeubank/tdm-gcc/releases/download/v10.3.0-tdm-1/tdm-gcc-10.3.0.exe" && echo "CC=${{ github.workspace }}/tdm/bin/gcc.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      run: msys2 -c "bash go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/scripts/get-tdm-gcc.sh tdm https://github.com/jmeubank/tdm-gcc/releases/download/v10.3.0-tdm-1/tdm-gcc-10.3.0.exe" && echo "CC=${{ github.workspace }}/tdm/bin/gcc.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       if: "contains( matrix.config.goarch, '386')"
       working-directory: ${{ github.workspace }}
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/kernel/go.mod
+        go-version-file: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/kernel/go.mod
     - run: go version
 
     - name: Set up goversioninfo
       run: go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo && go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo
       if: "contains( matrix.config.goos, 'windows')"
-      working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/kernel
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/kernel
       env:
         GO111MODULE: on
         CGO_ENABLED: 1
@@ -160,49 +172,49 @@ jobs:
 
     - name: Install Node pnpm
       run: npm install -g ${{ needs.create_release.outputs.packageManager }}
-      working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app
 
     - name: Install Node Dependencies
       run: pnpm install --no-frozen-lockfile
-      working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app
 
     - name: Building UI
       run: pnpm run build
-      working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app
 
     - name: Remove Build Directory
       uses: JesseTG/rm@v1.0.2
       with:
-        path: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app/build
+        path: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app/build
 
     - name: Remove Kernel Directory for Linux
       uses: JesseTG/rm@v1.0.2
       with:
-        path: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app/kernel-linux
+        path: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app/kernel-linux
 
     - name: Remove Kernel Directory for Windows
       uses: JesseTG/rm@v1.0.2
       with:
-        path: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app/kernel
+        path: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app/kernel
 
     - name: Remove Kernel Directory for macOS
       uses: JesseTG/rm@v1.0.2
       with:
-        path: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app/kernel-darwin
+        path: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app/kernel-darwin
 
     - name: Remove Kernel Directory for macOS ARM64
       uses: JesseTG/rm@v1.0.2
       with:
-        path: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app/kernel-darwin-arm64
+        path: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app/kernel-darwin-arm64
 
     - name: Generate Icon Resource and Properties/Version Info For Windows
       run: ${{ github.workspace }}\go\${{ matrix.config.gobin }}\goversioninfo -platform-specific=true -icon="resource\icon.ico" -manifest="resource\goversioninfo.exe.manifest"
       if: "contains( matrix.config.goos, 'windows')"
-      working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/kernel
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/kernel
     
     - name: Building Kernel
-      run: go build --tags fts5 -o "${{ matrix.config.kernel_path }}" -v -ldflags "${{ matrix.config.build_args }}"
-      working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/kernel
+      run: go build --tags fts5 -o "${{ matrix.config.kernel_path }}" -v -ldflags "${{ matrix.config.build_args_prefix }} github.com/${{ env.repo_owner }}/${{ env.repo_name }}/kernel/util.${{ matrix.config.build_args_suffix }}"
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/kernel
       env:
         GO111MODULE: on
         CGO_ENABLED: 1
@@ -212,7 +224,7 @@ jobs:
       
     - name: Building Electron
       run: pnpm run ${{ matrix.config.electron_args }}
-      working-directory: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app
+      working-directory: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app
 
     - name: Upload Release
       uses: actions/upload-release-asset@v1
@@ -221,5 +233,5 @@ jobs:
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
         asset_name: siyuan-${{ needs.create_release.outputs.release_version }}-${{ matrix.config.suffix }}
-        asset_path: ${{ github.workspace }}/go/src/github.com/siyuan-note/siyuan/app/build/siyuan-${{ needs.create_release.outputs.version }}-${{ matrix.config.suffix }}
+        asset_path: ${{ github.workspace }}/go/src/github.com/${{ env.repo_owner }}/${{ env.repo_name }}/app/build/siyuan-${{ needs.create_release.outputs.version }}-${{ matrix.config.suffix }}
         asset_content_type: application/octet-stream

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -11,14 +11,19 @@ on:
     branches:
       - master
 
+# ref https://docs.github.com/zh/actions/learn-github-actions/variables
+env:
+  repo_name_android: "siyuan-android"
+  repo_name: "siyuan"
+  repo_owner: "siyuan-note"
+  package_json: "app/package.json"
+  docker_hub_owner: "b3log"
+  docker_hub_repo: "siyuan"
+
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    strategy:
-        matrix:
-          string:
-            - package_json: "app/package.json"
     permissions:
       packages: write
       contents: read
@@ -34,7 +39,7 @@ jobs:
         uses: sergeysova/jq-action@v2
         id: version
         with:
-          cmd: "jq .version ${{ matrix.string.package_json }} -r"
+          cmd: "jq .version ${{ env.package_json }} -r"
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -67,9 +72,9 @@ jobs:
       - name: Build the Docker image use Workflow Dispatch inputs' version
         if: ${{ github.event_name == 'workflow_dispatch' && !github.event.inputs.image_tag == '' }}
         run: |
-          docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 -t b3log/siyuan:latest -t b3log/siyuan:v${{ github.event.inputs.image_tag }} .
+          docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 -t ${{ env.docker_hub_owner }}/${{ env.docker_hub_repo }}:latest -t ${{ env.docker_hub_owner }}/${{ env.docker_hub_repo }}:v${{ github.event.inputs.image_tag }} .
       - name: Build the Docker image use package_json version
         if: ${{ github.event_name == 'push' || github.event.inputs.image_tag == '' }}
         run: |
-          docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 -t b3log/siyuan:latest -t b3log/siyuan:v${{ steps.version.outputs.value }} .
+          docker buildx build --push --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8 -t ${{ env.docker_hub_owner }}/${{ env.docker_hub_repo }}:latest -t ${{ env.docker_hub_owner }}/${{ env.docker_hub_repo }}:v${{ steps.version.outputs.value }} .
     


### PR DESCRIPTION
参考：[cd.yml](https://github.com/Hi-Windom/Sillot/blob/v0.31/.github/workflows/cd.yml)  [dockerimage.yml](https://github.com/Hi-Windom/Sillot/blob/v0.31/.github/workflows/dockerimage.yml)
关联：https://github.com/Hi-Windom/Sillot/issues/655  https://github.com/Hi-Windom/Sillot/issues/644
测试：[cd.yml](https://github.com/Hi-Windom/Sillot/actions/runs/8834254248)  [dockerimage.yml](https://github.com/Hi-Windom/Sillot/actions/runs/8834656935)