### PR TITLE
`/api/icon/getDynamicIcon` type 4 set fontsize to 200px

### DIFF
--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -364,7 +364,7 @@ func generateTypeFourSVG(color string, lang string, dateInfo map[string]interfac
             <circle  cx="382.5" cy="135" r="14"/>
             <circle  cx="382.5" cy="93" r="14"/>
         </g>
-        <text x="50%%" y="410.5" style="fill: #66757f;font-size: 180px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
+        <text x="50%%" y="410.5" style="fill: #66757f;font-size: 200px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
     </svg>
     `, colorScheme.Primary, colorScheme.Secondary, dateInfo["year"])
 }


### PR DESCRIPTION
增加type4（仅显示年）的字体大小到200px
原来（180px）
![PixPin_2024-11-09_18-57-48](https://github.com/user-attachments/assets/5ab2ea97-100e-4df0-a846-fdba491f5032)

增加后（200px）
![PixPin_2024-11-09_18-58-22](https://github.com/user-attachments/assets/e2e3ae34-55a3-4222-bcb5-0c3ed7de75d7)
