### PR TITLE
改进主菜单按钮悬浮提示

### DIFF
--- a/app/src/layout/topBar.ts
+++ b/app/src/layout/topBar.ts
@@ -24,7 +24,7 @@ import {commandPanel} from "../boot/globalEvent/command/panel";
 export const initBar = (app: App) => {
     const toolbarElement = document.getElementById("toolbar");
     toolbarElement.innerHTML = `
-<div id="barWorkspace" aria-label="${window.siyuan.languages.mainMenu} ${updateHotkeyTip(window.siyuan.config.keymap.general.mainMenu.custom)}" class="ariaLabel toolbar__item toolbar__item--active">
+<div id="barWorkspace" class="ariaLabel toolbar__item toolbar__item--active" aria-label="${window.siyuan.languages.mainMenu} ${updateHotkeyTip(window.siyuan.config.keymap.general.mainMenu.custom)}">
     <span class="toolbar__text">${getWorkspaceName()}</span>
     <svg class="toolbar__svg"><use xlink:href="#iconDown"></use></svg>
 </div>

--- a/app/src/layout/topBar.ts
+++ b/app/src/layout/topBar.ts
@@ -24,7 +24,7 @@ import {commandPanel} from "../boot/globalEvent/command/panel";
 export const initBar = (app: App) => {
     const toolbarElement = document.getElementById("toolbar");
     toolbarElement.innerHTML = `
-<div id="barWorkspace" aria-label="${updateHotkeyTip(window.siyuan.config.keymap.general.mainMenu.custom)} <span class='ft__on-surface'>${window.siyuan.languages.mainMenu}</span>" class="ariaLabel toolbar__item toolbar__item--active">
+<div id="barWorkspace" aria-label="${window.siyuan.languages.mainMenu} ${updateHotkeyTip(window.siyuan.config.keymap.general.mainMenu.custom)}" class="ariaLabel toolbar__item toolbar__item--active">
     <span class="toolbar__text">${getWorkspaceName()}</span>
     <svg class="toolbar__svg"><use xlink:href="#iconDown"></use></svg>
 </div>


### PR DESCRIPTION
其他地方都是 `按钮名称 快捷键` 的形式：

![image](https://github.com/siyuan-note/siyuan/assets/78434827/fdcc1620-99a0-44c3-ac39-9bcbd9a3a61c)

![image](https://github.com/siyuan-note/siyuan/assets/78434827/4112d46a-9449-4e95-ba2b-6a247640a373)

只有主菜单按钮的名称变成灰色了，既不一致，也不清晰：（按钮名称应该是最清晰的）

![image](https://github.com/siyuan-note/siyuan/assets/78434827/f0679168-a787-4857-8c4b-36695bd9fefd)
