### PR TITLE
Fix API `/api/asset/upload` response body `succMap` field

### DIFF
--- a/app/src/protyle/util/Options.ts
+++ b/app/src/protyle/util/Options.ts
@@ -126,7 +126,7 @@ export class Options {
             url: Constants.UPLOAD_ADDRESS,
             extraData: {},
             fieldName: "file[]",
-            filename: (name: string) => name.replace(/[\\/:*?"'<>|]/g, ""),
+            filename: (name: string) => name.replace(/[\\/:*?"'<>|\[\]\(\)~!`&{}=#%$]/g, ""),
             linkToImgUrl: "",
             withCredentials: false,
         }

--- a/kernel/model/upload.go
+++ b/kernel/model/upload.go
@@ -284,7 +284,7 @@ func Upload(c *gin.Context) {
 				os.RemoveAll(tmpDir2)
 			}
 
-			succMap[fName] = strings.TrimPrefix(path.Join(relAssetsDirPath, fName), "/")
+			succMap[baseName] = strings.TrimPrefix(path.Join(relAssetsDirPath, fName), "/")
 		}
 	}
 

--- a/kernel/model/upload.go
+++ b/kernel/model/upload.go
@@ -100,7 +100,7 @@ func InsertLocalAssets(id string, assetPaths []string, isUpload bool) (succMap m
 				return
 			}
 			f.Close()
-			succMap[fName] = "assets/" + fName
+			succMap[baseName] = "assets/" + fName
 		}
 	}
 	IncSync()


### PR DESCRIPTION
稳定 API `/api/asset/upload` 在 #12255 中引入了破坏性变更
Stable API `/api/asset/upload` introduced a breaking change in #12255

响应体中 `succMap` 对象的字段名在部分情况下均会被错误得替换为实际保存的文件名, 导致 API 的调用者无法获取原文件名到新文件名的映射
In some cases, the field name and field value of the `succMap` object in the response body will be incorrectly replaced with the actual saved file name, causing the caller of the API to be unable to get the mapping from the original file name to the new file name.

同时造成该 API 的行为与文档不一致
It also causes the API to behave inconsistently with the documentation.

```diff
{
  "code": 0,
  "msg": "",
  "data": {
    "errFiles": [""],
    "succMap": {
-      "foo.png": "assets/foo-20210719092549-9j5y79r.png"
+      "foo-20210719092549-9j5y79r.png": "assets/foo-20210719092549-9j5y79r.png"
    }
  }
}
```

已经过测试
TESTED