### PR TITLE
update auto aur PKGBUILD.

### DIFF
--- a/.github/workflows/auto_aur_release_stable.yml
+++ b/.github/workflows/auto_aur_release_stable.yml
@@ -45,27 +45,51 @@ jobs:
           arch=("x86_64")
           url="https://b3log.org/siyuan"
           license=("AGPL-3.0-only")
-          _pkgname=siyuan-\${pkgver}-linux.AppImage
-          noextract=(siyuan-\${pkgver}-linux.AppImage)
           options=("!strip" "!debug")
           depends=("fuse2")
           optdepends=('pandoc: docx export')
           source=("https://github.com/siyuan-note/siyuan/releases/download/v\${pkgver}/siyuan-\${pkgver}-linux.AppImage")
           sha256sums=('SKIP')
 
-          _installdir=/opt/appimages
+          _pkgname=siyuan-\${pkgver}-linux.AppImage
+          noextract=("\${_pkgname}")
 
           prepare() {
-              chmod a+x \${_pkgname}
-              ./\${_pkgname} --appimage-extract >/dev/null
-              sed -i "s+AppRun+\${_installdir}/siyuan.AppImage+" "squashfs-root/siyuan.desktop"
-              sed -i "s+^Icon=.*+Icon=siyuan-bin+" "squashfs-root/siyuan.desktop"
+              chmod +x "\${_pkgname}"
+              ./"\${_pkgname}" --appimage-extract > /dev/null
+          }
+
+          build() {
+              # Adjust .desktop so it will work autside of AppImage container
+              sed -i \\
+                  -e "s|Exec=AppRun|Exec=/opt/\${pkgname}/\${pkgname}.AppImage|" \\
+                  -e "s+^Icon=.*+Icon=siyuan-bin+" \\
+                  "squashfs-root/siyuan.desktop"
+
+              # Fix permissions; .AppImage permissions are 700 for all directories
+              chmod -R a-x+rX squashfs-root/usr
           }
 
           package() {
-              install -Dm755 \${_pkgname} "\${pkgdir}/\${_installdir}/siyuan.AppImage"
-              install -Dm644 "squashfs-root/resources/stage/icon.png" "\${pkgdir}/usr/share/icons/hicolor/512x512/apps/siyuan-bin.png"
-              install -Dm644 "squashfs-root/siyuan.desktop" "\${pkgdir}/usr/share/applications/siyuan-bin.desktop"
+              # AppImage
+              install -Dm755 "\${srcdir}/\${_pkgname}" "\${pkgdir}/opt/\${pkgname}/\${pkgname}.AppImage"
+              install -Dm644 "\${srcdir}/squashfs-root/LICENSE" "\${pkgdir}/opt/\${pkgname}/LICENSE"
+
+              # Desktop file
+              install -Dm644 "\${srcdir}/squashfs-root/siyuan.desktop" \\
+                      "\${pkgdir}/usr/share/applications/siyuan.desktop"
+
+              # Icon images
+              install -Dm644 "squashfs-root/resources/stage/icon.png" \\
+                      "\${pkgdir}/usr/share/icons/hicolor/512x512/apps/siyuan-bin.png"
+
+              # Symlink executable
+              install -dm755 "\${pkgdir}/usr/bin"
+              ln -s "/opt/\${pkgname}/\${pkgname}.AppImage" "\${pkgdir}/usr/bin/siyuan"
+
+              # Symlink license
+              install -dm755 "\${pkgdir}/usr/share/licenses/\${pkgname}/"
+              ln -s "/opt/\${pkgname}/LICENSE" "\${pkgdir}/usr/share/licenses/\${pkgname}"
           }
           EOF
 


### PR DESCRIPTION
我注意到 [aur.archlinux-siyuan-bin](https://aur.archlinux.org/packages/siyuan-bin) 没有 `Symlink executable` 到 `/usr/bin/siyuan`

这会导致无法通过命令行 `siyuan` 的方式打开。

这是原有的 `PKGBUILD` 构建生成的文件列表：
![image](https://github.com/user-attachments/assets/35c4188f-794f-4c76-bbfd-e19fc316f9f5)

这是修改之后构建生成的文件列表：
![image](https://github.com/user-attachments/assets/cc203cda-5f3c-4349-932a-87f4d51dcfc4)

主要的修改如下：
1. 添加了 `${pkgdir}/usr/bin/siyuan`
2. 将 `/opt/appimages` 修改为 `/opt/${pkgname}`
3. Symlink 了相关 license.


