### PR TITLE
Improve data snapshots pagination navigation fix #12548

### DIFF
--- a/app/appearance/langs/en_US.json
+++ b/app/appearance/langs/en_US.json
@@ -1,6 +1,6 @@
 {
-  "historyRepoJumpPage": "Jump to the specified page: 1 ~ ${x}",
-  "historyRepoTitle": "Total <span class=\"count-page\">1</span> pages, <span class=\"count-snap\">1</span> snapshots",
+  "dataHistoryJumpPage": "Jump to the specified page: 1 ~ ${x}",
+  "pageCountAndSnapshotCount": "Total ${x} pages, ${y} snapshots",
   "visitCommunityShare": "Visit community share",
   "clearContextSucc": "The context has been cleared",
   "emptyMobilePlaceholder": "Record something",

--- a/app/appearance/langs/en_US.json
+++ b/app/appearance/langs/en_US.json
@@ -1,5 +1,5 @@
 {
-  "dataHistoryJumpPage": "Jump to the specified page: 1 ~ ${x}",
+  "jumpToPage": "Jump to the specified page: 1 ~ ${x}",
   "pageCountAndSnapshotCount": "Total ${x} pages, ${y} snapshots",
   "visitCommunityShare": "Visit community share",
   "clearContextSucc": "The context has been cleared",

--- a/app/appearance/langs/es_ES.json
+++ b/app/appearance/langs/es_ES.json
@@ -1,6 +1,6 @@
 {
-  "historyRepoJumpPage": "Saltar a la página especificada: 1 ~ ${x}",
-  "historyRepoTitle": "Total <span class=\"count-page\">1</span> páginas, <span class=\"count-snap\">1</span> instantáneas",
+  "dataHistoryJumpPage": "Saltar a la página especificada: 1 ~ ${x}",
+  "pageCountAndSnapshotCount": "Total ${x} páginas, ${y} instantáneas",
   "visitCommunityShare": "Visitar la comunidad compartida",
   "clearContextSucc": "Se ha borrado el contexto",
   "emptyMobilePlaceholder": "Grabar algo",

--- a/app/appearance/langs/es_ES.json
+++ b/app/appearance/langs/es_ES.json
@@ -1,5 +1,5 @@
 {
-  "dataHistoryJumpPage": "Saltar a la página especificada: 1 ~ ${x}",
+  "jumpToPage": "Saltar a la página especificada: 1 ~ ${x}",
   "pageCountAndSnapshotCount": "Total ${x} páginas, ${y} instantáneas",
   "visitCommunityShare": "Visitar la comunidad compartida",
   "clearContextSucc": "Se ha borrado el contexto",

--- a/app/appearance/langs/fr_FR.json
+++ b/app/appearance/langs/fr_FR.json
@@ -1,6 +1,6 @@
 {
-  "historyRepoJumpPage": "Aller à la page spécifiée : 1 ~ ${x}",
-  "historyRepoTitle": "Total de <span class=\"count-page\">1</span> pages, <span class=\"count-snap\">1</span> instantanés",
+  "dataHistoryJumpPage": "Aller à la page spécifiée : 1 ~ ${x}",
+  "pageCountAndSnapshotCount": "Total de ${x} pages, ${y} instantanés",
   "visitCommunityShare": "Visiter le partage communautaire",
   "clearContextSucc": "Le contexte a été effacé",
   "emptyMobilePlaceholder": "Enregistrer quelque chose",

--- a/app/appearance/langs/fr_FR.json
+++ b/app/appearance/langs/fr_FR.json
@@ -1,5 +1,5 @@
 {
-  "dataHistoryJumpPage": "Aller à la page spécifiée : 1 ~ ${x}",
+  "jumpToPage": "Aller à la page spécifiée : 1 ~ ${x}",
   "pageCountAndSnapshotCount": "Total de ${x} pages, ${y} instantanés",
   "visitCommunityShare": "Visiter le partage communautaire",
   "clearContextSucc": "Le contexte a été effacé",

--- a/app/appearance/langs/ja_JP.json
+++ b/app/appearance/langs/ja_JP.json
@@ -1,6 +1,6 @@
 {
-  "historyRepoJumpPage": "指定されたページにジャンプ：1 ~ ${x}",
-  "historyRepoTitle": "合計<span class=\"count-page\">1</span>ページ、<span class=\"count-snap\">1</span>スナップショット",
+  "dataHistoryJumpPage": "指定されたページにジャンプ：1 ~ ${x}",
+  "pageCountAndSnapshotCount": "合計 ${x} ページ、${y} スナップショット",
   "visitCommunityShare": "コミュニティシェアを訪問",
   "clearContextSucc": "コンテキストがクリアされました",
   "emptyMobilePlaceholder": "何かを記録する",

--- a/app/appearance/langs/ja_JP.json
+++ b/app/appearance/langs/ja_JP.json
@@ -1,5 +1,5 @@
 {
-  "dataHistoryJumpPage": "指定されたページにジャンプ：1 ~ ${x}",
+  "jumpToPage": "指定されたページにジャンプ：1 ~ ${x}",
   "pageCountAndSnapshotCount": "合計 ${x} ページ、${y} スナップショット",
   "visitCommunityShare": "コミュニティシェアを訪問",
   "clearContextSucc": "コンテキストがクリアされました",

--- a/app/appearance/langs/zh_CHT.json
+++ b/app/appearance/langs/zh_CHT.json
@@ -1,6 +1,6 @@
 {
-  "historyRepoJumpPage": "跳轉到指定頁：1 ~ ${x}",
-  "historyRepoTitle": "共<span class=\"count-page\">1</span>頁, <span class=\"count-snap\">1</span>個快照",
+  "dataHistoryJumpPage": "跳轉到指定頁：1 ~ ${x}",
+  "pageCountAndSnapshotCount": "共 ${x} 頁，${y} 個快照",
   "visitCommunityShare": "訪問社區分享",
   "clearContextSucc": "上下文已清空",
   "emptyMobilePlaceholder": "記錄點什麼",

--- a/app/appearance/langs/zh_CHT.json
+++ b/app/appearance/langs/zh_CHT.json
@@ -1,5 +1,5 @@
 {
-  "dataHistoryJumpPage": "跳轉到指定頁：1 ~ ${x}",
+  "jumpToPage": "跳轉到指定頁：1 ~ ${x}",
   "pageCountAndSnapshotCount": "共 ${x} 頁，${y} 個快照",
   "visitCommunityShare": "訪問社區分享",
   "clearContextSucc": "上下文已清空",

--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -1,6 +1,6 @@
 {
-  "historyRepoJumpPage": "跳转到指定页：1 ~ ${x}",
-  "historyRepoTitle": "共<span class=\"count-page\">1</span>页, <span class=\"count-snap\">1</span>个快照",
+  "dataHistoryJumpPage": "跳转到指定页：1 ~ ${x}",
+  "pageCountAndSnapshotCount": "共 ${x} 页，${y} 个快照",
   "visitCommunityShare": "访问社区分享",
   "clearContextSucc": "上下文已清空",
   "emptyMobilePlaceholder": "记录点什么",

--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -1,5 +1,5 @@
 {
-  "dataHistoryJumpPage": "跳转到指定页：1 ~ ${x}",
+  "jumpToPage": "跳转到指定页：1 ~ ${x}",
   "pageCountAndSnapshotCount": "共 ${x} 页，${y} 个快照",
   "visitCommunityShare": "访问社区分享",
   "clearContextSucc": "上下文已清空",

--- a/app/src/history/history.ts
+++ b/app/src/history/history.ts
@@ -241,14 +241,12 @@ ${actionHTML}
 const renderRepo = (element: Element, currentPage: number) => {
     const selectValue = (element.querySelector(".b3-select") as HTMLSelectElement).value;
     element.lastElementChild.innerHTML = '<li style="position: relative;height: 100%;"><div class="fn__loading"><img width="64px" src="/stage/loading-pure.svg"></div></li>';
-    const pageCount = element.querySelector(".history-repo__title span.count-page");
-    const snapCount = element.querySelector(".history-repo__title span.count-snap");
     const pageBtn = element.querySelector('button[data-type="jumpPage"]');
     pageBtn.textContent = `${currentPage}`;
 
     const previousElement = element.querySelector('[data-type="previous"]');
     const nextElement = element.querySelector('[data-type="next"]');
-    // const pageElement = nextElement.nextElementSibling.nextElementSibling;
+    const pageElement = nextElement.nextElementSibling.nextElementSibling;
     element.setAttribute("data-init", "true");
     if (selectValue === "getRepoTagSnapshots" || selectValue === "getCloudRepoTagSnapshots") {
         fetchPost(`/api/repo/${selectValue}`, {}, (response) => {
@@ -256,15 +254,13 @@ const renderRepo = (element: Element, currentPage: number) => {
         });
         previousElement.classList.add("fn__none");
         nextElement.classList.add("fn__none");
-        // pageElement.classList.add("fn__none");
+        pageElement.classList.add("fn__none");
         pageBtn.classList.add("fn__none");
-        pageCount.parentElement?.classList.add("fn__none");
     } else {
         previousElement.classList.remove("fn__none");
         nextElement.classList.remove("fn__none");
-        // pageElement.classList.remove("fn__none");
+        pageElement.classList.remove("fn__none");
         pageBtn.classList.remove("fn__none");
-        pageCount.parentElement?.classList.remove("fn__none");
         element.setAttribute("data-page", currentPage.toString());
         if (currentPage > 1) {
             previousElement.removeAttribute("disabled");
@@ -278,9 +274,8 @@ const renderRepo = (element: Element, currentPage: number) => {
             } else {
                 nextElement.setAttribute("disabled", "disabled");
             }
-            // pageElement.textContent = `${currentPage}/${response.data.pageCount || 1}`;
-            pageCount.textContent = `${response.data.pageCount}`;
-            snapCount.textContent = `${response.data.totalCount}`;
+            element.setAttribute("total-page", response.data.totalCount.toString());
+            pageElement.textContent = `${window.siyuan.languages.pageCountAndSnapshotCount.replace("${x}", response.data.pageCount).replace("${y}", response.data.totalCount || 1)}`;
             renderRepoItem(response, element, selectValue);
         });
     }
@@ -403,13 +398,11 @@ export const openHistory = (app: App) => {
         <div data-type="repo" class="fn__none history__repo">
             <div style="overflow: auto"">
                 <div class="block__icons">
-                    <div style="margin-left: 3px;" class="history-repo__title">
-                        ${window.siyuan.languages.historyRepoTitle}
-                    </div>
-                    <span class="fn__space"></span>
                     <span data-type="previous" class="block__icon block__icon--show b3-tooltips b3-tooltips__e" disabled="disabled" aria-label="${window.siyuan.languages.previousLabel}"><svg><use xlink:href='#iconLeft'></use></svg></span>
                     <button class="b3-button b3-button--text" data-type="jumpPage">1</button>
                     <span data-type="next" class="block__icon block__icon--show b3-tooltips b3-tooltips__e" disabled="disabled" aria-label="${window.siyuan.languages.nextLabel}"><svg><use xlink:href='#iconRight'></use></svg></span>
+                    <span class="fn__space"></span>
+                    <span class="ft__on-surface fn__flex-shrink ft__selectnone">${window.siyuan.languages.pageCountAndSnapshotCount}</span>
                     <span class="fn__space"></span>
                     <div class="fn__flex-1"></div>
                     <select class="b3-select ${isMobile() ? "fn__size96" : "fn__size200"}">
@@ -812,11 +805,10 @@ const bindEvent = (app: App, element: Element, dialog?: Dialog) => {
                 break;
             } else if (type === "jumpPage") {
                 const currentPage = parseInt(repoElement.getAttribute("data-page"));
-                const count = repoElement.querySelector("span.count-page");
-                const totalPage = parseInt(count?.textContent || "1");
+                const totalPage = parseInt(repoElement.getAttribute("total-page") || "1");
 
                 confirmDialog(
-                    window.siyuan.languages.historyRepoJumpPage.replace("${x}", totalPage),
+                    window.siyuan.languages.dataHistoryJumpPage.replace("${x}", totalPage),
                     // eslint-disable-next-line quotes
                     `<input style="width: 100%;" class="b3-text-field fn__flex-center" type="number" min="1" max="${totalPage}" value="${currentPage}">`,
                     (dialog: Dialog) => {

--- a/app/src/history/history.ts
+++ b/app/src/history/history.ts
@@ -274,7 +274,7 @@ const renderRepo = (element: Element, currentPage: number) => {
             } else {
                 nextElement.setAttribute("disabled", "disabled");
             }
-            element.setAttribute("total-page", response.data.totalCount.toString());
+            element.setAttribute("total-page", response.data.pageCount.toString());
             pageElement.textContent = `${window.siyuan.languages.pageCountAndSnapshotCount.replace("${x}", response.data.pageCount).replace("${y}", response.data.totalCount || 1)}`;
             renderRepoItem(response, element, selectValue);
         });

--- a/app/src/history/history.ts
+++ b/app/src/history/history.ts
@@ -808,7 +808,7 @@ const bindEvent = (app: App, element: Element, dialog?: Dialog) => {
                 const totalPage = parseInt(repoElement.getAttribute("total-page") || "1");
 
                 confirmDialog(
-                    window.siyuan.languages.dataHistoryJumpPage.replace("${x}", totalPage),
+                    window.siyuan.languages.jumpToPage.replace("${x}", totalPage),
                     // eslint-disable-next-line quotes
                     `<input style="width: 100%;" class="b3-text-field fn__flex-center" type="number" min="1" max="${totalPage}" value="${currentPage}">`,
                     (dialog: Dialog) => {


### PR DESCRIPTION
- 把按钮移到左边，文本在右边，避免文本宽度影响按钮位置（各语种的按钮位置都有偏差，用起来怪怪的）
- 数字和文本之间添加间隔（一个空格）
- 文本简化为单个 span 元素、像搜索界面顶部的文本一样显示为灰色、窗口宽度减小之后文本不换行
  `<span class="ft__on-surface fn__flex-shrink ft__selectnone">共 1 页, 2 个快照</span>`

---

[原来的样式](https://github.com/siyuan-note/siyuan/pull/12548)：

![image](https://github.com/user-attachments/assets/1f529a85-c570-4d9d-b28c-7b53e87b04cb)

参考搜素界面：

![image](https://github.com/user-attachments/assets/0b47b408-a17c-4b45-aa97-aba3d975b4f3)

本 PR 修改后的样式：

![image](https://github.com/user-attachments/assets/587b458d-003a-4a5c-bdcf-cfab05f0f934)
