### PR TITLE
The request of PWA files without `Authentication` Header

### DIFF
--- a/app/src/assets/template/desktop/index.tpl
+++ b/app/src/assets/template/desktop/index.tpl
@@ -6,7 +6,7 @@
           content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="manifest" href="/manifest.webmanifest">
+    <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials">
     <link rel="apple-touch-icon" href="../../icon.png">
     <style id="editorAttr" type="text/css"></style>
 </head>

--- a/app/src/assets/template/mobile/index.tpl
+++ b/app/src/assets/template/mobile/index.tpl
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
-    <link rel="manifest" href="/manifest.webmanifest">
+    <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials">
 </head>
 <body class="fn__flex-column">
 <div id="loading" class="b3-dialog b3-dialog--open">

--- a/app/src/util/serviceWorker.ts
+++ b/app/src/util/serviceWorker.ts
@@ -1,17 +1,27 @@
 // https://github.com/siyuan-note/siyuan/pull/8012
-export const registerServiceWorker = (scriptURL: string, scope = "/", workerType: WorkerType = "module") => {
-    if (!("serviceWorker" in navigator) || typeof (navigator.serviceWorker) === "undefined" ||
-        !("caches" in window) || !("fetch" in window)) {
+export const registerServiceWorker = (
+    scriptURL: string,
+    options: RegistrationOptions = {
+        scope: "/",
+        type: "classic",
+        updateViaCache: "all",
+    },
+) => {
+
+    if (!("serviceWorker" in window.navigator)
+        || !("caches" in window)
+        || !("fetch" in window)
+        || navigator.serviceWorker == null
+    ) {
         return;
     }
+
     // REF https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration
     window.navigator.serviceWorker
-        .register(scriptURL, {
-            scope,
-            type: workerType,
-        }).then(registration => {
-        registration.update();
-    }).catch(e => {
-        console.debug(`Registration failed with ${e}`);
-    });
+        .register(scriptURL, options)
+        .then(registration => {
+            registration.update();
+        }).catch(e => {
+            console.debug(`Registration failed with ${e}`);
+        });
 };


### PR DESCRIPTION
* [x] Please commit to the dev branch
* [ ] For bug fixes, please describe the problem and solution via code comments

修复在反向代理启用了 `BasicAuth` 时, 浏览器请求 `manifest.webmanifest` 与 `service-worker.js` 不自动附加 `Authentication: Basic xxx` 请求头的问题

Fixed the issue that when `BasicAuth` was enabled on the reverse proxy, the browser request `manifest.webmanifest` and `service-worker.js` would not automatically append header `Authentication: Basic xxx`