### PR TITLE
Kernel serve WebDAV service on path `/webdav/`

### DIFF
--- a/kernel/go.mod
+++ b/kernel/go.mod
@@ -71,6 +71,7 @@ require (
 	golang.org/x/image v0.19.0
 	golang.org/x/mobile v0.0.0-20240520174638-fa72addaaa1b
 	golang.org/x/mod v0.20.0
+	golang.org/x/net v0.28.0
 	golang.org/x/text v0.17.0
 	golang.org/x/time v0.6.0
 )
@@ -164,7 +165,6 @@ require (
 	golang.org/x/arch v0.9.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
-	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect

--- a/kernel/model/export.go
+++ b/kernel/model/export.go
@@ -441,7 +441,7 @@ func ExportData() (zipPath string, err error) {
 	util.PushEndlessProgress(Conf.Language(65))
 	defer util.ClearPushProgress(100)
 
-	name := util.FilterFileName(filepath.Base(util.WorkspaceDir)) + "-" + util.CurrentTimeSecondsStr()
+	name := util.FilterFileName(util.WorkspaceName) + "-" + util.CurrentTimeSecondsStr()
 	exportFolder := filepath.Join(util.TempDir, "export", name)
 	zipPath, err = exportData(exportFolder)
 	if err != nil {

--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -619,7 +619,7 @@ func serveWebDAV(ginServer *gin.Engine) {
 	ginGroup.Match(WebDavMethod, "/*path", func(c *gin.Context) {
 		if util.ReadOnly {
 			switch c.Request.Method {
-			case "POST", "PUT", "DELETE", "MKCOL", "COPY", "MOVE", "PROPPATCH":
+			case "POST", "PUT", "DELETE", "MKCOL", "COPY", "MOVE", "LOCK", "UNLOCK", "PROPPATCH":
 				c.AbortWithError(http.StatusForbidden, fmt.Errorf(model.Conf.Language(34)))
 				return
 			}

--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -44,10 +44,21 @@ import (
 	"github.com/siyuan-note/siyuan/kernel/model"
 	"github.com/siyuan-note/siyuan/kernel/server/proxy"
 	"github.com/siyuan-note/siyuan/kernel/util"
+	"golang.org/x/net/webdav"
 )
 
 var (
-	cookieStore = cookie.NewStore([]byte("ATN51UlxVq1Gcvdf"))
+	cookieStore  = cookie.NewStore([]byte("ATN51UlxVq1Gcvdf"))
+	WebDavMethod = []string{
+		"OPTIONS",
+		"GET", "HEAD",
+		"POST", "PUT",
+		"DELETE",
+		"MKCOL",
+		"COPY", "MOVE",
+		"LOCK", "UNLOCK",
+		"PROPFIND", "PROPPATCH",
+	}
 )
 
 func Serve(fastMode bool) {
@@ -76,6 +87,7 @@ func Serve(fastMode bool) {
 	serveAssets(ginServer)
 	serveAppearance(ginServer)
 	serveWebSocket(ginServer)
+	serveWebDAV(ginServer)
 	serveExport(ginServer)
 	serveWidgets(ginServer)
 	servePlugins(ginServer)
@@ -371,7 +383,7 @@ func serveAuthPage(c *gin.Context) {
 		"l8":                     model.Conf.Language(95),
 		"appearanceMode":         model.Conf.Appearance.Mode,
 		"appearanceModeOS":       model.Conf.Appearance.ModeOS,
-		"workspace":              filepath.Base(util.WorkspaceDir),
+		"workspace":              util.WorkspaceName,
 		"workspacePath":          util.WorkspaceDir,
 		"keymapGeneralToggleWin": keymapHideWindow,
 		"trayMenuLangs":          util.TrayMenuLangs[util.Lang],
@@ -586,6 +598,33 @@ func serveWebSocket(ginServer *gin.Engine) {
 		logging.LogTracef("parse cmd [%s] consumed [%d]ms", command.Name(), end.Sub(start).Milliseconds())
 
 		cmd.Exec(command)
+	})
+}
+
+func serveWebDAV(ginServer *gin.Engine) {
+	// REF: https://github.com/fungaren/gin-webdav
+	handler := webdav.Handler{
+		Prefix:     "/webdav/",
+		FileSystem: webdav.Dir(util.WorkspaceDir),
+		LockSystem: webdav.NewMemLS(),
+		Logger: func(r *http.Request, err error) {
+			if nil != err {
+				logging.LogErrorf("WebDAV [%s %s]: %s", r.Method, r.URL.String(), err.Error())
+			}
+			// logging.LogDebugf("WebDAV [%s %s]", r.Method, r.URL.String())
+		},
+	}
+
+	ginGroup := ginServer.Group("/webdav", model.CheckAuth, model.CheckAdminRole)
+	ginGroup.Match(WebDavMethod, "/*path", func(c *gin.Context) {
+		if util.ReadOnly {
+			switch c.Request.Method {
+			case "POST", "PUT", "DELETE", "MKCOL", "COPY", "MOVE", "PROPPATCH":
+				c.AbortWithError(http.StatusForbidden, fmt.Errorf(model.Conf.Language(34)))
+				return
+			}
+		}
+		handler.ServeHTTP(c.Writer, c.Request)
 	})
 }
 

--- a/kernel/util/working.go
+++ b/kernel/util/working.go
@@ -198,6 +198,7 @@ var (
 	WorkingDir, _ = os.Getwd()
 
 	WorkspaceDir       string        // 工作空间目录路径
+	WorkspaceName      string        // 工作空间名称
 	WorkspaceLock      *flock.Flock  // 工作空间锁
 	ConfDir            string        // 配置目录路径
 	DataDir            string        // 数据目录路径
@@ -269,6 +270,7 @@ func initWorkspaceDir(workspaceArg string) {
 		os.Exit(logging.ExitCodeInitWorkspaceErr)
 	}
 
+	WorkspaceName = filepath.Base(WorkspaceDir)
 	ConfDir = filepath.Join(WorkspaceDir, "conf")
 	DataDir = filepath.Join(WorkspaceDir, "data")
 	RepoDir = filepath.Join(WorkspaceDir, "repo")

--- a/kernel/util/working_mobile.go
+++ b/kernel/util/working_mobile.go
@@ -141,6 +141,7 @@ func initWorkspaceDirMobile(workspaceBaseDir string) {
 		os.Exit(logging.ExitCodeInitWorkspaceErr)
 	}
 
+	WorkspaceName = filepath.Base(WorkspaceDir)
 	ConfDir = filepath.Join(WorkspaceDir, "conf")
 	DataDir = filepath.Join(WorkspaceDir, "data")
 	RepoDir = filepath.Join(WorkspaceDir, "repo")


### PR DESCRIPTION
REF: #9633

- 内核在 `/webdav` 路径下提供 WebDAV 服务
  The kernel provides WebDAV service on path `/webdav`.
- 目录 `/webdav/` 映射为工作空间目录, 例如 `/webdav/data/` 映射为 `<工作空间目录>/data/`
  The directory `/webdav/` maps to the workspace directory, e.g. `/webdav/data/` maps to `<workspace-directory>/data/`.
- 该服务使用 BasicAuth 认证, 用户名为工作空间目录的目录名, 密码为访问授权码 `accessAuthCode`
  The service uses BasicAuth authentication, the username is the directory name of the workspace directory, and the password is the access authorization code `accessAuthCode`.

已测试 | TESTED