### PR TITLE
Allow users to specify abcjsParams

### DIFF
--- a/app/src/protyle/render/abcRender.ts
+++ b/app/src/protyle/render/abcRender.ts
@@ -2,8 +2,9 @@ import {addScript} from "../util/addScript";
 import {Constants} from "../../constants";
 import {genIconHTML} from "./util";
 import {hasClosestByClassName} from "../util/hasClosest";
+import {looseJsonParse} from "../../util/functions";
 
-const ABCJS_PARAMS_KEY = "%%abcjsParams:";
+const ABCJS_PARAMS_KEY = "%%params:";
 
 // Read the abcjsParams from the content if it exists.
 // The params *must* be the first line of the content in the form:
@@ -18,7 +19,7 @@ const getAbcParams = (abcString: string): any => {
     if (firstLine.startsWith(ABCJS_PARAMS_KEY)) {
         try {
             const jsonString = firstLine.substring(ABCJS_PARAMS_KEY.length);
-            params = { ...params, ...JSON.parse(jsonString) };
+            params = { ...params, ...looseJsonParse(jsonString) };
         } catch (e) {
             console.error(`Failed to parse ABCJS params: ${e}`);
         }

--- a/app/src/protyle/render/abcRender.ts
+++ b/app/src/protyle/render/abcRender.ts
@@ -3,6 +3,30 @@ import {Constants} from "../../constants";
 import {genIconHTML} from "./util";
 import {hasClosestByClassName} from "../util/hasClosest";
 
+const ABCJS_PARAMS_KEY = "%%abcjsParams:";
+
+// Read the abcjsParams from the content if it exists.
+// The params *must* be the first line of the content in the form:
+// %%abcjsParams: {JSON}
+const getAbcParams = (abcString: string): any => {
+    let params = {
+        responsive: 'resize',
+    };
+
+    const firstLine = abcString.substring(0, abcString.indexOf("\n"));
+
+    if (firstLine.startsWith(ABCJS_PARAMS_KEY)) {
+        try {
+            const jsonString = firstLine.substring(ABCJS_PARAMS_KEY.length);
+            params = { ...params, ...JSON.parse(jsonString) };
+        } catch (e) {
+            console.error(`Failed to parse ABCJS params: ${e}`);
+        }
+    }
+
+    return params;
+};
+
 export const abcRender = (element: Element, cdn = Constants.PROTYLE_CDN) => {
     let abcElements: Element[] = [];
     if (element.getAttribute("data-subtype") === "abc") {
@@ -26,9 +50,9 @@ export const abcRender = (element: Element, cdn = Constants.PROTYLE_CDN) => {
                 }
                 const renderElement = e.firstElementChild.nextElementSibling as HTMLElement;
                 renderElement.innerHTML = `<span style="position: absolute;left:0;top:0;width: 1px;">${Constants.ZWSP}</span><div contenteditable="false"></div>`;
-                window.ABCJS.renderAbc(renderElement.lastElementChild, Lute.UnEscapeHTMLStr(e.getAttribute("data-content")), {
-                    responsive: "resize"
-                });
+                const abcString = Lute.UnEscapeHTMLStr(e.getAttribute("data-content"));
+                const abcjsParams = getAbcParams(abcString)
+                window.ABCJS.renderAbc(renderElement.lastElementChild, abcString, abcjsParams);
                 e.setAttribute("data-render", "true");
             });
         });


### PR DESCRIPTION
Currently the parameters for abcjs are hard-coded to:
```json
{
  "responsive": "resize"
}
```

This prohibits the user from using other options, such as tablature.

For example, if I want to render [this violin tab](https://paulrosen.github.io/abcjs/visual/tablature.html#tablature) in the abcjs documentation, I cannot do it because there is no way to set the abcjsParams to:
```json
{
  "tablature": [
    { "instrument": "violin" }
  ]
}
```

This PR allows users to manually specify `abcjsParams` to use by prefixing the content with:
```
%%params {tablature: [{instrument: "violin"}]}
```

Using this, the example now renders correctly:
```abc
%%params {tablature: [{instrument: "violin"}]}
X:1
T: Cooley's
M: 4/4
L: 1/8
R: reel
K: G
|:D2|EB{c}BA B2 EB|~B2 AB dBAG|FDAD BDAD|FDAD dAFD|
```

Produces:
<img width="915" alt="image" src="https://github.com/siyuan-note/siyuan/assets/2176663/88008a36-1c6f-4fc4-aeb5-261f15f08091">

Please let me know if there is another approach to get the `abcjsParams` passed into the render function that you would prefer.

* [ ] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

EDIT: Updated the code to use the new format
