### PR TITLE
jp_JP → ja_JP

### DIFF
--- a/app/electron/init.html
+++ b/app/electron/init.html
@@ -210,7 +210,7 @@
             <option value="fr_FR">Français</option>
             <option value="zh_CN">简体中文</option>
             <option value="zh_CHT">繁體中文</option>
-            <option value="jp_JP">日本語</option>
+            <option value="ja_JP">日本語</option>
         </select>
     </label>
     <label class="b3-label">
@@ -254,7 +254,7 @@
             <option value="fr_FR">Français</option>
             <option value="zh_CN">简体中文</option>
             <option value="zh_CHT">繁體中文</option>
-            <option value="jp_JP">日本語</option>
+            <option value="ja_JP">日本語</option>
         </select>
     </label>
     <label class="b3-label">

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -190,7 +190,7 @@ export abstract class Constants {
         en_US: "20210808180117-6v0mkxr",
         fr_FR: "20210808180117-6v0mkxr",
         es_ES: "20210808180117-6v0mkxr",
-        jp_JP: "20210808180117-6v0mkxr",
+        ja_JP: "20210808180117-6v0mkxr",
     };
     public static readonly QUICK_DECK_ID = "20230218211946-2kw8jgx";
 

--- a/app/src/types/config.d.ts
+++ b/app/src/types/config.d.ts
@@ -263,7 +263,7 @@ declare namespace Config {
      * User interface language
      * Same as {@link IAppearance.lang}
      */
-    export type TLang = "en_US" | "es_ES" | "fr_FR" | "zh_CHT" | "zh_CN" | "jp_JP";
+    export type TLang = "en_US" | "es_ES" | "fr_FR" | "zh_CHT" | "zh_CN" | "ja_JP";
 
     /**
      * SiYuan bazaar related configuration

--- a/kernel/util/working.go
+++ b/kernel/util/working.go
@@ -79,7 +79,7 @@ func Boot() {
 	readOnly := flag.String("readonly", "false", "read-only mode")
 	accessAuthCode := flag.String("accessAuthCode", "", "access auth code")
 	ssl := flag.Bool("ssl", false, "for https and wss")
-	lang := flag.String("lang", "", "zh_CN/zh_CHT/en_US/fr_FR/es_ES/jp_JP")
+	lang := flag.String("lang", "", "zh_CN/zh_CHT/en_US/fr_FR/es_ES/ja_JP")
 	mode := flag.String("mode", "prod", "dev/prod")
 	flag.Parse()
 


### PR DESCRIPTION
https://github.com/siyuan-note/siyuan/commit/6e0da992af802965114d26d2fb75c5cdad5df991 搞错了，是 ja_JP 不是 jp_JP

#11212