### PR TITLE
Update pnpm to 9.1

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,2 @@
 shell-emulator=true
+virtual-store-dir-max-length=80

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "description": "Refactor your thinking",
   "homepage": "https://b3log.org/siyuan",
   "main": "./electron/main.js",
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@9.1.1",
   "scripts": {
     "lint": "eslint . --fix --cache",
     "dev": "webpack --mode development",


### PR DESCRIPTION
不需要合并此 PR，只是说 pnpm 9.1 有个利好 windows 用户（包括 github action）的重大改进：添加了名为 virtual-store-dir-max-length 的新设置，用于修改 node_modules/.pnpm 中目录的最大允许长度。默认长度设置为 120 个字符。此设置在 Windows 上特别有用，因为 Windows 对文件路径 [#7355](https://github.com/pnpm/pnpm/issues/7355) 的最大长度有限制。

这将带来两方面变化：一是有些 pnpm 命令运行速度在一些情况下会显著提升；二是可以避免一些构建错误情况的发生