### PR TITLE
Marketplace count error

### DIFF
--- a/app/src/config/bazaar.ts
+++ b/app/src/config/bazaar.ts
@@ -383,7 +383,7 @@ export const bazaar = {
             if (["icons", "themes"].includes(bazaarType)) {
                 showSwitch = true;
             }
-            const counterElement = contentElement.parentElement.querySelector(".counter");
+            const counterElement = contentElement.previousElementSibling.querySelector(".counter");
             if (response.data.packages.length === 0) {
                 counterElement.classList.add("fn__none");
             } else {


### PR DESCRIPTION
下图左边是正常的, 右边是异常的
原因是该页面有2个计数元素,上方和中间, 下方通过contentElement.parentElement.querySelector(".counter"); 获取计数元素,
 但下方(已安装列表)和上方(更新列表)两者是异步并发创建(fetch), 如果上面的先完成(因为下列表耗时),那么下方获取的计数元素将是上方的计数器,而不是中间的,
因此需要把 parentElement 改成了 previousElementSibling


![Clip_2024-04-27_08-15-48](https://github.com/siyuan-note/siyuan/assets/48077521/54587e99-f504-41d5-b090-f336265c7042)
