### PR TITLE
`/api/icon/getDynamicIcon` 样式改进

### DIFF
--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -248,7 +248,7 @@ func generateTypeThreeSVG(color string, lang string, dateInfo map[string]interfa
             <circle  cx="382.5" cy="93" r="14"/>
         </g>
         <text transform="translate(22 146.5)" style="fill: #fff;font-size: 120px; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
-        <text x="50%%" y="410.5" style="fill: #66757f;font-size: 160px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
+        <text x="50%%" y="410.5" style="fill: #66757f;font-size: 200px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
     </svg>
     `, colorScheme.Primary, colorScheme.Secondary, dateInfo["year"], dateInfo["month"])
 }

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -423,32 +423,32 @@ func generateTypeSevenSVG(color string, lang string, dateInfo map[string]interfa
 func generateTypeEightSVG(color, content string) string {
 	colorScheme := getColorScheme(color)
 
+	// 动态变化字体大小
 	isChinese := regexp.MustCompile(`[\p{Han}]`).MatchString(content)
-
 	var fontSize float64
-	switch {
-	case len([]rune(content)) == 1:
-		fontSize = 320
-	case len([]rune(content)) == 2:
-		fontSize = 240
-	case len([]rune(content)) == 3:
-		fontSize = 160
-	case len([]rune(content)) == 4:
-		fontSize = 120
-	case len([]rune(content)) == 5:
-		fontSize = 95
-	default:
-		if isChinese {
-			fontSize = 480 / float64(len([]rune(content)))
-		} else {
-			fontSize = 750 / float64(len([]rune(content)))
+	if isChinese {
+		switch {
+		case len([]rune(content)) == 1:
+			fontSize = 320
+		default:
+				fontSize = 480 / float64(len([]rune(content)))
 		}
+	} else {
+	switch {
+		case len([]rune(content)) == 1:
+			fontSize = 480
+		case len([]rune(content)) == 2:
+			fontSize = 300
+		default:
+				fontSize = 750 / float64(len([]rune(content)))
+	}
 	}
 
 	return fmt.Sprintf(`
     <svg id="dynamic_icon_type8" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 511">
         <path d="M39,0h434c20.97,0,38,17.03,38,38v412c0,33.11-26.89,60-60,60H60c-32.56,0-59-26.44-59-59V38C1,17.03,18.03,0,39,0Z" style="fill: %s;"/>
-        <text x="260px" y="55%%" style="font-size: %.2fpx; fill: #fff; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
+        <text x="50%%" y="55%%" style="font-size: %.2fpx; fill: #fff; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
     </svg>
     `, colorScheme.Primary, fontSize, content)
 }
+

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -436,6 +436,7 @@ func generateTypeSevenSVG(color string, lang string, dateInfo map[string]interfa
 		dayStr = "days"
 	}
 	// 动态变化字体大小
+	var fontSize float64
 	switch {
 	case len(diffDaysText) <= 3:
 		fontSize = 240

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -201,42 +201,41 @@ func getDateInfo(dateStr string, lang string, weekdayType string) map[string]int
 }
 
 func daysBetween(date1, date2 time.Time) int {
-    // 将两个日期都调整到UTC时间的0点
-    date1 = time.Date(date1.Year(), date1.Month(), date1.Day(), 0, 0, 0, 0, time.UTC)
-    date2 = time.Date(date2.Year(), date2.Month(), date2.Day(), 0, 0, 0, 0, time.UTC)
+	// 将两个日期都调整到UTC时间的0点
+	date1 = time.Date(date1.Year(), date1.Month(), date1.Day(), 0, 0, 0, 0, time.UTC)
+	date2 = time.Date(date2.Year(), date2.Month(), date2.Day(), 0, 0, 0, 0, time.UTC)
 
-    // 确保date1不晚于date2
-    swap := false
-    if date1.After(date2) {
-        date1, date2 = date2, date1
-        swap = true
-    }
+	// 确保date1不晚于date2
+	swap := false
+	if date1.After(date2) {
+		date1, date2 = date2, date1
+		swap = true
+	}
 
-    // 计算天数差
-    days := 0
-    for y := date1.Year(); y < date2.Year(); y++ {
-        if isLeapYear(y) {
-            days += 366
-        } else {
-            days += 365
-        }
-    }
+	// 计算天数差
+	days := 0
+	for y := date1.Year(); y < date2.Year(); y++ {
+		if isLeapYear(y) {
+			days += 366
+		} else {
+			days += 365
+		}
+	}
 
-    // 加上最后一年的天数
-    days += int(date2.YearDay() - date1.YearDay())
+	// 加上最后一年的天数
+	days += int(date2.YearDay() - date1.YearDay())
 
-    // 如果原始的date1晚于date2，返回负值
-    if swap {
-        return -days
-    }
-    return days
+	// 如果原始的date1晚于date2，返回负值
+	if swap {
+		return -days
+	}
+	return days
 }
 
 // 判断是否为闰年
 func isLeapYear(year int) bool {
-    return year%4 == 0 && (year%100 != 0 || year%400 == 0)
+	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
 }
-
 
 // Type 1: 显示年月日星期
 func generateTypeOneSVG(color string, lang string, dateInfo map[string]interface{}) string {
@@ -448,7 +447,6 @@ func generateTypeSevenSVG(color string, lang string, dateInfo map[string]interfa
 		fontSize = 780 / float64(len(diffDaysText))
 	}
 
-
 	return fmt.Sprintf(`
     <svg id="dynamic_icon_type7" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 504.5">
         <path id="bottom" d="M512,447.5c0,32-25,57-57,57H57c-32,0-57-25-57-57V120.5c0-31,25-57,57-57h398c32,0,57,26,57,57v327Z" style="fill: #ecf2f7;"/>
@@ -485,11 +483,23 @@ func generateTypeEightSVG(color, content string) string {
 			fontSize = 750 / float64(len([]rune(content)))
 		}
 	}
+	// 当内容为单个字符时，一些小写字母需要调整文字位置(暂时没法批量解决)
+	dy := "0%"
+	if len([]rune(content)) == 1 {
+		switch content {
+		case "g", "p", "y", "q":
+			dy = "-10%"
+		case "j":
+			dy = "-5%"
+		default:
+			dy = "0%"
+		}
+	}
 
 	return fmt.Sprintf(`
     <svg id="dynamic_icon_type8" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 511">
         <path d="M39,0h434c20.97,0,38,17.03,38,38v412c0,33.11-26.89,60-60,60H60c-32.56,0-59-26.44-59-59V38C1,17.03,18.03,0,39,0Z" style="fill: %s;"/>
-        <text x="50%%" y="55%%" style="font-size: %.2fpx; fill: #fff; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
-    </svg>
-    `, colorScheme.Primary, fontSize, content)
+        <text x="50%%" y="55%%" dy="%s" style="font-size: %.2fpx; fill: #fff; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
+	</svg>
+    `, colorScheme.Primary, dy, fontSize, content)
 }

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -414,7 +414,7 @@ func generateTypeSevenSVG(color string, lang string, dateInfo map[string]interfa
         <text id="year" transform="translate(46.1 78.92)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 60px;">%d</text>
         <text id="day" transform="translate(43.58 148.44)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 60px;">%s</text>
         <text id="passStr" transform="translate(400 148.44)" style="fill: #fff; text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 71.18px;">%s</text>
-        <text id="diffDays" x="260" y="76%%" style="font-size: %.0fpx; fill: #66757f; text-anchor: middle; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
+        <text id="diffDays" x="260" y="65%%" style="font-size: %.0fpx; fill: #66757f; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
         <text id="dayStr" transform="translate(260 472.5)" style="font-size: 64px; text-anchor: middle; fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei';">%s</text>
     </svg>`, colorScheme.Primary, dateInfo["year"], dateInfo["date"], tipText, fontSize, diffDaysText, dayStr)
 }

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -431,15 +431,15 @@ func generateTypeEightSVG(color, content string) string {
 		case len([]rune(content)) == 1:
 			fontSize = 320
 		default:
-				fontSize = 480 / float64(len([]rune(content)))
+			fontSize = 480 / float64(len([]rune(content)))
 		}
 	} else {
-	switch {
-		case len([]rune(content)) == 1:
-			fontSize = 480
-		case len([]rune(content)) == 2:
-			fontSize = 300
-		default:
+		switch {
+			case len([]rune(content)) == 1:
+				fontSize = 480
+			case len([]rune(content)) == 2:
+				fontSize = 300
+			default:
 				fontSize = 750 / float64(len([]rune(content)))
 	}
 	}

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -209,8 +209,8 @@ func generateTypeOneSVG(color string, lang string, dateInfo map[string]interface
     <path d="M512,447.5c0,32-25,57-57,57H57c-32,0-57-25-57-57V120.5c0-31,25-57,57-57h398c32,0,57,26,57,57v327Z" style="fill: #ecf2f7;"/>
     <path d="M39,0h434c21.52,0,39,17.48,39,39v146H0V39C0,17.48,17.48,0,39,0Z" style="fill: %s;"/>
     <text transform="translate(22 146.5)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 100px;">%s</text>
-    <text transform="translate(260 392.5)" style="fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 240px; text-anchor: middle">%d</text>
-    <text transform="translate(260 472.5)" style="fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 64px; text-anchor: middle">%s</text>
+    <text x="50%%" y="392.5" style="fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 240px; text-anchor: middle">%d</text>
+    <text x="50%%" y="472.5" style="fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 64px; text-anchor: middle">%s</text>
     <text transform="translate(331.03 148.44)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 71.18px;">%d</text>
     </svg>
     `, colorScheme.Primary, dateInfo["month"], dateInfo["day"], dateInfo["weekday"], dateInfo["year"])
@@ -225,7 +225,7 @@ func generateTypeTwoSVG(color string, lang string, dateInfo map[string]interface
     <path d="M512,447.5c0,32-25,57-57,57H57c-32,0-57-25-57-57V120.5c0-31,25-57,57-57h398c32,0,57,26,57,57v327Z" style="fill: #ecf2f7;"/>
     <path d="M39,0h434c21.52,0,39,17.48,39,39v146H0V39C0,17.48,17.48,0,39,0Z" style="fill: %s;"/>
     <text transform="translate(22 146.5)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 100px;">%s</text>
-    <text transform="translate(260 420.5)" style="fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 256px;text-anchor: middle">%d</text>
+    <text x="50%%" y="420.5"  style="fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 256px;text-anchor: middle">%d</text>
     <text transform="translate(331.03 148.44)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 71.18px;">%d</text>
     </svg>
     `, colorScheme.Primary, dateInfo["month"], dateInfo["day"], dateInfo["year"])
@@ -248,7 +248,7 @@ func generateTypeThreeSVG(color string, lang string, dateInfo map[string]interfa
             <circle  cx="382.5" cy="93" r="14"/>
         </g>
         <text transform="translate(22 146.5)" style="fill: #fff;font-size: 120px; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
-        <text transform="translate(260 410.5)" style="fill: #66757f;font-size: 160px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
+        <text x="50%%" y="410.5" style="fill: #66757f;font-size: 160px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
     </svg>
     `, colorScheme.Primary, colorScheme.Secondary, dateInfo["year"], dateInfo["month"])
 }
@@ -269,7 +269,7 @@ func generateTypeFourSVG(color string, lang string, dateInfo map[string]interfac
             <circle  cx="382.5" cy="135" r="14"/>
             <circle  cx="382.5" cy="93" r="14"/>
         </g>
-        <text transform="translate(260 410.5)" style="fill: #66757f;font-size: 180px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
+        <text x="50%%" y="410.5" style="fill: #66757f;font-size: 180px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
     </svg>
     `, colorScheme.Primary, colorScheme.Secondary, dateInfo["year"])
 }
@@ -291,7 +291,7 @@ func generateTypeFiveSVG(color string, lang string, dateInfo map[string]interfac
             <circle  cx="382.5" cy="93" r="14"/>
         </g>
         <text transform="translate(22 146.5)" style="fill: #fff;font-size: 120px; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
-        <text transform="translate(260 410.5)" style="fill: #66757f;font-size: 200px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
+        <text x="50%%" y="410.5" style="fill: #66757f;font-size: 200px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
     </svg>
     `, colorScheme.Primary, colorScheme.Secondary, dateInfo["year"], dateInfo["week"])
 }
@@ -345,7 +345,7 @@ func generateTypeSixSVG(color string, lang string, weekdayType string, dateInfo 
         <circle cx="382.5" cy="113.5" r="14"/>
         <circle cx="382.5" cy="71.5" r="14"/>
     </g>
-    <text id="weekday" x="260px"  y="65%%" style="fill: %s; font-size: %.2fpx; text-anchor: middle; dominant-baseline:middle; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei';">%s</text>
+    <text id="weekday" x="50%%"  y="65%%" style="fill: %s; font-size: %.2fpx; text-anchor: middle; dominant-baseline:middle; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei';">%s</text>
     </svg>`, colorScheme.Primary, colorScheme.Secondary, colorScheme.Primary, fontSize, weekday)
 }
 
@@ -414,8 +414,8 @@ func generateTypeSevenSVG(color string, lang string, dateInfo map[string]interfa
         <text id="year" transform="translate(46.1 78.92)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 60px;">%d</text>
         <text id="day" transform="translate(43.58 148.44)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 60px;">%s</text>
         <text id="passStr" transform="translate(400 148.44)" style="fill: #fff; text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 71.18px;">%s</text>
-        <text id="diffDays" x="260" y="65%%" style="font-size: %.0fpx; fill: #66757f; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
-        <text id="dayStr" transform="translate(260 472.5)" style="font-size: 64px; text-anchor: middle; fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei';">%s</text>
+        <text id="diffDays" x="50%%" y="65%%" style="font-size: %.0fpx; fill: #66757f; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
+        <text id="dayStr" x="50%%" y="472.5" style="font-size: 64px; text-anchor: middle; fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei';">%s</text>
     </svg>`, colorScheme.Primary, dateInfo["year"], dateInfo["date"], tipText, fontSize, diffDaysText, dayStr)
 }
 
@@ -451,4 +451,3 @@ func generateTypeEightSVG(color, content string) string {
     </svg>
     `, colorScheme.Primary, fontSize, content)
 }
-

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -479,6 +479,8 @@ func generateTypeEightSVG(color, content string) string {
 			fontSize = 480
 		case len([]rune(content)) == 2:
 			fontSize = 300
+		case len([]rune(content)) == 3:
+			fontSize = 240
 		default:
 			fontSize = 750 / float64(len([]rune(content)))
 		}

--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -435,13 +435,13 @@ func generateTypeEightSVG(color, content string) string {
 		}
 	} else {
 		switch {
-			case len([]rune(content)) == 1:
-				fontSize = 480
-			case len([]rune(content)) == 2:
-				fontSize = 300
-			default:
-				fontSize = 750 / float64(len([]rune(content)))
-	}
+		case len([]rune(content)) == 1:
+			fontSize = 480
+		case len([]rune(content)) == 2:
+			fontSize = 300
+		default:
+			fontSize = 750 / float64(len([]rune(content)))
+		}
 	}
 
 	return fmt.Sprintf(`


### PR DESCRIPTION
1. type=7 倒数日图标文字始终垂直居中
之前的代码里，倒数日的天数不同，所在的位置会有点不同
通过在svg设置dominant-baseline:middle;和调整y的位置来让图标中的文字始终垂直居中
修改前：倒数日天数少的时候，天数位置偏上，天数多的时候，天数位置偏下
![PixPin_2024-10-28_01-17-01](https://github.com/user-attachments/assets/e80a63a8-4b98-4357-b5b7-f4903b0be911)

![PixPin_2024-10-28_01-16-11](https://github.com/user-attachments/assets/1c322bdd-97a3-4131-bdf6-3d408dd003fe)

修改后效果：始终居中
![PixPin_2024-10-28_01-15-15](https://github.com/user-attachments/assets/c6d8d92c-b1f6-4976-b333-0885cb031e95)
![PixPin_2024-10-28_01-15-33](https://github.com/user-attachments/assets/3dc6062b-18fd-4863-9dfd-633d0d17a034)

```go
	return fmt.Sprintf(`
    <svg id="dynamic_icon_type7" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 504.5">
        <path id="bottom" d="M512,447.5c0,32-25,57-57,57H57c-32,0-57-25-57-57V120.5c0-31,25-57,57-57h398c32,0,57,26,57,57v327Z" style="fill: #ecf2f7;"/>
        <path id="top" d="M39,0h434c21.52,0,39,17.48,39,39v146H0V39C0,17.48,17.48,0,39,0Z" style="fill: %s;"/>
        <text id="year" transform="translate(46.1 78.92)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 60px;">%d</text>
        <text id="day" transform="translate(43.58 148.44)" style="fill: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 60px;">%s</text>
        <text id="passStr" transform="translate(400 148.44)" style="fill: #fff; text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; font-size: 71.18px;">%s</text>
        <text id="diffDays" x="260" y="65%%" style="font-size: %.0fpx; fill: #66757f; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
        <text id="dayStr" transform="translate(260 472.5)" style="font-size: 64px; text-anchor: middle; fill: #66757f; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei';">%s</text>
    </svg>`, colorScheme.Primary, dateInfo["year"], dateInfo["date"], tipText, fontSize, diffDaysText, dayStr)
}

```
2. type=8 文字图标fontsize动态变化规则改进，之前代码忘记改了，导致英文字体偏小，动态变化规则不对。并调整文字居中。
```go
// Type 8: 文字图标
func generateTypeEightSVG(color, content string) string {
	colorScheme := getColorScheme(color)

	// 动态变化字体大小
	isChinese := regexp.MustCompile(`[\p{Han}]`).MatchString(content)
	var fontSize float64
	if isChinese {
		switch {
		case len([]rune(content)) == 1:
			fontSize = 320
		default:
				fontSize = 480 / float64(len([]rune(content)))
		}
	} else {
	switch {
		case len([]rune(content)) == 1:
			fontSize = 480
		case len([]rune(content)) == 2:
			fontSize = 300
		default:
				fontSize = 750 / float64(len([]rune(content)))
	}
	}

	return fmt.Sprintf(`
    <svg id="dynamic_icon_type8" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 511">
        <path d="M39,0h434c20.97,0,38,17.03,38,38v412c0,33.11-26.89,60-60,60H60c-32.56,0-59-26.44-59-59V38C1,17.03,18.03,0,39,0Z" style="fill: %s;"/>
        <text x="50%%" y="55%%" style="font-size: %.2fpx; fill: #fff; text-anchor: middle; dominant-baseline:middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
    </svg>
    `, colorScheme.Primary, fontSize, content)
}
```
3. 所有type的水平居中文字使用`x="50%"`进行水平居中，效果比用像素px来指定好
4. type=3 显示年月图标，年文字fontsize增加
5. type=7 倒数日算法改进，支持超过106751天的倒数正数