### PR TITLE
Set the default value of `item.direction`

### DIFF
--- a/app/src/plugin/Setting.ts
+++ b/app/src/plugin/Setting.ts
@@ -49,6 +49,9 @@ export class Setting {
                 actionElement = item.createActionElement();
             }
             const tagName = actionElement?.classList.contains("b3-switch")?"label":"div";
+            if (item.direction === undefined) {
+                item.direction = ["TEXTAREA"].includes(actionElement.tagName) ? 'row' : 'column';
+            }
             if (item.direction === "row") {
                 html = `<${tagName} class="b3-label">
     <div class="fn__block">


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [x] For contributing new features, please supplement and improve the corresponding user guide documents
* [x] For bug fixes, please describe the problem and solution via code comments
* [x] For text improvements (such as typos and wording adjustments), please submit directly

- 设置插件 Setting 默认的 `direction`; textarea 默认设置为 `row`，其他的默认设置为 `column`
- 相关 issue
  - #11198 
  - #11183
  - https://github.com/zxkmm/siyuan_rmv_btn/issues/14