### PR TITLE
Add a parameter `containChildren` for the kernel API `/api/ref/getBacklinkDoc`

### DIFF
--- a/app/src/layout/dock/Backlink.ts
+++ b/app/src/layout/dock/Backlink.ts
@@ -436,7 +436,8 @@ export class Backlink extends Model {
             fetchPost(isMention ? "/api/ref/getBackmentionDoc" : "/api/ref/getBacklinkDoc", {
                 defID: this.blockId,
                 refTreeID: docId,
-                keyword: isMention ? this.inputsElement[1].value : this.inputsElement[0].value
+                keyword: isMention ? this.inputsElement[1].value : this.inputsElement[0].value,
+                containChildren: true
             }, (response) => {
                 svgElement.removeAttribute("disabled");
                 svgElement.classList.add("b3-list-item__arrow--open");

--- a/app/src/protyle/util/reload.ts
+++ b/app/src/protyle/util/reload.ts
@@ -40,7 +40,8 @@ export const reloadProtyle = (protyle: IProtyle, focus: boolean, updateReadonly?
             fetchPost(isMention ? "/api/ref/getBackmentionDoc" : "/api/ref/getBacklinkDoc", {
                 defID: protyle.element.getAttribute("data-defid"),
                 refTreeID: protyle.block.rootID,
-                keyword: isMention ? inputsElement[1].value : inputsElement[0].value
+                keyword: isMention ? inputsElement[1].value : inputsElement[0].value,
+                containChildren: true
             }, response => {
                 protyle.options.backlinkData = isMention ? response.data.backmentions : response.data.backlinks;
                 renderBacklink(protyle, protyle.options.backlinkData);

--- a/kernel/api/ref.go
+++ b/kernel/api/ref.go
@@ -51,7 +51,11 @@ func getBackmentionDoc(c *gin.Context) {
 	defID := arg["defID"].(string)
 	refTreeID := arg["refTreeID"].(string)
 	keyword := arg["keyword"].(string)
-	backlinks := model.GetBackmentionDoc(defID, refTreeID, keyword)
+	containChildren := true
+	if val, ok := arg["containChildren"]; ok {
+		containChildren = val.(bool)
+	}
+	backlinks := model.GetBackmentionDoc(defID, refTreeID, keyword, containChildren)
 	ret.Data = map[string]interface{}{
 		"backmentions": backlinks,
 	}
@@ -69,7 +73,11 @@ func getBacklinkDoc(c *gin.Context) {
 	defID := arg["defID"].(string)
 	refTreeID := arg["refTreeID"].(string)
 	keyword := arg["keyword"].(string)
-	backlinks := model.GetBacklinkDoc(defID, refTreeID, keyword)
+	containChildren := true
+	if val, ok := arg["containChildren"]; ok {
+		containChildren = val.(bool)
+	}
+	backlinks := model.GetBacklinkDoc(defID, refTreeID, keyword, containChildren)
 	ret.Data = map[string]interface{}{
 		"backlinks": backlinks,
 	}

--- a/kernel/model/backlink.go
+++ b/kernel/model/backlink.go
@@ -68,7 +68,7 @@ type Backlink struct {
 	Expand     bool         `json:"expand"`
 }
 
-func GetBackmentionDoc(defID, refTreeID, keyword string) (ret []*Backlink) {
+func GetBackmentionDoc(defID, refTreeID, keyword string, containChildren bool) (ret []*Backlink) {
 	keyword = strings.TrimSpace(keyword)
 	ret = []*Backlink{}
 	beforeLen := 12
@@ -78,7 +78,7 @@ func GetBackmentionDoc(defID, refTreeID, keyword string) (ret []*Backlink) {
 	}
 	rootID := sqlBlock.RootID
 
-	refs := sql.QueryRefsByDefID(defID, true)
+	refs := sql.QueryRefsByDefID(defID, containChildren)
 	refs = removeDuplicatedRefs(refs) // 同一个块中引用多个相同块时反链去重 https://github.com/siyuan-note/siyuan/issues/3317
 
 	linkRefs, _, excludeBacklinkIDs := buildLinkRefs(rootID, refs, keyword)
@@ -114,7 +114,7 @@ func GetBackmentionDoc(defID, refTreeID, keyword string) (ret []*Backlink) {
 	return
 }
 
-func GetBacklinkDoc(defID, refTreeID, keyword string) (ret []*Backlink) {
+func GetBacklinkDoc(defID, refTreeID, keyword string, containChildren bool) (ret []*Backlink) {
 	keyword = strings.TrimSpace(keyword)
 	ret = []*Backlink{}
 	sqlBlock := sql.GetBlock(defID)
@@ -123,7 +123,7 @@ func GetBacklinkDoc(defID, refTreeID, keyword string) (ret []*Backlink) {
 	}
 	rootID := sqlBlock.RootID
 
-	tmpRefs := sql.QueryRefsByDefID(defID, true)
+	tmpRefs := sql.QueryRefsByDefID(defID, containChildren)
 	var refs []*sql.Ref
 	for _, ref := range tmpRefs {
 		if ref.RootID == refTreeID {


### PR DESCRIPTION
内核接口 `/api/ref/getBacklinkDoc` 和 `/api/ref/getBackmentionDoc`  添加参数 `containChildren` 。

同时修改前端调用这两个接口时，加上 containChildren 字段默认为 true 的参数（保证接口处理跟以前一致）。