### PR TITLE
改变数据库 `添加条目` `加载更多` 按钮的结构

### DIFF
--- a/app/src/protyle/render/av/action.ts
+++ b/app/src/protyle/render/av/action.ts
@@ -43,6 +43,18 @@ export const avClick = (protyle: IProtyle, event: MouseEvent & { target: HTMLEle
     if (!blockElement) {
         return false;
     }
+    const setPageSizeElement = hasClosestByAttribute(event.target, "data-type", "set-page-size");
+    if (setPageSizeElement) {
+        setPageSize({
+            target: event.target,
+            protyle,
+            avID: blockElement.getAttribute("data-av-id"),
+            nodeElement: blockElement
+        });
+        event.preventDefault();
+        event.stopPropagation();
+        return true;
+    }
     const loadMoreElement = hasClosestByAttribute(event.target, "data-type", "av-load-more");
     if (loadMoreElement) {
         (blockElement.querySelector(".av__row--footer") as HTMLElement).style.transform = "";
@@ -178,16 +190,6 @@ export const avClick = (protyle: IProtyle, event: MouseEvent & { target: HTMLEle
             target.parentElement.classList.add("av__cell--select");
             addDragFill(target.parentElement);
             hintRef(target.previousElementSibling.textContent.trim(), protyle, "av");
-            event.preventDefault();
-            event.stopPropagation();
-            return true;
-        } else if (type === "set-page-size") {
-            setPageSize({
-                target,
-                protyle,
-                avID: blockElement.getAttribute("data-av-id"),
-                nodeElement: blockElement
-            });
             event.preventDefault();
             event.stopPropagation();
             return true;

--- a/app/src/protyle/render/av/render.ts
+++ b/app/src/protyle/render/av/render.ts
@@ -264,14 +264,12 @@ ${cell.color ? `color:${cell.color};` : ""}">${renderCell(cell.value, rowIndex)}
                 <div class="av__colsticky">
                     <button class="b3-button" data-type="av-add-bottom">
                         <svg><use xlink:href="#iconAdd"></use></svg>
-                        ${window.siyuan.languages.newRow}
+                        <span>${window.siyuan.languages.newRow}</span>
                     </button>
                     <span class="fn__space"></span>
-                    <button class="b3-button${data.rowCount > data.rows.length ? "" : " fn__none"}">
-                        <svg data-type="av-load-more"><use xlink:href="#iconArrowDown"></use></svg>
-                        <span data-type="av-load-more">
-                            ${window.siyuan.languages.loadMore}
-                        </span>
+                    <button class="b3-button data-type="av-load-more"${data.rowCount > data.rows.length ? "" : " fn__none"}">
+                        <svg><use xlink:href="#iconArrowDown"></use></svg>
+                        <span>${window.siyuan.languages.loadMore}</span>
                         <svg data-type="set-page-size" data-size="${data.pageSize}"><use xlink:href="#iconMore"></use></svg>
                     </button>
                 </div>

--- a/app/src/protyle/render/av/render.ts
+++ b/app/src/protyle/render/av/render.ts
@@ -267,7 +267,7 @@ ${cell.color ? `color:${cell.color};` : ""}">${renderCell(cell.value, rowIndex)}
                         <span>${window.siyuan.languages.newRow}</span>
                     </button>
                     <span class="fn__space"></span>
-                    <button class="b3-button data-type="av-load-more"${data.rowCount > data.rows.length ? "" : " fn__none"}">
+                    <button class="b3-button${data.rowCount > data.rows.length ? "" : " fn__none"}" data-type="av-load-more">
                         <svg><use xlink:href="#iconArrowDown"></use></svg>
                         <span>${window.siyuan.languages.loadMore}</span>
                         <svg data-type="set-page-size" data-size="${data.pageSize}"><use xlink:href="#iconMore"></use></svg>


### PR DESCRIPTION
我的需求是使用这个代码片段：

```
.av__container {
    width: 100%;

    .av__body {
        min-width: 100%;

        .av__row--header {
            .block__icons {
                padding: unset;
                flex-direction: row; /* "添加字段"和"更多"按钮调换顺序 */
                flex-grow: 1;
                align-items: stretch; /* 使子元素在垂直方向上填满父容器 */

                .block__icon {
                    border-radius: unset;
                    padding: 0 10px;

                    &:nth-child(1) {
                        order: 1;
                        flex-grow: 1;
                    }
  
                    &:nth-child(3) {
                        order: 0; /* 添加字段按钮排在前面 */
                    }
                }

                >.fn__space {
                    display: none;
                }
            }
        }

        .av__row--util {
            .av__colsticky {
                width: 100%;
                flex-direction: column; /* "添加条目"和"加载更多"按钮分成两行显示 */
  
                >.b3-button {
                    border-radius: unset;
                    margin: unset;
                    padding: unset;
                    height: 2.7em;
                    justify-content: flex-start;
                    border-bottom: 1px solid var(--b3-theme-surface-lighter);
                    position: sticky;
                    left: 5px;

                    span {
                        position: sticky;
                        left: 28px;
                    }

                    svg {
                        position: sticky;
                        left: 5px;
                        padding-right: 10px;

                        &[data-type="set-page-size"] {
                            margin-left: auto;
                            padding: 2px 6px;
                            right: 5px;

                            &:hover {
                                background-color: var(--b3-list-hover);
                            }
                        }
                    }
                }

                > .b3-button:first-of-type {
                    order: 2; /* 将 "添加条目" 按钮放在底部 */
                }
  
                > .b3-button:last-of-type {
                    order: 1; /* 将 "加载更多" 按钮放在顶部 */
                }

                >.fn__space {
                    display: none;
                }
            }
        }

        .av__row--footer {
            border-top: unset;
        }
    }
}
```

实现这个类似 Notion 的样式：#12950

[video.webm](https://github.com/user-attachments/assets/36a79645-0447-45c6-ad35-33ee33b39ba8)

但目前的结构实现不了，必须要改动一点