### PR TITLE
Add electron version info to release_body

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,32 +41,38 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           excludes: prerelease, draft
 
-      - name: Gather Release Information
-        id: release_info
-        run: |
-          echo "release_title=$(git show --format=%s --no-patch | head -1)" >> $GITHUB_OUTPUT
-          echo "release_version=$(TZ=Asia/Shanghai date +'v%Y%m%d%H%M')" >> $GITHUB_OUTPUT
-          changelog_header=$(python scripts/parse-changelog-HEAD.py -t ${{ github.ref }} -b ${{ steps.thisLatestRelease.outputs.release }} ${{ env.repo_owner }}/${{ env.repo_name }})
-          changelog=$(python scripts/parse-changelog.py -t ${{ github.ref }} ${{ env.repo_owner }}/${{ env.repo_name }})
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "release_body<<$EOF" >> $GITHUB_ENV
-          echo "$changelog_header" >> $GITHUB_ENV
-          echo "$changelog" >> $GITHUB_ENV
-          echo "$EOF" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract version from package.json
         uses: sergeysova/jq-action@v2
         id: version
         with:
           cmd: 'jq .version ${{ env.package_json }} -r'
 
+      - name: Extract electronVersion from package.json
+        uses: sergeysova/jq-action@v2
+        id: electronVersion
+        with:
+          cmd: "jq .devDependencies.electron ${{ env.package_json }} -r"
+
       - name: Extract packageManager from package.json
         uses: sergeysova/jq-action@v2
         id: packageManager
         with:
             cmd: "jq .packageManager ${{ env.package_json }} -r"
+
+      - name: Gather Release Information
+        id: release_info
+        run: |
+            echo "release_title=$(git show --format=%s --no-patch | head -1)" >> $GITHUB_OUTPUT
+            echo "release_version=$(TZ=Asia/Shanghai date +'v%Y%m%d%H%M')" >> $GITHUB_OUTPUT
+            changelog_header=$(python scripts/parse-changelog-HEAD.py -t ${{ github.ref }} -b ${{ steps.thisLatestRelease.outputs.release }} -e ${{ steps.electronVersion.outputs.value }} ${{ env.repo_owner }}/${{ env.repo_name }})
+            changelog=$(python scripts/parse-changelog.py -t ${{ github.ref }} ${{ env.repo_owner }}/${{ env.repo_name }})
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "release_body<<$EOF" >> $GITHUB_ENV
+            echo "$changelog_header" >> $GITHUB_ENV
+            echo "$changelog" >> $GITHUB_ENV
+            echo "$EOF" >> $GITHUB_ENV
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         id: create_release

--- a/scripts/_pkg/Utils.py
+++ b/scripts/_pkg/Utils.py
@@ -44,7 +44,7 @@ def get_issue_first_label(issue, docmap):
             return label.name
     return ""
 
-def generate_header_from_repo(repo_name, tag_name, lastestRelease, action_file, HEADER=''):
+def generate_header_from_repo(repo_name, tag_name, lastestRelease, electron_version, action_file, HEADER=''):
     thisRelease = tag_name.split("/")[-1]
     pat = re.search("v([0-9.]+)", thisRelease)
     if not pat:
@@ -56,6 +56,7 @@ def generate_header_from_repo(repo_name, tag_name, lastestRelease, action_file, 
 <a href="https://github.com/{repo_name}/actions/workflows/{action_file}"><img src="https://img.shields.io/github/actions/workflow/status/{repo_name}/{action_file}?logo=github&label={action_file}%20Action" style="cursor:pointer;height: 30px;margin: 3px auto;"/></a>
 <a href="https://github.com/{repo_name}/releases/{thisRelease}/"><img src="https://img.shields.io/github/downloads/{repo_name}/{thisRelease}/total?logo=github" style="cursor:pointer;height: 30px;margin: 3px auto;"/></a>
 <img alt="GitHub commits difference between two branches/tags/commits" src="https://img.shields.io/github/commits-difference/{repo_name}?base={lastestRelease}&head={thisRelease}&logo=git" style="cursor:pointer;height: 30px;margin: 3px auto;"/>
+<img src="https://img.shields.io/badge/Electron {electron_version}-47848F.svg?style=flat&logo=Electron&logoColor=white" alt="Electron">
 </p>
 
 {HEADER}'''

--- a/scripts/parse-changelog-HEAD.py
+++ b/scripts/parse-changelog-HEAD.py
@@ -4,14 +4,14 @@ from argparse import ArgumentParser
 from _pkg import Const as C
 from _pkg import Utils as U
 
-def generate_msg_from_repo(repo_name, tag_name, lastestRelease):
-    thisRelease = tag_name.split("/")[-1]
+def generate_msg_from_repo(repo_name, args):
+    thisRelease = args.tag.split("/")[-1]
     pat = re.search("v([0-9.]+)", thisRelease)
     if not pat:
         return None
 
     action_file = "cd.yml"
-    print(U.generate_header_from_repo(repo_name, tag_name, lastestRelease, action_file, C.HEADER[repo_name]))
+    print(U.generate_header_from_repo(repo_name, args.tag, args.lastestRelease, args.electronVersion, action_file, C.HEADER[repo_name]))
 
 
 if __name__ == "__main__":
@@ -20,10 +20,11 @@ if __name__ == "__main__":
     )
     parser.add_argument("-t", "--tag", help="the tag to filter issues.")
     parser.add_argument("-b", "--lastestRelease", help="lastest Release")
+    parser.add_argument("-e", "--electronVersion", help="Electron Release")
     parser.add_argument("repo", help="The repository name")
     args = parser.parse_args()
 
     try:
-        generate_msg_from_repo(args.repo, args.tag, args.lastestRelease)
+        generate_msg_from_repo(args.repo, args)
     except AssertionError:
         print(args.tag)


### PR DESCRIPTION
此 pr 通过在 github release_body 添加目标 electron 版本信息，方便用户参考。
效果参考：
![image](https://github.com/siyuan-note/siyuan/assets/83791825/1cb9ba2f-7d6a-4a28-8212-251ee0e4350c)
步骤 release_info 被移动到 create_release 上方，更符合逻辑