### PR TITLE
Improve the styling of the selected blocks

### DIFF
--- a/app/appearance/themes/daylight/theme.css
+++ b/app/appearance/themes/daylight/theme.css
@@ -4,6 +4,7 @@
     --b3-theme-primary-light: rgba(53, 117, 240, .54);
     --b3-theme-primary-lighter: rgba(53, 117, 240, .38);
     --b3-theme-primary-lightest: rgba(53, 117, 240, .12);
+    --b3-theme-primary-lightest-light: rgba(53, 117, 240, .03);
     --b3-theme-secondary: #f3a92f;
     --b3-theme-background: #fff;
     --b3-theme-background-light: #dfe0e1;
@@ -18,6 +19,8 @@
     --b3-theme-on-secondary: #fff;
     --b3-theme-on-background: #222;
     --b3-theme-on-background-select: rgb(36, 44, 59);
+    --b3-theme-on-background-select-double: rgb(38, 53, 81);
+    --b3-theme-on-background-av-hover: rgb(31, 31, 31);
     --b3-theme-on-surface: #5f6368;
     --b3-theme-on-surface-light: rgba(95, 99, 104, .68);
     --b3-theme-on-error: #fff;
@@ -61,7 +64,8 @@
     --b3-tooltips-shadow: 0 2px 8px rgba(0, 0, 0, .1);
 
     /* av */
-    --b3-av-hover: #e8e8e9;
+    --b3-av-hover: rgb(236, 236, 236); /* 初始值为 --b3-theme-background 混合 --b3-list-hover */
+    --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #e8eefc;
 
     /* 为空提示 */
@@ -75,18 +79,22 @@
     --b3-card-error-background: #f5d1cf;
     --b3-card-error-background-select: rgb(222, 198, 211);
     --b3-card-error-background-select-double: rgb(202, 188, 214);
+    --b3-card-error-background-av-hover: rgb(227, 193, 191);
     --b3-card-warning-color: rgb(102, 60, 0);
     --b3-card-warning-background: #ffe8c8;
     --b3-card-warning-background-select: rgb(231, 218, 205);
     --b3-card-warning-background-select-double: rgb(210, 206, 209);
+    --b3-card-warning-background-av-hover: rgb(236, 215, 185);
     --b3-card-info-color: rgb(13, 60, 97);
     --b3-card-info-background: #d6eaf9;
     --b3-card-info-background-select: rgb(195, 220, 248);
     --b3-card-info-background-select-double: rgb(178, 208, 247);
+    --b3-card-info-background-av-hover: rgb(198, 216, 230);
     --b3-card-success-color: rgb(30, 70, 32);
     --b3-card-success-background: #d7eed8;
     --b3-card-success-background-select: rgb(196, 223, 219);
     --b3-card-success-background-select-double: rgb(179, 210, 222);
+    --b3-card-success-background-av-hover: rgb(199, 220, 200);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -142,7 +150,21 @@
     --b3-font-background10-select-double: rgb(190, 180, 232);
     --b3-font-background11-select-double: rgb(184, 212, 222);
     --b3-font-background12-select-double: rgb(205, 202, 230);
-    --b3-font-background13-select-double: rgb(38, 53, 81);
+    --b3-font-background13-select-double: var(--b3-theme-on-background-select-double);
+    /* -av-hover 是块的背景色与 --b3-list-hover 混合后的颜色 */
+    --b3-font-background1-av-hover: var(--b3-card-error-background-av-hover);
+    --b3-font-background2-av-hover: var(--b3-card-warning-background-av-hover);
+    --b3-font-background3-av-hover: var(--b3-card-info-background-av-hover);
+    --b3-font-background4-av-hover: var(--b3-card-success-background-av-hover);
+    --b3-font-background5-av-hover: rgb(209, 210, 211);
+    --b3-font-background6-av-hover: rgb(159, 192, 233);
+    --b3-font-background7-av-hover: rgb(234, 220, 198);
+    --b3-font-background8-av-hover: rgb(231, 208, 191);
+    --b3-font-background9-av-hover: rgb(234, 197, 214);
+    --b3-font-background10-av-hover: rgb(213, 184, 213);
+    --b3-font-background11-av-hover: rgb(205, 222, 201);
+    --b3-font-background12-av-hover: rgb(231, 210, 211);
+    --b3-font-background13-av-hover: var(--b3-theme-on-background-av-hover);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;

--- a/app/appearance/themes/daylight/theme.css
+++ b/app/appearance/themes/daylight/theme.css
@@ -17,7 +17,7 @@
     --b3-theme-on-primary: #fff;
     --b3-theme-on-secondary: #fff;
     --b3-theme-on-background: #222;
-    --b3-theme-on-background-rgba: rgb(34, 34, 34, .86);
+    --b3-theme-on-background-select: rgb(36, 44, 59);
     --b3-theme-on-surface: #5f6368;
     --b3-theme-on-surface-light: rgba(95, 99, 104, .68);
     --b3-theme-on-error: #fff;
@@ -73,16 +73,20 @@
     /* 卡片背景 */
     --b3-card-error-color: rgb(97, 26, 21);
     --b3-card-error-background: #f5d1cf;
-    --b3-card-error-background-rgba: rgb(245, 209, 207, .86);
+    --b3-card-error-background-select: rgb(222, 198, 211);
+    --b3-card-error-background-select-double: rgb(202, 188, 214);
     --b3-card-warning-color: rgb(102, 60, 0);
     --b3-card-warning-background: #ffe8c8;
-    --b3-card-warning-background-rgba: rgb(255, 232, 200, .86);
+    --b3-card-warning-background-select: rgb(231, 218, 205);
+    --b3-card-warning-background-select-double: rgb(210, 206, 209);
     --b3-card-info-color: rgb(13, 60, 97);
     --b3-card-info-background: #d6eaf9;
-    --b3-card-info-background-rgba: rgb(214, 234, 249, .86);
+    --b3-card-info-background-select: rgb(195, 220, 248);
+    --b3-card-info-background-select-double: rgb(178, 208, 247);
     --b3-card-success-color: rgb(30, 70, 32);
     --b3-card-success-background: #d7eed8;
-    --b3-card-success-background-rgba: rgb(215, 238, 216, .86);
+    --b3-card-success-background-select: rgb(196, 223, 219);
+    --b3-card-success-background-select-double: rgb(179, 210, 222);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -111,19 +115,34 @@
     --b3-font-background11: #def0d9;
     --b3-font-background12: #fae3e4;
     --b3-font-background13: var(--b3-theme-on-background);
-    --b3-font-background1-rgba: var(--b3-card-error-background-rgba);
-    --b3-font-background2-rgba: var(--b3-card-warning-background-rgba);
-    --b3-font-background3-rgba: var(--b3-card-info-background-rgba);
-    --b3-font-background4-rgba: var(--b3-card-success-background-rgba);
-    --b3-font-background5-rgba: rgb(226, 227, 228, .86);
-    --b3-font-background6-rgba: rgb(172, 208, 252, .86);
-    --b3-font-background7-rgba: rgb(253, 238, 214, .86);
-    --b3-font-background8-rgba: rgb(250, 225, 207, .86);
-    --b3-font-background9-rgba: rgb(253, 213, 231, .86);
-    --b3-font-background10-rgba: rgb(230, 199, 230, .86);
-    --b3-font-background11-rgba: rgb(222, 240, 217, .86);
-    --b3-font-background12-rgba: rgb(250, 227, 228, .86);
-    --b3-font-background13-rgba: var(--b3-theme-on-background-rgba);
+    /* -select 是块的背景色与 --b3-theme-primary-lightest 混合后的颜色 */
+    --b3-font-background1-select: var(--b3-card-error-background-select);
+    --b3-font-background2-select: var(--b3-card-warning-background-select);
+    --b3-font-background3-select: var(--b3-card-info-background-select);
+    --b3-font-background4-select: var(--b3-card-success-background-select);
+    --b3-font-background5-select: rgb(205, 214, 229);
+    --b3-font-background6-select: rgb(158, 197, 251);
+    --b3-font-background7-select: rgb(229, 223, 217);
+    --b3-font-background8-select: rgb(226, 212, 211);
+    --b3-font-background9-select: rgb(229, 201, 232);
+    --b3-font-background10-select: rgb(209, 189, 231);
+    --b3-font-background11-select: rgb(202, 225, 220);
+    --b3-font-background12-select: rgb(226, 214, 229);
+    --b3-font-background13-select: var(--b3-theme-on-background-select);
+    /* -select-double 是 -select 与 --b3-theme-primary-lightest 再次混合后的颜色 */
+    --b3-font-background1-select-double: var(--b3-card-error-background-select-double);
+    --b3-font-background2-select-double: var(--b3-card-warning-background-select-double);
+    --b3-font-background3-select-double: var(--b3-card-info-background-select-double);
+    --b3-font-background4-select-double: var(--b3-card-success-background-select-double);
+    --b3-font-background5-select-double: rgb(187, 202, 230);
+    --b3-font-background6-select-double: rgb(145, 187, 250);
+    --b3-font-background7-select-double: rgb(208, 210, 220);
+    --b3-font-background8-select-double: rgb(205, 201, 214);
+    --b3-font-background9-select-double: rgb(208, 191, 233);
+    --b3-font-background10-select-double: rgb(190, 180, 232);
+    --b3-font-background11-select-double: rgb(184, 212, 222);
+    --b3-font-background12-select-double: rgb(205, 202, 230);
+    --b3-font-background13-select-double: rgb(38, 53, 81);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;
@@ -197,7 +216,7 @@
     /* 表格 */
     --b3-table-even-background: rgba(0, 0, 0, .02);
 
-    /* 潜入块 */
+    /* 嵌入块 */
     --b3-embed-background: var(--b3-table-even-background);
 
     /* 引述块 */

--- a/app/appearance/themes/midnight/theme.css
+++ b/app/appearance/themes/midnight/theme.css
@@ -4,6 +4,7 @@
     --b3-theme-primary-light: rgba(53, 115, 240, .72);
     --b3-theme-primary-lighter: rgba(53, 115, 240, .48);
     --b3-theme-primary-lightest: rgba(53, 115, 240, .24);
+    --b3-theme-primary-lightest-light: rgba(53, 115, 240, .04);
     --b3-theme-secondary: #f3a92f;
     --b3-theme-background: #1e1e1e;
     --b3-theme-background-light: rgba(255, 255, 255, .075);
@@ -18,6 +19,8 @@
     --b3-theme-on-secondary: #fff;
     --b3-theme-on-background: #dadada;
     --b3-theme-on-background-select: rgb(198, 206, 221);
+    --b3-theme-on-background-select-double: rgb(181, 195, 223);
+    --b3-theme-on-background-av-hover: rgb(202, 202, 202);
     --b3-theme-on-surface: #9aa0a6;
     --b3-theme-on-surface-light: #bababa;
     --b3-theme-on-error: #fff;
@@ -60,7 +63,8 @@
     --b3-tooltips-shadow: 0 2px 8px rgba(0, 0, 0, .3);
 
     /* av */
-    --b3-av-hover: #2a2a2a;
+    --b3-av-hover: rgb(42, 42, 42); /* 初始值为 --b3-theme-background 混合 --b3-list-hover */
+    --b3-av-background: var(--b3-theme-background);
     --b3-av-background-hl: #28324e;
 
     /* 为空提示 */
@@ -74,18 +78,22 @@
     --b3-card-error-background: #442724;
     --b3-card-error-background-select: rgb(66, 48, 60);
     --b3-card-error-background-select-double: rgb(64, 56, 82);
+    --b3-card-error-background-av-hover: rgb(63, 36, 33);
     --b3-card-warning-color: rgb(255, 213, 153);
     --b3-card-warning-background: #554636;
     --b3-card-warning-background-select: rgb(81, 76, 76);
     --b3-card-warning-background-select-double: rgb(78, 81, 96);
+    --b3-card-warning-background-av-hover: rgb(79, 65, 50);
     --b3-card-info-color: rgb(166, 213, 250);
     --b3-card-info-background: #28405c;
     --b3-card-info-background-select: rgb(42, 70, 110);
     --b3-card-info-background-select-double: rgb(43, 76, 126);
+    --b3-card-info-background-av-hover: rgb(37, 59, 85);
     --b3-card-success-color: rgb(183, 223, 185);
     --b3-card-success-background: #425347;
     --b3-card-success-background-select: rgb(64, 87, 91);
     --b3-card-success-background-select-double: rgb(63, 91, 109);
+    --b3-card-success-background-av-hover: rgb(61, 77, 66);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -141,7 +149,21 @@
     --b3-font-background10-select-double: rgb(95, 62, 137);
     --b3-font-background11-select-double: rgb(55, 106, 86);
     --b3-font-background12-select-double: rgb(111, 71, 59);
-    --b3-font-background13-select-double: rgb(181, 195, 223);
+    --b3-font-background13-select-double: var(--b3-theme-on-background-select-double);
+    /* -av-hover 是块的背景色与 --b3-list-hover 混合后的颜色 */
+    --b3-font-background1-av-hover: var(--b3-card-error-background-av-hover);
+    --b3-font-background2-av-hover: var(--b3-card-warning-background-av-hover);
+    --b3-font-background3-av-hover: var(--b3-card-info-background-av-hover);
+    --b3-font-background4-av-hover: var(--b3-card-success-background-av-hover);
+    --b3-font-background5-av-hover: rgb(70, 76, 80);
+    --b3-font-background6-av-hover: rgb(11, 56, 126);
+    --b3-font-background7-av-hover: rgb(82, 53, 5);
+    --b3-font-background8-av-hover: rgb(78, 22, 17);
+    --b3-font-background9-av-hover: rgb(98, 6, 48);
+    --b3-font-background10-av-hover: rgb(99, 43, 99);
+    --b3-font-background11-av-hover: rgb(51, 94, 38);
+    --b3-font-background12-av-hover: rgb(118, 54, 6);
+    --b3-font-background13-av-hover: var(--b3-theme-on-background-av-hover);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;

--- a/app/appearance/themes/midnight/theme.css
+++ b/app/appearance/themes/midnight/theme.css
@@ -17,7 +17,7 @@
     --b3-theme-on-primary: #fff;
     --b3-theme-on-secondary: #fff;
     --b3-theme-on-background: #dadada;
-    --b3-theme-on-background-rgba: rgb(218, 218, 218, 0.86);
+    --b3-theme-on-background-select: rgb(198, 206, 221);
     --b3-theme-on-surface: #9aa0a6;
     --b3-theme-on-surface-light: #bababa;
     --b3-theme-on-error: #fff;
@@ -72,16 +72,20 @@
     /* 卡片背景 */
     --b3-card-error-color: rgb(243, 153, 147);
     --b3-card-error-background: #442724;
-    --b3-card-error-background-rgba: rgb(68, 39, 36, 0.86);
+    --b3-card-error-background-select: rgb(66, 48, 60);
+    --b3-card-error-background-select-double: rgb(64, 56, 82);
     --b3-card-warning-color: rgb(255, 213, 153);
     --b3-card-warning-background: #554636;
-    --b3-card-warning-background-rgba: rgb(85, 70, 54, 0.86);
+    --b3-card-warning-background-select: rgb(81, 76, 76);
+    --b3-card-warning-background-select-double: rgb(78, 81, 96);
     --b3-card-info-color: rgb(166, 213, 250);
     --b3-card-info-background: #28405c;
-    --b3-card-info-background-rgba: rgb(40, 64, 92, 0.86);
+    --b3-card-info-background-select: rgb(42, 70, 110);
+    --b3-card-info-background-select-double: rgb(43, 76, 126);
     --b3-card-success-color: rgb(183, 223, 185);
     --b3-card-success-background: #425347;
-    --b3-card-success-background-rgba: rgb(66, 83, 71, 0.86);
+    --b3-card-success-background-select: rgb(64, 87, 91);
+    --b3-card-success-background-select-double: rgb(63, 91, 109);
 
     /* 自定义文字 */
     --b3-font-color1: var(--b3-card-error-color);
@@ -110,19 +114,34 @@
     --b3-font-background11: #376629;
     --b3-font-background12: #803a06;
     --b3-font-background13: var(--b3-theme-on-background);
-    --b3-font-background1-rgba: var(--b3-card-error-background-rgba);
-    --b3-font-background2-rgba: var(--b3-card-warning-background-rgba);
-    --b3-font-background3-rgba: var(--b3-card-info-background-rgba);
-    --b3-font-background4-rgba: var(--b3-card-success-background-rgba);
-    --b3-font-background5-rgba: rgb(76, 82, 87, 0.86);
-    --b3-font-background6-rgba: rgb(12, 61, 136, 0.86);
-    --b3-font-background7-rgba: rgb(89, 57, 5, 0.86);
-    --b3-font-background8-rgba: rgb(84, 24, 18, 0.86);
-    --b3-font-background9-rgba: rgb(106, 6, 52, 0.86);
-    --b3-font-background10-rgba: rgb(107, 47, 107, 0.86);
-    --b3-font-background11-rgba: rgb(55, 102, 41, 0.86);
-    --b3-font-background12-rgba: rgb(128, 58, 6, 0.86);
-    --b3-font-background13-rgba: var(--b3-theme-on-background-rgba);
+    /* -select 是块的背景色与 --b3-theme-primary-lightest 混合后的颜色 */
+    --b3-font-background1-select: var(--b3-card-error-background-select);
+    --b3-font-background2-select: var(--b3-card-warning-background-select);
+    --b3-font-background3-select: var(--b3-card-info-background-select);
+    --b3-font-background4-select: var(--b3-card-success-background-select);
+    --b3-font-background5-select: rgb(73, 86, 105);
+    --b3-font-background6-select: rgb(17, 68, 148);
+    --b3-font-background7-select: rgb(85, 64, 33);
+    --b3-font-background8-select: rgb(80, 35, 45);
+    --b3-font-background9-select: rgb(100, 19, 75);
+    --b3-font-background10-select: rgb(101, 55, 123);
+    --b3-font-background11-select: rgb(55, 104, 65);
+    --b3-font-background12-select: rgb(119, 65, 34);
+    --b3-font-background13-select: var(--b3-theme-on-background-select);
+    /* -select-double 是 -select 与 --b3-theme-primary-lightest 再次混合后的颜色 */
+    --b3-font-background1-select-double: var(--b3-card-error-background-select-double);
+    --b3-font-background2-select-double: var(--b3-card-warning-background-select-double);
+    --b3-font-background3-select-double: var(--b3-card-info-background-select-double);
+    --b3-font-background4-select-double: var(--b3-card-success-background-select-double);
+    --b3-font-background5-select-double: rgb(71, 90, 121);
+    --b3-font-background6-select-double: rgb(21, 74, 159);
+    --b3-font-background7-select-double: rgb(81, 70, 58);
+    --b3-font-background8-select-double: rgb(77, 45, 68);
+    --b3-font-background9-select-double: rgb(94, 31, 95);
+    --b3-font-background10-select-double: rgb(95, 62, 137);
+    --b3-font-background11-select-double: rgb(55, 106, 86);
+    --b3-font-background12-select-double: rgb(111, 71, 59);
+    --b3-font-background13-select-double: rgb(181, 195, 223);
 
     /* 动画效果 */
     --b3-transition: all .2s cubic-bezier(0, 0, .2, 1) 0ms;
@@ -196,7 +215,7 @@
     /* 表格 */
     --b3-table-even-background: rgba(255, 255, 255, .03);
 
-    /* 潜入块 */
+    /* 嵌入块 */
     --b3-embed-background: var(--b3-table-even-background);
 
     /* 引述块 */

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -537,6 +537,7 @@
   }
 }
 
+// https://github.com/siyuan-note/siyuan/pull/12837
 .protyle-wysiwyg--select {
   --b3-av-background: var(--b3-av-background-hl);
 
@@ -572,7 +573,6 @@
   }
 }
 
-// https://github.com/siyuan-note/siyuan/pull/12706
 $backgrounds: (
   "font-background" 13,
   "card-error-background" 1,

--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -98,7 +98,7 @@
     bottom: 0;
     height: 26px;
     padding: 0 5px;
-    background-color: var(--av-background);
+    background-color: var(--b3-av-background);
     font-size: 87.5%;
   }
 
@@ -161,7 +161,7 @@
 
     &--header,
     &--footer {
-      background-color: var(--av-background);
+      background-color: var(--b3-av-background);
     }
 
     &--footer {
@@ -177,7 +177,7 @@
       }
 
       .av__colsticky {
-        background-color: var(--av-background); // 保证盯住时无计算结果的列不被覆盖
+        background-color: var(--b3-av-background); // 保证钉住时无计算结果的列不被覆盖
       }
 
       .av__calc {
@@ -301,13 +301,13 @@
     }
 
     &--select {
-      background-color: var(--b3-menu-background);
+      background-color: var(--b3-theme-primary-lightest-light);
       box-shadow: 2px 2px 0 var(--b3-theme-primary-lighter) inset, -2px -2px 0 var(--b3-theme-primary-lighter) inset;
       border-radius: var(--b3-border-radius);
     }
 
     &--active {
-      background-color: var(--b3-menu-background);
+      background-color: var(--b3-theme-primary-lightest-light);
     }
 
     &--header {
@@ -436,7 +436,14 @@
 
     &.av__firstcol,
     & > div:not(.av__cell--select):not(.av__cell--active):not(.av__calc--ashow) {
-      background-color: var(--av-background);
+      background-color: var(--b3-av-background);
+
+      &.av__cell--header:hover {
+        background-color: var(--b3-av-hover);
+      }
+      &.av__calc:hover {
+        background-color: var(--b3-av-hover);
+      }
     }
   }
 
@@ -531,31 +538,173 @@
 }
 
 .protyle-wysiwyg--select {
+  --b3-av-background: var(--b3-av-background-hl);
+
   .av__row--header,
   .av__row--footer,
   .av__row--footer .av__colsticky,
   .av__row--select .av__cell,
-  .av__colsticky.av__firstcol,
-  .av__colsticky > div,
-  .av__cell--select,
-  .av__cell--active,
+  .av__colsticky > div:not(.av__cell--select):not(.av__cell--active),
   .av__counter {
-    background-color: var(--b3-av-background-hl) !important;
+    background-color: var(--b3-av-background);
+  }
+  .av__cell--select,
+  .av__cell--active {
+    background-color: var(--b3-theme-primary-lightest-light);
   }
 }
 
 .protyle-wysiwyg--hl {
+  --b3-av-background: var(--b3-av-background-hl);
+
   .av__row--header,
   .av__row--footer,
   .av__row--footer .av__colsticky,
   .av__row--select .av__cell,
-  .av__colsticky.av__firstcol,
-  .av__colsticky > div,
-  .av__cell--select,
-  .av__cell--active,
+  .av__colsticky > div:not(.av__cell--select):not(.av__cell--active),
   .av__counter {
-    background-color: var(--b3-av-background-hl) !important;
     transition: var(--b3-background-transition);
+    background-color: var(--b3-av-background);
+  }
+  .av__cell--select,
+  .av__cell--active {
+    background-color: var(--b3-theme-primary-lightest-light);
+  }
+}
+
+// https://github.com/siyuan-note/siyuan/pull/12706
+$backgrounds: (
+  "font-background" 13,
+  "card-error-background" 1,
+  "card-warning-background" 1,
+  "card-info-background" 1,
+  "card-success-background" 1,
+);
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 外层没有被选中的块时，从最近的“带背景色的父块（包括数据库块本身）”继承背景色
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      --b3-av-background: var(#{$bg-variable});
+      --b3-av-hover: var(#{$bg-av-hover-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 在 选中块 的外层
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      .protyle-wysiwyg--select,
+      .protyle-wysiwyg--hl {
+        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-hover: var(#{$bg-av-hover-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 就是 选中块
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      &.protyle-wysiwyg--select,
+      &.protyle-wysiwyg--hl {
+        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-hover: var(#{$bg-av-hover-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-variable: if($count == 1, "--b3-#{$key}-select", "--b3-#{$key}#{$i}-select");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 在 选中块 的内层
+    .protyle-wysiwyg--select,
+    .protyle-wysiwyg--hl {
+      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+        --b3-av-background: var(#{$bg-select-variable});
+        --b3-av-hover: var(#{$bg-av-hover-variable});
+      }
+    }
+  }
+}
+// 某种情况下 .protyle-wysiwyg--hl 和 .protyle-wysiwyg--select 会叠加，此时 --b3-av-background 需要再叠加一层 --b3-theme-primary-lightest ，使用 -select-double
+// ".protyle-wysiwyg--select 在外，.protyle-wysiwyg--hl 在内"与".protyle-wysiwyg--hl 在外，.protyle-wysiwyg--select 在内"两种情况
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-double-variable: if($count == 1, "--b3-#{$key}-select-double", "--b3-#{$key}#{$i}-select-double");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 在 两个选中块 的外层
+    [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+      .protyle-wysiwyg--select .protyle-wysiwyg--hl,
+      .protyle-wysiwyg--hl .protyle-wysiwyg--select {
+        --b3-av-background: var(#{$bg-select-double-variable});
+        --b3-av-hover: var(#{$bg-av-hover-variable});
+      }
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-double-variable: if($count == 1, "--b3-#{$key}-select-double", "--b3-#{$key}#{$i}-select-double");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 在 两个选中块 的中间，并且就是靠外层的选中块
+    .protyle-wysiwyg--select[data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl,
+    .protyle-wysiwyg--hl[data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--select {
+      --b3-av-background: var(#{$bg-select-double-variable});
+      --b3-av-hover: var(#{$bg-av-hover-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-double-variable: if($count == 1, "--b3-#{$key}-select-double", "--b3-#{$key}#{$i}-select-double");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 在 两个选中块 的中间
+    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--hl,
+    .protyle-wysiwyg--hl [data-node-id][style*="background-color: var(#{$bg-variable})"] .protyle-wysiwyg--select {
+      --b3-av-background: var(#{$bg-select-double-variable});
+      --b3-av-hover: var(#{$bg-av-hover-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-double-variable: if($count == 1, "--b3-#{$key}-select-double", "--b3-#{$key}#{$i}-select-double");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 在 两个选中块 的中间，并且就是靠内层的选中块
+    .protyle-wysiwyg--select [data-node-id][style*="background-color: var(#{$bg-variable})"].protyle-wysiwyg--hl,
+    .protyle-wysiwyg--hl [data-node-id][style*="background-color: var(#{$bg-variable})"].protyle-wysiwyg--select {
+      --b3-av-background: var(#{$bg-select-double-variable});
+      --b3-av-hover: var(#{$bg-av-hover-variable});
+    }
+  }
+}
+@each $key, $count in $backgrounds {
+  @for $i from 1 through $count {
+    $bg-variable: if($count == 1, "--b3-#{$key}", "--b3-#{$key}#{$i}");
+    $bg-select-double-variable: if($count == 1, "--b3-#{$key}-select-double", "--b3-#{$key}#{$i}-select-double");
+    $bg-av-hover-variable: if($count == 1, "--b3-#{$key}-av-hover", "--b3-#{$key}#{$i}-av-hover");
+    // 带背景色的块 在 两个选中块 的内层
+    .protyle-wysiwyg--select .protyle-wysiwyg--hl,
+    .protyle-wysiwyg--hl .protyle-wysiwyg--select {
+      [data-node-id][style*="background-color: var(#{$bg-variable})"] {
+        --b3-av-background: var(#{$bg-select-double-variable});
+        --b3-av-hover: var(#{$bg-av-hover-variable});
+      }
+    }
   }
 }
 

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -464,68 +464,70 @@
 
   &--select {
     background-color: var(--b3-theme-primary-lightest) !important;
+  }
+  &--hl {
+    transition: var(--b3-background-transition);
+    background-color: var(--b3-theme-primary-lightest) !important;
 
-    [data-node-id][style*="background-color: var(--b3-font-background1)"] {
-      background-color: var(--b3-font-background1-rgba) !important;
-    }
+    [data-node-id],
+    &[data-node-id] {
+        transition: var(--b3-background-transition);
+      }
+  }
 
-    [data-node-id][style*="background-color: var(--b3-font-background2)"] {
-      background-color: var(--b3-font-background2-rgba) !important;
-    }
+  $backgrounds: (
+    "font-background": 13,
+    "card-error-background": 1,
+    "card-warning-background": 1,
+    "card-info-background": 1,
+    "card-success-background": 1,
+  );
+  @each $key, $count in $backgrounds {
+    @for $i from 1 through $count {
+      $bg-variable: if($count == 1, var(--b3-#{$key}), var(--b3-#{$key}#{$i}));
+      $bg-select-variable: if($count == 1, var(--b3-#{$key}-select), var(--b3-#{$key}#{$i}-select));
+      $bg-select-double-variable: if($count == 1, var(--b3-#{$key}-select-double), var(--b3-#{$key}#{$i}-select-double));
 
-    [data-node-id][style*="background-color: var(--b3-font-background3)"] {
-      background-color: var(--b3-font-background3-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background4)"] {
-      background-color: var(--b3-font-background4-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background5)"] {
-      background-color: var(--b3-font-background5-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background6)"] {
-      background-color: var(--b3-font-background6-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background7)"] {
-      background-color: var(--b3-font-background7-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background8)"] {
-      background-color: var(--b3-font-background8-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background9)"] {
-      background-color: var(--b3-font-background9-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background10)"] {
-      background-color: var(--b3-font-background10-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background11)"] {
-      background-color: var(--b3-font-background11-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background12)"] {
-      background-color: var(--b3-font-background12-rgba) !important;
-    }
-
-    [data-node-id][style*="background-color: var(--b3-font-background13)"] {
-      background-color: var(--b3-font-background13-rgba) !important;
+      &--select {
+        [data-node-id],
+        &[data-node-id] {
+          &[style*="background-color: #{$bg-variable}"] {
+            background-color: #{$bg-select-variable} !important;
+          }
+        }
+        // 叠加两层高亮
+        .protyle-wysiwyg--hl {
+          [data-node-id],
+          &[data-node-id] {
+            &[style*="background-color: #{$bg-variable}"] {
+              background-color: #{$bg-select-double-variable} !important;
+            }
+          }
+        }
+      }
+      &--hl {
+        [data-node-id],
+        &[data-node-id] {
+          &[style*="background-color: #{$bg-variable}"] {
+            background-color: #{$bg-select-variable} !important;
+          }
+        }
+        // 叠加两层高亮
+        .protyle-wysiwyg--select {
+          [data-node-id],
+          &[data-node-id] {
+            &[style*="background-color: #{$bg-variable}"] {
+              background-color: #{$bg-select-double-variable} !important;
+            }
+          }
+        }
+      }
     }
   }
 
   // https://github.com/siyuan-note/siyuan/issues/11589
   .hljs wbr {
     display: none;
-  }
-
-  &--hl {
-    transition: var(--b3-background-transition);
-    background-color: var(--b3-theme-primary-lightest) !important;
   }
 
   .dragover {

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -462,6 +462,7 @@
     }
   }
 
+  // https://github.com/siyuan-note/siyuan/pull/12837
   &--select {
     background-color: var(--b3-theme-primary-lightest) !important;
   }


### PR DESCRIPTION
解决了 https://github.com/siyuan-note/siyuan/pull/12706 提到的大部分问题。

另外：

1. 如果数据库块在引述块或嵌入块内，由于这两种块有带透明度的背景色，会导致数据库块的子元素颜色不一致，无法解决，只能将就了（但不管怎么说都比之前好多了，之前的颜色差别更大，现在已经能保证在大多数情况下颜色一致了）。
2. 合并 PR 后还需要删除其他代码里给 .av__container 添加(更新)内联样式 style="--av-background:var(xxx)" 的逻辑，因为这个 PR 修改之后就用不上 --av-background 了（p.s.我看不懂所以没改）。