### PR TITLE
修复数据历史页面跳转输入框中，数字显示错误的 bug

### DIFF
--- a/app/src/history/history.ts
+++ b/app/src/history/history.ts
@@ -814,7 +814,9 @@ const bindEvent = (app: App, element: Element, dialog?: Dialog) => {
                 event.preventDefault();
                 break;
             } else if (type === "jumpRepoPage") {
-                const currentPage = parseInt(repoElement.getAttribute("data-page"));
+                // const currentPage = parseInt(repoElement.getAttribute("data-page"));
+                let currentPage = parseInt(target.innerText);
+                currentPage = isNaN(currentPage) ? 1 : currentPage;
                 const totalPage = parseInt(target.getAttribute("data-totalpage") || "1");
 
                 if (totalPage > 1) {
@@ -833,7 +835,9 @@ const bindEvent = (app: App, element: Element, dialog?: Dialog) => {
                     );
                 }
             } else if (type === "jumpHistoryPage") {
-                const currentPage = parseInt(repoElement.getAttribute("data-page"));
+                // const currentPage = parseInt(repoElement.getAttribute("data-page"));
+                let currentPage = parseInt(target.innerText);
+                currentPage = isNaN(currentPage) ? 1 : currentPage;
                 const totalPage = parseInt(target.getAttribute("data-totalpage") || "1");
 
                 if (totalPage > 1) {


### PR DESCRIPTION
## Feature or bug? 特性或者缺陷？

上次提交的 PR 有点问题。数据历史里面点击跳转页面后，一进去数字输入框里面的值错误。

![image](https://github.com/user-attachments/assets/77a50d6f-d7c5-4b25-9d33-09afdd600651)


## Multilingual or copywriting? 多语言或者文案？

Please submit directly, we will evaluate.
请直接提交，我们会进行评估。

## Dev branch!

Any changes should be submitted to the dev branch.
任何改动，请提交到 dev 分支。
