### PR TITLE
让数据库列开启换行时被截断的文本也有悬浮提示

### DIFF
--- a/app/src/block/popover.ts
+++ b/app/src/block/popover.ts
@@ -43,7 +43,7 @@ export const initBlockPopover = (app: App) => {
                             }
                             aElement.style.overflow = "";
                         }
-                        if (aElement.dataset.wrap == "true") {
+                        else if (aElement.dataset.wrap == "true") {
                             const textElement = aElement.querySelector(".av__celltext");
                             if (textElement.scrollHeight > textElement.clientHeight) {
                                 tip = getCellText(aElement);

--- a/app/src/block/popover.ts
+++ b/app/src/block/popover.ts
@@ -35,12 +35,20 @@ export const initBlockPopover = (app: App) => {
                             tip = aElement.firstElementChild.getAttribute("data-href");
                         }
                     }
-                    if (!tip && aElement.dataset.wrap !== "true" && event.target.dataset.type !== "block-more" && !hasClosestByClassName(event.target, "block__icon")) {
-                        aElement.style.overflow = "auto";
-                        if (aElement.scrollWidth > aElement.clientWidth + 2) {
-                            tip = getCellText(aElement);
+                    if (!tip && event.target.dataset.type !== "block-more" && !hasClosestByClassName(event.target, "block__icon")) {
+                        if (aElement.dataset.wrap !== "true") {
+                            aElement.style.overflow = "auto";
+                            if (aElement.scrollWidth > aElement.clientWidth + 2) {
+                                tip = getCellText(aElement);
+                            }
+                            aElement.style.overflow = "";
                         }
-                        aElement.style.overflow = "";
+                        if (aElement.dataset.wrap == "true") {
+                            const textElement = aElement.querySelector(".av__celltext");
+                            if (textElement.scrollHeight > textElement.clientHeight) {
+                                tip = getCellText(aElement);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#11365

使用如下 CSS 可以将换行文本限制为3行：

```css
.av__row:not(.av__row--header) .av__cell[data-wrap="true"] .av__celltext {
  display: -webkit-box;
  -webkit-box-orient: vertical;
  -webkit-line-clamp: 3;
  overflow: hidden;
}
```

但是鼠标悬浮在上面时无法显示悬浮提示：

![image](https://github.com/siyuan-note/siyuan/assets/78434827/79a2556f-7bd5-4ab6-85a3-793da5ac9a4f)

改了这部分代码之后就可以显示了：

![image](https://github.com/siyuan-note/siyuan/assets/78434827/e9da7903-eae3-456f-90ec-98230724e3f7)
