### PR TITLE
Improve .protyle-scroll tooltip

### DIFF
--- a/app/src/dialog/tooltip.ts
+++ b/app/src/dialog/tooltip.ts
@@ -1,4 +1,4 @@
-import { isMobile } from "../util/functions";
+import {isMobile} from "../util/functions";
 
 export const showTooltip = (message: string, target: Element, error = false) => {
     if (isMobile()) {
@@ -40,7 +40,7 @@ export const showTooltip = (message: string, target: Element, error = false) => 
     }
 
     if (position?.endsWith("bottom")) {
-        top += parseInt(position.replace("right", ""));
+        top += parseInt(position.replace("right", "").replace("left", ""));
     } else if (position?.endsWith("top")) {
         top = targetRect.top - messageElement.clientHeight;
     } else if (position === "parentE") {
@@ -55,8 +55,9 @@ export const showTooltip = (message: string, target: Element, error = false) => 
 
     const topHeight = position === "parentE" ? top : targetRect.top;
     const bottomHeight = window.innerHeight - top;
-    messageElement.style.maxHeight = Math.max(topHeight, bottomHeight) + "px";
 
+    messageElement.style.maxHeight = Math.max(topHeight, bottomHeight) + "px";
+    
     if (top + messageElement.clientHeight > window.innerHeight && topHeight > bottomHeight) {
         messageElement.style.top = ((position === "parentE" ? parentRect.bottom : targetRect.top) - messageElement.clientHeight) + "px";
     } else {

--- a/app/src/dialog/tooltip.ts
+++ b/app/src/dialog/tooltip.ts
@@ -1,4 +1,4 @@
-import {isMobile} from "../util/functions";
+import { isMobile } from "../util/functions";
 
 export const showTooltip = (message: string, target: Element, error = false) => {
     if (isMobile()) {
@@ -26,16 +26,23 @@ export const showTooltip = (message: string, target: Element, error = false) => 
     } else {
         messageElement.classList.remove("tooltip--memo");
     }
+
     let left = targetRect.left;
     let top = targetRect.bottom;
     const position = target.getAttribute("data-position");
     const parentRect = target.parentElement.getBoundingClientRect();
+
     if (position?.startsWith("right")) {
         // block icon and background icon
         left = targetRect.right - messageElement.clientWidth;
+    } else if (position?.startsWith("left")) {
+        left = targetRect.left;
     }
+
     if (position?.endsWith("bottom")) {
         top += parseInt(position.replace("right", ""));
+    } else if (position?.endsWith("top")) {
+        top = targetRect.top - messageElement.clientHeight;
     } else if (position === "parentE") {
         // file tree and outline、backlink
         top = parentRect.top;
@@ -45,14 +52,17 @@ export const showTooltip = (message: string, target: Element, error = false) => 
         top = parentRect.top + 8;
         left = parentRect.left - messageElement.clientWidth;
     }
+
     const topHeight = position === "parentE" ? top : targetRect.top;
     const bottomHeight = window.innerHeight - top;
     messageElement.style.maxHeight = Math.max(topHeight, bottomHeight) + "px";
+
     if (top + messageElement.clientHeight > window.innerHeight && topHeight > bottomHeight) {
         messageElement.style.top = ((position === "parentE" ? parentRect.bottom : targetRect.top) - messageElement.clientHeight) + "px";
     } else {
         messageElement.style.top = top + "px";
     }
+
     if (left + messageElement.clientWidth > window.innerWidth) {
         if (position === "parentE") {
             messageElement.style.left = (parentRect.left - 8 - messageElement.clientWidth) + "px";

--- a/app/src/protyle/scroll/index.ts
+++ b/app/src/protyle/scroll/index.ts
@@ -20,13 +20,13 @@ export class Scroll {
         if (!isMobile()) {
             this.parentElement.style.right = "10px";
         }
-        this.parentElement.innerHTML = `<div class="b3-tooltips b3-tooltips__w protyle-scroll__up" aria-label="${updateHotkeyTip("⌘Home")}">
+        this.parentElement.innerHTML = `<div class="protyle-scroll__up ariaLabel" data-position="right4top" aria-label="${updateHotkeyTip("⌘Home")}">
     <svg><use xlink:href="#iconUp"></use></svg>
 </div>
 <div class="fn__none protyle-scroll__bar ariaLabel" data-position="right18bottom" aria-label="Blocks 1/1">
     <input class="b3-slider" type="range" max="1" min="1" step="1" value="1" />
 </div>
-<div class="b3-tooltips b3-tooltips__w protyle-scroll__down" aria-label="${updateHotkeyTip("⌘End")}">
+<div class="protyle-scroll__down ariaLabel" data-position="right4bottom" aria-label="${updateHotkeyTip("⌘End")}">
     <svg><use xlink:href="#iconDown"></use></svg>
 </div>`;
 


### PR DESCRIPTION
因为经常误触右侧栏悬浮面板，所以打算把 .protyle-scroll 放到编辑器左边，改 CSS 之后发现伪元素提示会被侧栏覆盖掉大半，所以换成悬浮提示解决问题：

![image](https://github.com/user-attachments/assets/2e09329f-92bc-4e0e-8900-84a6b879e0a6)

> 关联 #11502