### PR TITLE
fix(Setting.ts): destroyCallback 参数没有被使用

### DIFF
--- a/app/src/plugin/Setting.ts
+++ b/app/src/plugin/Setting.ts
@@ -16,6 +16,7 @@ export class Setting {
         confirmCallback?: () => void
     }) {
         this.confirmCallback = options.confirmCallback;
+        this.destroyCallback = options.destroyCallback;
         this.width = options.width || (isMobile() ? "92vw" : "768px");
         this.height = options.height || "80vh";
     }


### PR DESCRIPTION
destroyCallback 参数没有被使用，导致传入的 callback 实际上不会起到任何效果。

