### PR TITLE
Support dark theme for Star History in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ Some features are only available to paid members, for more details please refer 
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=siyuan-note/siyuan&type=Date)](https://star-history.com/#siyuan-note/siyuan&Date)
+<a href="https://star-history.com/#siyuan-note/siyuan&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=siyuan-note/siyuan&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=siyuan-note/siyuan&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=siyuan-note/siyuan&type=Date" />
+ </picture>
+</a>
 
 ## 🗺️ Roadmap
 


### PR DESCRIPTION
Star History 支持夜间主题了，现在可以自适应不同主题。此改动可改善在夜间主题下浏览 README 的体验（不再被白色背景闪瞎双眼）。

改动前：

<img width="828" alt="image" src="https://github.com/user-attachments/assets/7363599e-14f8-4bf7-8b6f-712209ab70bd">

改动后：

<img width="828" alt="image" src="https://github.com/user-attachments/assets/a4f10eee-0f1f-4c7d-8a9c-6dfe6503a5d5">