### PR TITLE
Fix the index task of the embed block

### DIFF
--- a/kernel/model/index.go
+++ b/kernel/model/index.go
@@ -291,13 +291,16 @@ func IndexEmbedBlockJob() {
 func autoIndexEmbedBlock(embedBlocks []*sql.Block) {
 	for i, embedBlock := range embedBlocks {
 		markdown := strings.TrimSpace(embedBlock.Markdown)
-		stmt := strings.TrimPrefix(markdown, "{{")
-		stmt = strings.TrimSuffix(stmt, "}}")
-		stmt = html.UnescapeString(stmt)
-		stmt = strings.ReplaceAll(stmt, editor.IALValEscNewLine, "\n")
+		markdown = strings.TrimPrefix(markdown, "{{")
+		content := strings.TrimSuffix(markdown, "}}")
 
+		// 嵌入块的 Markdown 内容需要反转义
+		stmt := html.UnescapeString(content)
+		stmt = strings.ReplaceAll(stmt, editor.IALValEscNewLine, "\n")
 		stmt = strings.TrimSpace(stmt)
+
 		if strings.HasPrefix(stmt, "//!js") {
+			// https://github.com/siyuan-note/siyuan/issues/9648
 			// js 嵌入块不支持自动索引，由前端主动调用 /api/search/updateEmbedBlock 接口更新内容 https://github.com/siyuan-note/siyuan/issues/9736
 			continue
 		}

--- a/kernel/model/index.go
+++ b/kernel/model/index.go
@@ -292,13 +292,14 @@ func autoIndexEmbedBlock(embedBlocks []*sql.Block) {
 	for i, embedBlock := range embedBlocks {
 		markdown := strings.TrimSpace(embedBlock.Markdown)
 		markdown = strings.TrimPrefix(markdown, "{{")
-		content := strings.TrimSuffix(markdown, "}}")
+		stmt := strings.TrimSuffix(markdown, "}}")
 
 		// 嵌入块的 Markdown 内容需要反转义
-		stmt := html.UnescapeString(content)
+		stmt = html.UnescapeString(stmt)
 		stmt = strings.ReplaceAll(stmt, editor.IALValEscNewLine, "\n")
-		stmt = strings.TrimSpace(stmt)
 
+		// 需要移除首尾的空白字符以判断是否具有 //!js 标记
+		stmt = strings.TrimSpace(stmt)
 		if strings.HasPrefix(stmt, "//!js") {
 			// https://github.com/siyuan-note/siyuan/issues/9648
 			// js 嵌入块不支持自动索引，由前端主动调用 /api/search/updateEmbedBlock 接口更新内容 https://github.com/siyuan-note/siyuan/issues/9736

--- a/kernel/model/index.go
+++ b/kernel/model/index.go
@@ -30,6 +30,7 @@ import (
 	"github.com/88250/go-humanize"
 	"github.com/88250/gulu"
 	"github.com/88250/lute/ast"
+	"github.com/88250/lute/editor"
 	"github.com/88250/lute/html"
 	"github.com/88250/lute/parse"
 	"github.com/panjf2000/ants/v2"
@@ -289,14 +290,18 @@ func IndexEmbedBlockJob() {
 
 func autoIndexEmbedBlock(embedBlocks []*sql.Block) {
 	for i, embedBlock := range embedBlocks {
-		md := strings.TrimSpace(embedBlock.Markdown)
-		if strings.Contains(md, "//js") {
+		markdown := strings.TrimSpace(embedBlock.Markdown)
+		stmt := strings.TrimPrefix(markdown, "{{")
+		stmt = strings.TrimSuffix(stmt, "}}")
+		stmt = html.UnescapeString(stmt)
+		stmt = strings.ReplaceAll(stmt, editor.IALValEscNewLine, "\n")
+
+		stmt = strings.TrimSpace(stmt)
+		if strings.HasPrefix(stmt, "//!js") {
 			// js 嵌入块不支持自动索引，由前端主动调用 /api/search/updateEmbedBlock 接口更新内容 https://github.com/siyuan-note/siyuan/issues/9736
 			continue
 		}
 
-		stmt := strings.TrimPrefix(md, "{{")
-		stmt = strings.TrimSuffix(stmt, "}}")
 		if !strings.Contains(strings.ToLower(stmt), "select") {
 			continue
 		}


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For bug fixes, please describe the problem and solution via code comments

- 修复嵌入块的索引任务无法解析包含转移符号的嵌入块/多行嵌入块
  Fixed the issue that the indexing task for embedding blocks could not resolve multi-row embedded blocks or embedded block containing the transfer symbol
- 修复嵌入块的索引任务无法正确识别 `JavaScript` 模式的嵌入块
  Fixed the issue that the indexing task for embedding blocks could not correctly recognizing embedding blocks in 'JavaScript' mode

REL: #7112, #9648

已经过测试 | TESTED