### PR TITLE
获取非默认readme失败后尝试获取默认readme

### DIFF
--- a/kernel/bazaar/package.go
+++ b/kernel/bazaar/package.go
@@ -506,8 +506,16 @@ func GetPackageREADME(repoURL, repoHash, packageType string) (ret string) {
 
 	data, err := downloadPackage(repoURLHash+"/"+readme, false, "")
 	if nil != err {
-		ret = "Load bazaar package's README.md failed: " + err.Error()
-		return
+		ret = fmt.Sprintf("Load bazaar package's README.md(%s) failed: %s", readme, err.Error())
+		if readme == repo.Package.Readme.Default || "" == strings.TrimSpace(repo.Package.Readme.Default) {
+			return
+		}
+		readme = repo.Package.Readme.Default
+		data, err = downloadPackage(repoURLHash+"/"+readme, false, "")
+		if nil != err {
+			ret += fmt.Sprintf("<br>Load bazaar package's README.md(%s) failed: %s", readme, err.Error())
+			return
+		}
 	}
 
 	if 2 < len(data) {


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For contributing new features, please supplement and improve the corresponding user guide documents
* [ ] For bug fixes, please describe the problem and solution via code comments
* [ ] For text improvements (such as typos and wording adjustments), please submit directly

集市获取readme时,如果 Preferred Readme 无法获取到,就尝试获取默认的readme(Readme.Default)
场景: 在plugin.json里指定了中文readme, 但是没有上传到github,这时可以试试默认的readme

