### PR TITLE
Superblock padding

### DIFF
--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -160,8 +160,13 @@
     }
 
     &.sb {
-      padding: 0;
+      padding: 0.5rem;
       max-width: 100%;
+      border: solid 1px var(--b3-theme-background-light)
+      
+      & :not(.sb)[data-type] {
+        background: linear-gradient(90deg,transparent,var(--b3-theme-surface-light));
+      }
 
       &[data-sb-layout="col"] {
         display: flex;


### PR DESCRIPTION
Presently, superblocks lack padding around their inner elements, causing frustration when attempting to drag and drop these elements in and out of superblocks. This is due to the overlap between the "snap edges" of the inner elements and the outer superblock. This update introduces a slight (0.5rem) padding between inner elements and the superblock, enhancing visibility by adding borders and background. These adjustments accentuate the superblock, facilitating the containment of various blocks within it.