### PR TITLE
Improve the styling of the selected blocks (third-party themes need to be adapted) #12105 #12579

### DIFF
--- a/app/appearance/themes/daylight/theme.css
+++ b/app/appearance/themes/daylight/theme.css
@@ -64,6 +64,23 @@
     --b3-av-hover: #e8e8e9;
     --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #e8eefc;
+    --b3-av-font-background1-hl: rgb(202, 188, 214);
+    --b3-av-font-background2-hl: rgb(210, 206, 209);
+    --b3-av-font-background3-hl: rgb(178, 208, 247);
+    --b3-av-font-background4-hl: rgb(179, 210, 222);
+    --b3-av-font-background5-hl: rgb(187, 202, 230);
+    --b3-av-font-background6-hl: rgb(145, 187, 250);
+    --b3-av-font-background7-hl: rgb(208, 210, 220);
+    --b3-av-font-background8-hl: rgb(205, 201, 214);
+    --b3-av-font-background9-hl: rgb(208, 191, 233);
+    --b3-av-font-background10-hl: rgb(190, 180, 232);
+    --b3-av-font-background11-hl: rgb(184, 212, 222);
+    --b3-av-font-background12-hl: rgb(205, 202, 230);
+    --b3-av-font-background13-hl: rgb(38, 53, 81);
+    --b3-av-card-error-background-hl: var(--b3-av-font-background1-hl);
+    --b3-av-card-warning-background-hl: var(--b3-av-font-background2-hl);
+    --b3-av-card-info-background-hl: var(--b3-av-font-background3-hl);
+    --b3-av-card-success-background-hl: var(--b3-av-font-background4-hl);
 
     /* 为空提示 */
     --b3-empty-color: var(--b3-theme-on-surface-light);

--- a/app/appearance/themes/daylight/theme.css
+++ b/app/appearance/themes/daylight/theme.css
@@ -116,6 +116,7 @@
     --b3-font-background11: #def0d9;
     --b3-font-background12: #fae3e4;
     --b3-font-background13: var(--b3-theme-on-background);
+    /* -select 是与 --b3-theme-primary-lightest 混合后的颜色 */
     --b3-font-background1-select: var(--b3-card-error-background-select);
     --b3-font-background2-select: var(--b3-card-warning-background-select);
     --b3-font-background3-select: var(--b3-card-info-background-select);
@@ -129,6 +130,7 @@
     --b3-font-background11-select: rgb(202, 225, 220);
     --b3-font-background12-select: rgb(226, 214, 229);
     --b3-font-background13-select: var(--b3-theme-on-background-select);
+    /* -hl 是 -select 与 --b3-theme-primary-lightest 再次混合后的颜色 */
     --b3-font-background1-hl: var(--b3-card-error-background-hl);
     --b3-font-background2-hl: var(--b3-card-warning-background-hl);
     --b3-font-background3-hl: var(--b3-card-info-background-hl);

--- a/app/appearance/themes/daylight/theme.css
+++ b/app/appearance/themes/daylight/theme.css
@@ -64,23 +64,6 @@
     --b3-av-hover: #e8e8e9;
     --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #e8eefc;
-    --b3-av-font-background1-hl: rgb(202, 188, 214);
-    --b3-av-font-background2-hl: rgb(210, 206, 209);
-    --b3-av-font-background3-hl: rgb(178, 208, 247);
-    --b3-av-font-background4-hl: rgb(179, 210, 222);
-    --b3-av-font-background5-hl: rgb(187, 202, 230);
-    --b3-av-font-background6-hl: rgb(145, 187, 250);
-    --b3-av-font-background7-hl: rgb(208, 210, 220);
-    --b3-av-font-background8-hl: rgb(205, 201, 214);
-    --b3-av-font-background9-hl: rgb(208, 191, 233);
-    --b3-av-font-background10-hl: rgb(190, 180, 232);
-    --b3-av-font-background11-hl: rgb(184, 212, 222);
-    --b3-av-font-background12-hl: rgb(205, 202, 230);
-    --b3-av-font-background13-hl: rgb(38, 53, 81);
-    --b3-av-card-error-background-hl: var(--b3-av-font-background1-hl);
-    --b3-av-card-warning-background-hl: var(--b3-av-font-background2-hl);
-    --b3-av-card-info-background-hl: var(--b3-av-font-background3-hl);
-    --b3-av-card-success-background-hl: var(--b3-av-font-background4-hl);
 
     /* 为空提示 */
     --b3-empty-color: var(--b3-theme-on-surface-light);
@@ -92,15 +75,19 @@
     --b3-card-error-color: rgb(97, 26, 21);
     --b3-card-error-background: #f5d1cf;
     --b3-card-error-background-select: rgb(222, 198, 211);
+    --b3-card-error-background-hl: rgb(202, 188, 214);
     --b3-card-warning-color: rgb(102, 60, 0);
     --b3-card-warning-background: #ffe8c8;
     --b3-card-warning-background-select: rgb(231, 218, 205);
+    --b3-card-warning-background-hl: rgb(210, 206, 209);
     --b3-card-info-color: rgb(13, 60, 97);
     --b3-card-info-background: #d6eaf9;
     --b3-card-info-background-select: rgb(195, 220, 248);
+    --b3-card-info-background-hl: rgb(178, 208, 247);
     --b3-card-success-color: rgb(30, 70, 32);
     --b3-card-success-background: #d7eed8;
     --b3-card-success-background-select: rgb(196, 223, 219);
+    --b3-card-success-background-hl: rgb(179, 210, 222);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -142,6 +129,19 @@
     --b3-font-background11-select: rgb(202, 225, 220);
     --b3-font-background12-select: rgb(226, 214, 229);
     --b3-font-background13-select: var(--b3-theme-on-background-select);
+    --b3-font-background1-hl: var(--b3-card-error-background-hl);
+    --b3-font-background2-hl: var(--b3-card-warning-background-hl);
+    --b3-font-background3-hl: var(--b3-card-info-background-hl);
+    --b3-font-background4-hl: var(--b3-card-success-background-hl);
+    --b3-font-background5-hl: rgb(187, 202, 230);
+    --b3-font-background6-hl: rgb(145, 187, 250);
+    --b3-font-background7-hl: rgb(208, 210, 220);
+    --b3-font-background8-hl: rgb(205, 201, 214);
+    --b3-font-background9-hl: rgb(208, 191, 233);
+    --b3-font-background10-hl: rgb(190, 180, 232);
+    --b3-font-background11-hl: rgb(184, 212, 222);
+    --b3-font-background12-hl: rgb(205, 202, 230);
+    --b3-font-background13-hl: rgb(38, 53, 81);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;

--- a/app/appearance/themes/daylight/theme.css
+++ b/app/appearance/themes/daylight/theme.css
@@ -17,7 +17,7 @@
     --b3-theme-on-primary: #fff;
     --b3-theme-on-secondary: #fff;
     --b3-theme-on-background: #222;
-    --b3-theme-on-background-rgba: rgb(34, 34, 34, 0.86);
+    --b3-theme-on-background-select: rgb(36, 44, 59);
     --b3-theme-on-surface: #5f6368;
     --b3-theme-on-surface-light: rgba(95, 99, 104, .68);
     --b3-theme-on-error: #fff;
@@ -62,6 +62,7 @@
 
     /* av */
     --b3-av-hover: #e8e8e9;
+    --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #e8eefc;
 
     /* 为空提示 */
@@ -73,16 +74,16 @@
     /* 卡片背景 */
     --b3-card-error-color: rgb(97, 26, 21);
     --b3-card-error-background: #f5d1cf;
-    --b3-card-error-background-rgba: rgb(245, 209, 207, 0.86);
+    --b3-card-error-background-select: rgb(222, 198, 211);
     --b3-card-warning-color: rgb(102, 60, 0);
     --b3-card-warning-background: #ffe8c8;
-    --b3-card-warning-background-rgba: rgb(255, 232, 200, 0.86);
+    --b3-card-warning-background-select: rgb(231, 218, 205);
     --b3-card-info-color: rgb(13, 60, 97);
     --b3-card-info-background: #d6eaf9;
-    --b3-card-info-background-rgba: rgb(214, 234, 249, 0.86);
+    --b3-card-info-background-select: rgb(195, 220, 248);
     --b3-card-success-color: rgb(30, 70, 32);
     --b3-card-success-background: #d7eed8;
-    --b3-card-success-background-rgba: rgb(215, 238, 216, 0.86);
+    --b3-card-success-background-select: rgb(196, 223, 219);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -111,19 +112,19 @@
     --b3-font-background11: #def0d9;
     --b3-font-background12: #fae3e4;
     --b3-font-background13: var(--b3-theme-on-background);
-    --b3-font-background1-rgba: var(--b3-card-error-background-rgba);
-    --b3-font-background2-rgba: var(--b3-card-warning-background-rgba);
-    --b3-font-background3-rgba: var(--b3-card-info-background-rgba);
-    --b3-font-background4-rgba: var(--b3-card-success-background-rgba);
-    --b3-font-background5-rgba: rgb(226, 227, 228, 0.86);
-    --b3-font-background6-rgba: rgb(172, 208, 252, 0.86);
-    --b3-font-background7-rgba: rgb(253, 238, 214, 0.86);
-    --b3-font-background8-rgba: rgb(250, 225, 207, 0.86);
-    --b3-font-background9-rgba: rgb(253, 213, 231, 0.86);
-    --b3-font-background10-rgba: rgb(230, 199, 230, 0.86);
-    --b3-font-background11-rgba: rgb(222, 240, 217, 0.86);
-    --b3-font-background12-rgba: rgb(250, 227, 228, 0.86);
-    --b3-font-background13-rgba: var(--b3-theme-on-background-rgba);
+    --b3-font-background1-select: var(--b3-card-error-background-select);
+    --b3-font-background2-select: var(--b3-card-warning-background-select);
+    --b3-font-background3-select: var(--b3-card-info-background-select);
+    --b3-font-background4-select: var(--b3-card-success-background-select);
+    --b3-font-background5-select: rgb(205, 214, 229);
+    --b3-font-background6-select: rgb(158, 197, 251);
+    --b3-font-background7-select: rgb(229, 223, 217);
+    --b3-font-background8-select: rgb(226, 212, 211);
+    --b3-font-background9-select: rgb(229, 201, 232);
+    --b3-font-background10-select: rgb(209, 189, 231);
+    --b3-font-background11-select: rgb(202, 225, 220);
+    --b3-font-background12-select: rgb(226, 214, 229);
+    --b3-font-background13-select: var(--b3-theme-on-background-select);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;

--- a/app/appearance/themes/midnight/theme.css
+++ b/app/appearance/themes/midnight/theme.css
@@ -17,7 +17,7 @@
     --b3-theme-on-primary: #fff;
     --b3-theme-on-secondary: #fff;
     --b3-theme-on-background: #dadada;
-    --b3-theme-on-background-rgba: rgb(218, 218, 218, 0.86);
+    --b3-theme-on-background-select: rgb(198, 206, 221);
     --b3-theme-on-surface: #9aa0a6;
     --b3-theme-on-surface-light: #bababa;
     --b3-theme-on-error: #fff;
@@ -61,6 +61,7 @@
 
     /* av */
     --b3-av-hover: #2a2a2a;
+    --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #28324e;
 
     /* 为空提示 */
@@ -72,16 +73,16 @@
     /* 卡片背景 */
     --b3-card-error-color: rgb(243, 153, 147);
     --b3-card-error-background: #442724;
-    --b3-card-error-background-rgba: rgb(68, 39, 36, 0.86);
+    --b3-card-error-background-select: rgb(66, 48, 60);
     --b3-card-warning-color: rgb(255, 213, 153);
     --b3-card-warning-background: #554636;
-    --b3-card-warning-background-rgba: rgb(85, 70, 54, 0.86);
+    --b3-card-warning-background-select: rgb(81, 76, 76);
     --b3-card-info-color: rgb(166, 213, 250);
     --b3-card-info-background: #28405c;
-    --b3-card-info-background-rgba: rgb(40, 64, 92, 0.86);
+    --b3-card-info-background-select: rgb(42, 70, 110);
     --b3-card-success-color: rgb(183, 223, 185);
     --b3-card-success-background: #425347;
-    --b3-card-success-background-rgba: rgb(66, 83, 71, 0.86);
+    --b3-card-success-background-select: rgb(64, 87, 91);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -110,19 +111,19 @@
     --b3-font-background11: #376629;
     --b3-font-background12: #803a06;
     --b3-font-background13: var(--b3-theme-on-background);
-    --b3-font-background1-rgba: var(--b3-card-error-background-rgba);
-    --b3-font-background2-rgba: var(--b3-card-warning-background-rgba);
-    --b3-font-background3-rgba: var(--b3-card-info-background-rgba);
-    --b3-font-background4-rgba: var(--b3-card-success-background-rgba);
-    --b3-font-background5-rgba: rgb(76, 82, 87, 0.86);
-    --b3-font-background6-rgba: rgb(12, 61, 136, 0.86);
-    --b3-font-background7-rgba: rgb(89, 57, 5, 0.86);
-    --b3-font-background8-rgba: rgb(84, 24, 18, 0.86);
-    --b3-font-background9-rgba: rgb(106, 6, 52, 0.86);
-    --b3-font-background10-rgba: rgb(107, 47, 107, 0.86);
-    --b3-font-background11-rgba: rgb(55, 102, 41, 0.86);
-    --b3-font-background12-rgba: rgb(128, 58, 6, 0.86);
-    --b3-font-background13-rgba: var(--b3-theme-on-background-rgba);
+    --b3-font-background1-select: var(--b3-card-error-background-select);
+    --b3-font-background2-select: var(--b3-card-warning-background-select);
+    --b3-font-background3-select: var(--b3-card-info-background-select);
+    --b3-font-background4-select: var(--b3-card-success-background-select);
+    --b3-font-background5-select: rgb(73, 86, 105);
+    --b3-font-background6-select: rgb(17, 68, 148);
+    --b3-font-background7-select: rgb(85, 64, 33);
+    --b3-font-background8-select: rgb(80, 35, 45);
+    --b3-font-background9-select: rgb(100, 19, 75);
+    --b3-font-background10-select: rgb(101, 55, 123);
+    --b3-font-background11-select: rgb(55, 104, 65);
+    --b3-font-background12-select: rgb(119, 65, 34);
+    --b3-font-background13-select: var(--b3-theme-on-background-select);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;

--- a/app/appearance/themes/midnight/theme.css
+++ b/app/appearance/themes/midnight/theme.css
@@ -63,6 +63,23 @@
     --b3-av-hover: #2a2a2a;
     --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #28324e;
+    --b3-av-font-background1-hl: rgb(64, 56, 82);
+    --b3-av-font-background2-hl: rgb(78, 81, 96);
+    --b3-av-font-background3-hl: rgb(43, 76, 126);
+    --b3-av-font-background4-hl: rgb(63, 91, 109);
+    --b3-av-font-background5-hl: rgb(71, 90, 121);
+    --b3-av-font-background6-hl: rgb(21, 74, 159);
+    --b3-av-font-background7-hl: rgb(81, 70, 58);
+    --b3-av-font-background8-hl: rgb(77, 45, 68);
+    --b3-av-font-background9-hl: rgb(94, 31, 95);
+    --b3-av-font-background10-hl: rgb(95, 62, 137);
+    --b3-av-font-background11-hl: rgb(55, 106, 86);
+    --b3-av-font-background12-hl: rgb(111, 71, 59);
+    --b3-av-font-background13-hl: rgb(181, 195, 223);
+    --b3-av-card-error-background-hl: var(--b3-av-font-background1-hl);
+    --b3-av-card-warning-background-hl: var(--b3-av-font-background2-hl);
+    --b3-av-card-info-background-hl: var(--b3-av-font-background3-hl);
+    --b3-av-card-success-background-hl: var(--b3-av-font-background4-hl);
 
     /* 为空提示 */
     --b3-empty-color: var(--b3-theme-on-surface);

--- a/app/appearance/themes/midnight/theme.css
+++ b/app/appearance/themes/midnight/theme.css
@@ -63,23 +63,6 @@
     --b3-av-hover: #2a2a2a;
     --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #28324e;
-    --b3-av-font-background1-hl: rgb(64, 56, 82);
-    --b3-av-font-background2-hl: rgb(78, 81, 96);
-    --b3-av-font-background3-hl: rgb(43, 76, 126);
-    --b3-av-font-background4-hl: rgb(63, 91, 109);
-    --b3-av-font-background5-hl: rgb(71, 90, 121);
-    --b3-av-font-background6-hl: rgb(21, 74, 159);
-    --b3-av-font-background7-hl: rgb(81, 70, 58);
-    --b3-av-font-background8-hl: rgb(77, 45, 68);
-    --b3-av-font-background9-hl: rgb(94, 31, 95);
-    --b3-av-font-background10-hl: rgb(95, 62, 137);
-    --b3-av-font-background11-hl: rgb(55, 106, 86);
-    --b3-av-font-background12-hl: rgb(111, 71, 59);
-    --b3-av-font-background13-hl: rgb(181, 195, 223);
-    --b3-av-card-error-background-hl: var(--b3-av-font-background1-hl);
-    --b3-av-card-warning-background-hl: var(--b3-av-font-background2-hl);
-    --b3-av-card-info-background-hl: var(--b3-av-font-background3-hl);
-    --b3-av-card-success-background-hl: var(--b3-av-font-background4-hl);
 
     /* 为空提示 */
     --b3-empty-color: var(--b3-theme-on-surface);
@@ -91,15 +74,19 @@
     --b3-card-error-color: rgb(243, 153, 147);
     --b3-card-error-background: #442724;
     --b3-card-error-background-select: rgb(66, 48, 60);
+    --b3-card-error-background-hl: rgb(64, 56, 82);
     --b3-card-warning-color: rgb(255, 213, 153);
     --b3-card-warning-background: #554636;
     --b3-card-warning-background-select: rgb(81, 76, 76);
+    --b3-card-warning-background-hl: rgb(78, 81, 96);
     --b3-card-info-color: rgb(166, 213, 250);
     --b3-card-info-background: #28405c;
     --b3-card-info-background-select: rgb(42, 70, 110);
+    --b3-card-info-background-hl: rgb(43, 76, 126);
     --b3-card-success-color: rgb(183, 223, 185);
     --b3-card-success-background: #425347;
     --b3-card-success-background-select: rgb(64, 87, 91);
+    --b3-card-success-background-hl: rgb(63, 91, 109);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -141,6 +128,19 @@
     --b3-font-background11-select: rgb(55, 104, 65);
     --b3-font-background12-select: rgb(119, 65, 34);
     --b3-font-background13-select: var(--b3-theme-on-background-select);
+    --b3-font-background1-hl: var(--b3-card-error-background-hl);
+    --b3-font-background2-hl: var(--b3-card-warning-background-hl);
+    --b3-font-background3-hl: var(--b3-card-info-background-hl);
+    --b3-font-background4-hl: var(--b3-card-success-background-hl);
+    --b3-font-background5-hl: rgb(71, 90, 121);
+    --b3-font-background6-hl: rgb(21, 74, 159);
+    --b3-font-background7-hl: rgb(81, 70, 58);
+    --b3-font-background8-hl: rgb(77, 45, 68);
+    --b3-font-background9-hl: rgb(94, 31, 95);
+    --b3-font-background10-hl: rgb(95, 62, 137);
+    --b3-font-background11-hl: rgb(55, 106, 86);
+    --b3-font-background12-hl: rgb(111, 71, 59);
+    --b3-font-background13-hl: rgb(181, 195, 223);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;

--- a/app/appearance/themes/midnight/theme.css
+++ b/app/appearance/themes/midnight/theme.css
@@ -115,6 +115,7 @@
     --b3-font-background11: #376629;
     --b3-font-background12: #803a06;
     --b3-font-background13: var(--b3-theme-on-background);
+    /* -select 是与 --b3-theme-primary-lightest 混合后的颜色 */
     --b3-font-background1-select: var(--b3-card-error-background-select);
     --b3-font-background2-select: var(--b3-card-warning-background-select);
     --b3-font-background3-select: var(--b3-card-info-background-select);
@@ -128,6 +129,7 @@
     --b3-font-background11-select: rgb(55, 104, 65);
     --b3-font-background12-select: rgb(119, 65, 34);
     --b3-font-background13-select: var(--b3-theme-on-background-select);
+    /* -hl 是 -select 与 --b3-theme-primary-lightest 再次混合后的颜色 */
     --b3-font-background1-hl: var(--b3-card-error-background-hl);
     --b3-font-background2-hl: var(--b3-card-warning-background-hl);
     --b3-font-background3-hl: var(--b3-card-info-background-hl);

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -643,12 +643,13 @@ $backgrounds: (
     }
   }
 }
-// 某种情况下 .protyle-wysiwyg--hl 是 .protyle-wysiwyg--select 的子元素，--b3-av-background 需要再叠加一层 --b3-theme-primary-lightest
+// 某种情况下 .protyle-wysiwyg--hl 和 .protyle-wysiwyg--select 会叠加，--b3-av-background 需要再叠加一层 --b3-theme-primary-lightest
+// .protyle-wysiwyg--select 在外，.protyle-wysiwyg--hl 在内
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 在 选中块 的外层
+    // 带背景色的块 在 两个选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       .protyle-wysiwyg--select .protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-hl-variable});
@@ -660,9 +661,52 @@ $backgrounds: (
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 就是 选中块
+    // 带背景色的块 在 两个选中块 的中间，并且是靠外层的选中块
+    .protyle-wysiwyg--select[data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl {
+      --b3-av-background: var(#{$bg-hl-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
+    // 带背景色的块 在 两个选中块 的中间
+    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl {
+      --b3-av-background: var(#{$bg-hl-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
+    // 带背景色的块 在 两个选中块 的中间，并且是靠内层的选中块
+    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"].protyle-wysiwyg--hl {
+      --b3-av-background: var(#{$bg-hl-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
+    // 带背景色的块 在 两个选中块 的内层
+    .protyle-wysiwyg--select .protyle-wysiwyg--hl {
+      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+        --b3-av-background: var(#{$bg-hl-variable});
+      }
+    }
+  }
+}
+// .protyle-wysiwyg--hl 在外，.protyle-wysiwyg--select 在内
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
+    // 带背景色的块 在 两个选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      &.protyle-wysiwyg--select .protyle-wysiwyg--hl {
+      .protyle-wysiwyg--hl .protyle-wysiwyg--select {
         --b3-av-background: var(#{$bg-hl-variable});
       }
     }
@@ -672,8 +716,38 @@ $backgrounds: (
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 在 选中块 的内层
-    .protyle-wysiwyg--select .protyle-wysiwyg--hl {
+    // 带背景色的块 在 两个选中块 的中间，并且是靠外层的选中块
+    .protyle-wysiwyg--hl[data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--select {
+      --b3-av-background: var(#{$bg-hl-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
+    // 带背景色的块 在 两个选中块 的中间
+    .protyle-wysiwyg--hl [data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--select {
+      --b3-av-background: var(#{$bg-hl-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
+    // 带背景色的块 在 两个选中块 的中间，并且是靠内层的选中块
+    .protyle-wysiwyg--hl [data-node-id][style*="background-color: var(#{$bg-variable})"].protyle-wysiwyg--select {
+      --b3-av-background: var(#{$bg-hl-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
+    // 带背景色的块 在 两个选中块 的内层
+    .protyle-wysiwyg--hl .protyle-wysiwyg--select {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
         --b3-av-background: var(#{$bg-hl-variable});
       }

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -537,7 +537,6 @@
 .protyle-wysiwyg--select {
   --b3-av-background: var(--b3-av-background-hl);
 }
-
 .protyle-wysiwyg--hl {
   --b3-av-background: var(--b3-av-background-hl);
   .av__row--header,
@@ -550,7 +549,6 @@
   .av__cell--active,
   .av__counter {
     transition: var(--b3-background-transition);
-    background-color: var(--b3-av-background-hl) !important;
   }
 }
 

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -537,6 +537,7 @@
 .protyle-wysiwyg--select {
   --b3-av-background: var(--b3-av-background-hl);
 }
+
 .protyle-wysiwyg--hl {
   --b3-av-background: var(--b3-av-background-hl);
   .av__row--header,

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -647,11 +647,11 @@ $backgrounds: (
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-av-#{$key}-hl", "--b3-av-#{$key}#{$i}-hl");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 在 选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       .protyle-wysiwyg--select .protyle-wysiwyg--hl {
-        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-background: var(#{$bg-hl-variable});
       }
     }
   }
@@ -659,11 +659,11 @@ $backgrounds: (
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-av-#{$key}-hl", "--b3-av-#{$key}#{$i}-hl");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 就是 选中块
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       &.protyle-wysiwyg--select .protyle-wysiwyg--hl {
-        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-background: var(#{$bg-hl-variable});
       }
     }
   }
@@ -671,11 +671,11 @@ $backgrounds: (
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-av-#{$key}-hl", "--b3-av-#{$key}#{$i}-hl");
+    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 在 选中块 的内层
     .protyle-wysiwyg--select .protyle-wysiwyg--hl {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-background: var(#{$bg-hl-variable});
       }
     }
   }

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -577,7 +577,42 @@ $backgrounds: (
     $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
     // 带背景色的块 在 选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      .protyle-wysiwyg--select,
+      .protyle-wysiwyg--select {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 就是 选中块
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      &.protyle-wysiwyg--select {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 在 选中块 的内层
+    .protyle-wysiwyg--select {
+      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 在 选中块 的外层
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       .protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-select-variable});
       }
@@ -590,7 +625,6 @@ $backgrounds: (
     $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
     // 带背景色的块 就是 选中块
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      &.protyle-wysiwyg--select ,
       &.protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-select-variable});
       }
@@ -602,7 +636,6 @@ $backgrounds: (
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
     // 带背景色的块 在 选中块 的内层
-    .protyle-wysiwyg--select,
     .protyle-wysiwyg--hl {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
         --b3-av-background: var(#{$bg-select-variable});

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -611,8 +611,7 @@ $backgrounds: (
   }
 }
 // 某种情况下 .protyle-wysiwyg--hl 和 .protyle-wysiwyg--select 会叠加，--b3-av-background 需要再叠加一层 --b3-theme-primary-lightest
-// .protyle-wysiwyg--select 在外，.protyle-wysiwyg--hl 在内
-// .protyle-wysiwyg--hl 在外，.protyle-wysiwyg--select 在内
+// ".protyle-wysiwyg--select 在外，.protyle-wysiwyg--hl 在内"与".protyle-wysiwyg--hl 在外，.protyle-wysiwyg--select 在内"两种情况
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -534,8 +534,6 @@
   }
 }
 
-// https://github.com/siyuan-note/siyuan/pull/12706
-// 给 .av__container 添加(更新) style="--av-background:var(xxx)" 的逻辑可以删除掉，用不上 --av-background 了
 .protyle-wysiwyg--select {
   --b3-av-background: var(--b3-av-background-hl);
   .av__row--header,
@@ -567,6 +565,7 @@
   }
 }
 
+// https://github.com/siyuan-note/siyuan/pull/12706
 $backgrounds: (
   "font-background" 13,
   "card-error-background" 1,

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -534,7 +534,7 @@
   }
 }
 
-// https://github.com/siyuan-note/siyuan/pull/12643
+// https://github.com/siyuan-note/siyuan/pull/12706
 // 给 .av__container 添加(更新) style="--av-background:var(xxx)" 的逻辑可以删除掉，用不上 --av-background 了
 .protyle-wysiwyg--select {
     --b3-av-background: var(--b3-av-background-hl);

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -537,10 +537,10 @@
 // https://github.com/siyuan-note/siyuan/pull/12706
 // 给 .av__container 添加(更新) style="--av-background:var(xxx)" 的逻辑可以删除掉，用不上 --av-background 了
 .protyle-wysiwyg--select {
-    --b3-av-background: var(--b3-av-background-hl);
+  --b3-av-background: var(--b3-av-background-hl);
 }
 .protyle-wysiwyg--hl {
-    --b3-av-background: var(--b3-av-background-hl);
+  --b3-av-background: var(--b3-av-background-hl);
   .av__row--header,
   .av__row--footer,
   .av__row--footer .av__colsticky,
@@ -565,7 +565,7 @@ $backgrounds: (
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
-    // 没有 选中块 时从最近的 带背景色的父块 继承
+    // 没有 选中块 时从最近的 带背景色的父块 继承（包括数据库块本身）
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       --b3-av-background: var(#{$bg-variable});
     }
@@ -643,14 +643,14 @@ $backgrounds: (
     }
   }
 }
-// 某种情况下 .protyle-wysiwyg--hl 是 .protyle-wysiwyg--select 的父元素，数据库的 --b3-av-background 不能继承 .protyle-wysiwyg--select 的
+// 某种情况下 .protyle-wysiwyg--hl 是 .protyle-wysiwyg--select 的子元素，--b3-av-background 需要再叠加一层 --b3-theme-primary-lightest
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    $bg-select-variable: if($count == 1, "--b3-av-#{$key}-hl", "--b3-av-#{$key}#{$i}-hl");
     // 带背景色的块 在 选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      .protyle-wysiwyg--hl .protyle-wysiwyg--select {
+      .protyle-wysiwyg--select .protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-select-variable});
       }
     }
@@ -659,10 +659,10 @@ $backgrounds: (
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    $bg-select-variable: if($count == 1, "--b3-av-#{$key}-hl", "--b3-av-#{$key}#{$i}-hl");
     // 带背景色的块 就是 选中块
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      &.protyle-wysiwyg--hl .protyle-wysiwyg--select {
+      &.protyle-wysiwyg--select .protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-select-variable});
       }
     }
@@ -671,9 +671,9 @@ $backgrounds: (
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    $bg-select-variable: if($count == 1, "--b3-av-#{$key}-hl", "--b3-av-#{$key}#{$i}-hl");
     // 带背景色的块 在 选中块 的内层
-    .protyle-wysiwyg--hl .protyle-wysiwyg--select {
+    .protyle-wysiwyg--select .protyle-wysiwyg--hl {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
         --b3-av-background: var(#{$bg-select-variable});
       }

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -614,7 +614,7 @@ $backgrounds: (
     // 带背景色的块 在 选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       .protyle-wysiwyg--hl {
-        --b3-av-background: var(#{$bg-select-variable}) !important;
+        --b3-av-background: var(#{$bg-select-variable});
       }
     }
   }
@@ -626,7 +626,7 @@ $backgrounds: (
     // 带背景色的块 就是 选中块
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       &.protyle-wysiwyg--hl {
-        --b3-av-background: var(#{$bg-select-variable}) !important;
+        --b3-av-background: var(#{$bg-select-variable});
       }
     }
   }
@@ -638,7 +638,44 @@ $backgrounds: (
     // 带背景色的块 在 选中块 的内层
     .protyle-wysiwyg--hl {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-        --b3-av-background: var(#{$bg-select-variable}) !important;
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+// 某种情况下 .protyle-wysiwyg--hl 是 .protyle-wysiwyg--select 的父元素，数据库的 --b3-av-background 不能继承 .protyle-wysiwyg--select 的
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 在 选中块 的外层
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      .protyle-wysiwyg--hl .protyle-wysiwyg--select {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 就是 选中块
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      &.protyle-wysiwyg--hl .protyle-wysiwyg--select {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 在 选中块 的内层
+    .protyle-wysiwyg--hl .protyle-wysiwyg--select {
+      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+        --b3-av-background: var(#{$bg-select-variable});
       }
     }
   }

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -577,42 +577,7 @@ $backgrounds: (
     $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
     // 带背景色的块 在 选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      .protyle-wysiwyg--select {
-        --b3-av-background: var(#{$bg-select-variable});
-      }
-    }
-  }
-}
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
-    // 带背景色的块 就是 选中块
-    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      &.protyle-wysiwyg--select {
-        --b3-av-background: var(#{$bg-select-variable});
-      }
-    }
-  }
-}
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
-    // 带背景色的块 在 选中块 的内层
-    .protyle-wysiwyg--select {
-      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-        --b3-av-background: var(#{$bg-select-variable});
-      }
-    }
-  }
-}
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
-    // 带背景色的块 在 选中块 的外层
-    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      .protyle-wysiwyg--select,
       .protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-select-variable});
       }
@@ -625,7 +590,8 @@ $backgrounds: (
     $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
     // 带背景色的块 就是 选中块
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      &.protyle-wysiwyg--hl {
+      &.protyle-wysiwyg--select,
+      .protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-select-variable});
       }
     }
@@ -636,6 +602,7 @@ $backgrounds: (
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
     // 带背景色的块 在 选中块 的内层
+    .protyle-wysiwyg--select,
     .protyle-wysiwyg--hl {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
         --b3-av-background: var(#{$bg-select-variable});

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -536,17 +536,6 @@
 
 .protyle-wysiwyg--select {
   --b3-av-background: var(--b3-av-background-hl);
-  .av__row--header,
-  .av__row--footer,
-  .av__row--footer .av__colsticky,
-  .av__row--select .av__cell,
-  .av__colsticky.av__firstcol,
-  .av__colsticky > div,
-  .av__cell--select,
-  .av__cell--active,
-  .av__counter {
-    background-color: var(--b3-av-background-hl) !important;
-  }
 }
 
 .protyle-wysiwyg--hl {

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -97,7 +97,7 @@
     bottom: 0;
     height: 26px;
     padding: 0 5px;
-    background-color: var(--av-background);
+    background-color: var(--b3-av-background);
     font-size: 87.5%;
   }
 
@@ -160,7 +160,7 @@
 
     &--header,
     &--footer {
-      background-color: var(--av-background);
+      background-color: var(--b3-av-background);
     }
 
     &--footer {
@@ -176,7 +176,7 @@
       }
 
       .av__colsticky {
-        background-color: var(--av-background); // 保证盯住时无计算结果的列不被覆盖
+        background-color: var(--b3-av-background); // 保证钉住时无计算结果的列不被覆盖
       }
 
       .av__calc {
@@ -434,7 +434,14 @@
 
     &.av__firstcol,
     & > div:not(.av__cell--select):not(.av__cell--active):not(.av__calc--ashow) {
-      background-color: var(--av-background);
+      background-color: var(--b3-av-background);
+
+      &.av__cell--header:hover {
+        background-color: var(--b3-av-hover);
+      }
+      &.av__calc:hover {
+        background-color: var(--b3-av-hover);
+      }
     }
   }
 
@@ -527,7 +534,13 @@
   }
 }
 
+// https://github.com/siyuan-note/siyuan/pull/12643
+// 给 .av__container 添加(更新) style="--av-background:var(xxx)" 的逻辑可以删除掉，用不上 --av-background 了
 .protyle-wysiwyg--select {
+    --b3-av-background: var(--b3-av-background-hl);
+}
+.protyle-wysiwyg--hl {
+    --b3-av-background: var(--b3-av-background-hl);
   .av__row--header,
   .av__row--footer,
   .av__row--footer .av__colsticky,
@@ -537,22 +550,64 @@
   .av__cell--select,
   .av__cell--active,
   .av__counter {
-    background-color: var(--b3-av-background-hl) !important;
+    transition: var(--b3-background-transition);
   }
 }
 
-.protyle-wysiwyg--hl {
-  .av__row--header,
-  .av__row--footer,
-  .av__row--footer .av__colsticky,
-  .av__row--select .av__cell,
-  .av__colsticky.av__firstcol,
-  .av__colsticky > div,
-  .av__cell--select,
-  .av__cell--active,
-  .av__counter {
-    background-color: var(--b3-av-background-hl) !important;
-    transition: var(--b3-background-transition);
+$backgrounds: (
+  "font-background" 13,
+  "card-error-background" 1,
+  "card-warning-background" 1,
+  "card-info-background" 1,
+  "card-success-background" 1,
+);
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 没有 选中块 时从最近的 带背景色的父块 继承
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      --b3-av-background: var(#{$bg-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 在 选中块 的外层
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      .protyle-wysiwyg--select,
+      .protyle-wysiwyg--hl {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 就是 选中块
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      &.protyle-wysiwyg--select ,
+      &.protyle-wysiwyg--hl {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    // 带背景色的块 在 选中块 的内层
+    .protyle-wysiwyg--select,
+    .protyle-wysiwyg--hl {
+      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+        --b3-av-background: var(#{$bg-select-variable});
+      }
+    }
   }
 }
 

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -645,60 +645,6 @@ $backgrounds: (
 }
 // 某种情况下 .protyle-wysiwyg--hl 和 .protyle-wysiwyg--select 会叠加，--b3-av-background 需要再叠加一层 --b3-theme-primary-lightest
 // .protyle-wysiwyg--select 在外，.protyle-wysiwyg--hl 在内
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 在 两个选中块 的外层
-    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-      .protyle-wysiwyg--select .protyle-wysiwyg--hl {
-        --b3-av-background: var(#{$bg-hl-variable});
-      }
-    }
-  }
-}
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 在 两个选中块 的中间，并且是靠外层的选中块
-    .protyle-wysiwyg--select[data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl {
-      --b3-av-background: var(#{$bg-hl-variable});
-    }
-  }
-}
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 在 两个选中块 的中间
-    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl {
-      --b3-av-background: var(#{$bg-hl-variable});
-    }
-  }
-}
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 在 两个选中块 的中间，并且是靠内层的选中块
-    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"].protyle-wysiwyg--hl {
-      --b3-av-background: var(#{$bg-hl-variable});
-    }
-  }
-}
-@each $key, $count in $backgrounds {
-  @for $i from 1 through $count {
-    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
-    $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
-    // 带背景色的块 在 两个选中块 的内层
-    .protyle-wysiwyg--select .protyle-wysiwyg--hl {
-      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-        --b3-av-background: var(#{$bg-hl-variable});
-      }
-    }
-  }
-}
 // .protyle-wysiwyg--hl 在外，.protyle-wysiwyg--select 在内
 @each $key, $count in $backgrounds {
   @for $i from 1 through $count {
@@ -706,6 +652,7 @@ $backgrounds: (
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 在 两个选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      .protyle-wysiwyg--select .protyle-wysiwyg--hl,
       .protyle-wysiwyg--hl .protyle-wysiwyg--select {
         --b3-av-background: var(#{$bg-hl-variable});
       }
@@ -717,6 +664,7 @@ $backgrounds: (
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 在 两个选中块 的中间，并且是靠外层的选中块
+    .protyle-wysiwyg--select[data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl,
     .protyle-wysiwyg--hl[data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--select {
       --b3-av-background: var(#{$bg-hl-variable});
     }
@@ -727,6 +675,7 @@ $backgrounds: (
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 在 两个选中块 的中间
+    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl,
     .protyle-wysiwyg--hl [data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--select {
       --b3-av-background: var(#{$bg-hl-variable});
     }
@@ -737,6 +686,7 @@ $backgrounds: (
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 在 两个选中块 的中间，并且是靠内层的选中块
+    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"].protyle-wysiwyg--hl,
     .protyle-wysiwyg--hl [data-node-id][style*="background-color: var(#{$bg-variable})"].protyle-wysiwyg--select {
       --b3-av-background: var(#{$bg-hl-variable});
     }
@@ -747,6 +697,7 @@ $backgrounds: (
     $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
     $bg-hl-variable: if($count == 1, "--b3-#{$key}-hl", "--b3-#{$key}#{$i}-hl");
     // 带背景色的块 在 两个选中块 的内层
+    .protyle-wysiwyg--select .protyle-wysiwyg--hl,
     .protyle-wysiwyg--hl .protyle-wysiwyg--select {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
         --b3-av-background: var(#{$bg-hl-variable});

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -550,6 +550,7 @@
     background-color: var(--b3-av-background-hl) !important;
   }
 }
+
 .protyle-wysiwyg--hl {
   --b3-av-background: var(--b3-av-background-hl);
   .av__row--header,
@@ -562,6 +563,7 @@
   .av__cell--active,
   .av__counter {
     transition: var(--b3-background-transition);
+    background-color: var(--b3-av-background-hl) !important;
   }
 }
 

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -538,6 +538,17 @@
 // 给 .av__container 添加(更新) style="--av-background:var(xxx)" 的逻辑可以删除掉，用不上 --av-background 了
 .protyle-wysiwyg--select {
   --b3-av-background: var(--b3-av-background-hl);
+  .av__row--header,
+  .av__row--footer,
+  .av__row--footer .av__colsticky,
+  .av__row--select .av__cell,
+  .av__colsticky.av__firstcol,
+  .av__colsticky > div,
+  .av__cell--select,
+  .av__cell--active,
+  .av__counter {
+    background-color: var(--b3-av-background-hl) !important;
+  }
 }
 .protyle-wysiwyg--hl {
   --b3-av-background: var(--b3-av-background-hl);

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -591,7 +591,7 @@ $backgrounds: (
     // 带背景色的块 就是 选中块
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       &.protyle-wysiwyg--select,
-      .protyle-wysiwyg--hl {
+      &.protyle-wysiwyg--hl {
         --b3-av-background: var(#{$bg-select-variable});
       }
     }

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -614,7 +614,7 @@ $backgrounds: (
     // 带背景色的块 在 选中块 的外层
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       .protyle-wysiwyg--hl {
-        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-background: var(#{$bg-select-variable}) !important;
       }
     }
   }
@@ -626,7 +626,7 @@ $backgrounds: (
     // 带背景色的块 就是 选中块
     [data-node-id][style*="background-color: var(#{$bg-variable})"] {
       &.protyle-wysiwyg--hl {
-        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-background: var(#{$bg-select-variable}) !important;
       }
     }
   }
@@ -638,7 +638,7 @@ $backgrounds: (
     // 带背景色的块 在 选中块 的内层
     .protyle-wysiwyg--hl {
       [data-node-id][style*="background-color: var(#{$bg-variable})"] {
-        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-background: var(#{$bg-select-variable}) !important;
       }
     }
   }

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -462,6 +462,19 @@
     }
   }
 
+  &--select {
+    background-color: var(--b3-theme-primary-lightest) !important;
+  }
+  &--hl {
+    transition: var(--b3-background-transition);
+    background-color: var(--b3-theme-primary-lightest) !important;
+
+    [data-node-id],
+    &[data-node-id] {
+        transition: var(--b3-background-transition);
+      }
+    }
+  }
   // https://github.com/siyuan-note/siyuan/pull/12706
   $backgrounds: (
     "font-background": 13,
@@ -476,7 +489,6 @@
       $bg-select-variable: if($count == 1, var(--b3-#{$key}-select), var(--b3-#{$key}#{$i}-select));
 
       &--select {
-        background-color: var(--b3-theme-primary-lightest) !important;
         [data-node-id],
         &[data-node-id] {
           &[style*="background-color: #{$bg-variable}"] {
@@ -485,12 +497,9 @@
         }
       }
       &--hl {
-        transition: var(--b3-background-transition);
-        background-color: var(--b3-theme-primary-lightest) !important;
         [data-node-id],
         &[data-node-id] {
           &[style*="background-color: #{$bg-variable}"] {
-            transition: var(--b3-background-transition);
             background-color: #{$bg-select-variable} !important;
           }
         }

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -512,6 +512,14 @@
             background-color: #{$bg-select-variable} !important;
           }
         }
+        .protyle-wysiwyg--select {
+          [data-node-id],
+          &[data-node-id] {
+            &[style*="background-color: #{$bg-variable}"] {
+              background-color: #{$bg-hl-variable} !important;
+            }
+          }
+        }
       }
     }
   }

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -496,6 +496,7 @@
             background-color: #{$bg-select-variable} !important;
           }
         }
+        // 叠加两层高亮的样式
         .protyle-wysiwyg--hl {
           [data-node-id],
           &[data-node-id] {
@@ -512,6 +513,7 @@
             background-color: #{$bg-select-variable} !important;
           }
         }
+        // 叠加两层高亮的样式
         .protyle-wysiwyg--select {
           [data-node-id],
           &[data-node-id] {

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -487,12 +487,21 @@
     @for $i from 1 through $count {
       $bg-variable: if($count == 1, var(--b3-#{$key}), var(--b3-#{$key}#{$i}));
       $bg-select-variable: if($count == 1, var(--b3-#{$key}-select), var(--b3-#{$key}#{$i}-select));
+      $bg-hl-variable: if($count == 1, var(--b3-#{$key}-hl), var(--b3-#{$key}#{$i}-hl));
 
       &--select {
         [data-node-id],
         &[data-node-id] {
           &[style*="background-color: #{$bg-variable}"] {
             background-color: #{$bg-select-variable} !important;
+          }
+        }
+        &--hl {
+          [data-node-id],
+          &[data-node-id] {
+            &[style*="background-color: #{$bg-variable}"] {
+              background-color: #{$bg-hl-variable} !important;
+            }
           }
         }
       }

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -496,7 +496,7 @@
             background-color: #{$bg-select-variable} !important;
           }
         }
-        &--hl {
+        .protyle-wysiwyg--hl {
           [data-node-id],
           &[data-node-id] {
             &[style*="background-color: #{$bg-variable}"] {

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -462,7 +462,7 @@
     }
   }
 
-  // https://github.com/siyuan-note/siyuan/pull/12643
+  // https://github.com/siyuan-note/siyuan/pull/12706
   $backgrounds: (
     "font-background": 13,
     "card-error-background": 1,

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -462,70 +462,45 @@
     }
   }
 
-  &--select {
-    background-color: var(--b3-theme-primary-lightest) !important;
+  // https://github.com/siyuan-note/siyuan/pull/12643
+  $backgrounds: (
+    "font-background": 13,
+    "card-error-background": 1,
+    "card-warning-background": 1,
+    "card-info-background": 1,
+    "card-success-background": 1,
+  );
+  @each $key, $count in $backgrounds {
+    @for $i from 1 through $count {
+      $bg-variable: if($count == 1, var(--b3-#{$key}), var(--b3-#{$key}#{$i}));
+      $bg-select-variable: if($count == 1, var(--b3-#{$key}-select), var(--b3-#{$key}#{$i}-select));
 
-    [data-node-id][style*="background-color: var(--b3-font-background1)"] {
-      background-color: var(--b3-font-background1-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background2)"] {
-      background-color: var(--b3-font-background2-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background3)"] {
-      background-color: var(--b3-font-background3-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background4)"] {
-      background-color: var(--b3-font-background4-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background5)"] {
-      background-color: var(--b3-font-background5-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background6)"] {
-      background-color: var(--b3-font-background6-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background7)"] {
-      background-color: var(--b3-font-background7-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background8)"] {
-      background-color: var(--b3-font-background8-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background9)"] {
-      background-color: var(--b3-font-background9-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background10)"] {
-      background-color: var(--b3-font-background10-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background11)"] {
-      background-color: var(--b3-font-background11-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background12)"] {
-      background-color: var(--b3-font-background12-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background13)"] {
-      background-color: var(--b3-font-background13-rgba) !important;
+      &--select {
+        background-color: var(--b3-theme-primary-lightest) !important;
+        [data-node-id],
+        &[data-node-id] {
+          &[style*="background-color: #{$bg-variable}"] {
+            background-color: #{$bg-select-variable} !important;
+          }
+        }
+      }
+      &--hl {
+        transition: var(--b3-background-transition);
+        background-color: var(--b3-theme-primary-lightest) !important;
+        [data-node-id],
+        &[data-node-id] {
+          &[style*="background-color: #{$bg-variable}"] {
+            transition: var(--b3-background-transition);
+            background-color: #{$bg-select-variable} !important;
+          }
+        }
+      }
     }
   }
 
   // https://github.com/siyuan-note/siyuan/issues/11589
   .hljs wbr {
     display: none;
-  }
-
-  &--hl {
-    transition: var(--b3-background-transition);
-    background-color: var(--b3-theme-primary-lightest) !important;
   }
 
   .dragover {

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -473,8 +473,8 @@
     &[data-node-id] {
         transition: var(--b3-background-transition);
       }
-    }
   }
+
   // https://github.com/siyuan-note/siyuan/pull/12706
   $backgrounds: (
     "font-background": 13,


### PR DESCRIPTION
> 备注：要考虑在嵌入块中显示的数据库块

### 选中块时，使当前块和子块的颜色都变深

我发现在选中“带背景色的块的子块”（左）和选中“带背景色的块的父块”（右）时，背景色与高亮叠加之后的颜色是不同的：

![image](https://github.com/user-attachments/assets/a9d27ce5-638c-47ba-9a0c-715d8c0012d5)

然后我研究了一下 Notion 发现带颜色的块被选中之后颜色是会变得更深的（颜色叠加）：

![image](https://github.com/user-attachments/assets/0b5e8ee9-68d4-4302-b102-416e2f19262b)

所以说之前 https://github.com/siyuan-note/siyuan/commit/11386294056d511ee0127b92daed9418254be255 和 https://github.com/siyuan-note/siyuan/pull/12579 的颜色处理都不对，不应该让原来的背景色变浅，而是应该叠加颜色后变深

#### 颜色算法：

<details>
<summary>透明度混合算法</summary>

参考：[RGBA alpha 透明度混合算法实现和测试 - 小张的笔记](https://blog.zhangyirui.cn/2023/12/04/transparency-blending-algorithm/)

### 明亮主题

```js
function mixColors(rgba1, rgba2) {
    const [R1, G1, B1, Alpha1] = rgba1;
    const [R2, G2, B2, Alpha2] = rgba2;

    const Alpha = 1 - (1 - Alpha1) * (1 - Alpha2);
    const R = (R1 * Alpha1 + R2 * Alpha2 * (1 - Alpha1)) / Alpha;
    const G = (G1 * Alpha1 + G2 * Alpha2 * (1 - Alpha1)) / Alpha;
    const B = (B1 * Alpha1 + B2 * Alpha2 * (1 - Alpha1)) / Alpha;

    return [Math.round(R), Math.round(G), Math.round(B)];
}

const baseColor = [53, 117, 240, 0.12];
const backgroundColors = [
    [245, 209, 207, 1],
    [255, 232, 200, 1],
    [214, 234, 249, 1],
    [215, 238, 216, 1],
    [226, 227, 228, 1],
    [172, 208, 252, 1],
    [253, 238, 214, 1],
    [250, 225, 207, 1],
    [253, 213, 231, 1],
    [230, 199, 230, 1],
    [222, 240, 217, 1],
    [250, 227, 228, 1],
    [34, 34, 34, 1],
];

const results = backgroundColors.map((background, index) => {
    const mixedColor = mixColors(baseColor, background);
    return `--b3-font-background${index + 1}-select: rgb(${mixedColor[0]}, ${mixedColor[1]}, ${mixedColor[2]});`;
});

// 输出所有结果的字符串，用换行符连接
console.log(results.join('\n'));
```

### 暗黑主题

```js
function mixColors(rgba1, rgba2) {
    const [R1, G1, B1, Alpha1] = rgba1;
    const [R2, G2, B2, Alpha2] = rgba2;

    const Alpha = 1 - (1 - Alpha1) * (1 - Alpha2);
    const R = (R1 * Alpha1 + R2 * Alpha2 * (1 - Alpha1)) / Alpha;
    const G = (G1 * Alpha1 + G2 * Alpha2 * (1 - Alpha1)) / Alpha;
    const B = (B1 * Alpha1 + B2 * Alpha2 * (1 - Alpha1)) / Alpha;

    return [Math.round(R), Math.round(G), Math.round(B)];
}

const baseColor = [53, 117, 240, 0.12];
const backgroundColors = [
    [68, 39, 36, 1],
    [85, 70, 54, 1],
    [40, 64, 92, 1],
    [66, 83, 71, 1],
    [76, 82, 87, 1],
    [12, 61, 136, 1],
    [89, 57, 5, 1],
    [84, 24, 18, 1],
    [106, 6, 52, 1],
    [107, 47, 107, 1],
    [55, 102, 41, 1],
    [128, 58, 6, 1],
    [218, 218, 218, 1],
];

const results = backgroundColors.map((background, index) => {
    const mixedColor = mixColors(baseColor, background);
    return `--b3-font-background${index + 1}-select: rgb(${mixedColor[0]}, ${mixedColor[1]}, ${mixedColor[2]});`;
});

// 输出所有结果的字符串，用换行符连接
console.log(results.join('\n'));
```

</details>

### 多选块之后，将鼠标移动到父块或子块的块标，高亮的背景色会再叠加一次高亮

用途是判断块标对应的块，尽量避免拖拽错误的块标：https://github.com/siyuan-note/siyuan/issues/11882#issuecomment-2209349005

颜色的计算也是用上面那个颜色混合算法。

### 解决了数据库子元素颜色不一致的问题：

#### 01

   之前存在的问题：

   ![image](https://github.com/user-attachments/assets/2da4b90f-c06a-41ec-b830-6c0c3047e37a)

   本 PR 修改后：

   ![image](https://github.com/user-attachments/assets/3ea533dc-ed00-4d15-ac64-e2c13566d9bd)

#### 02 hover 的时候只有非固定列的背景色会变，修复了：

   ![image](https://github.com/user-attachments/assets/6ad4962a-5ebb-4e13-8448-352b87e9354b)