### PR TITLE
Improve drag block highlighting

### DIFF
--- a/app/src/assets/scss/business/_drag.scss
+++ b/app/src/assets/scss/business/_drag.scss
@@ -1,5 +1,16 @@
 .dragover {
-  background-color: var(--b3-theme-primary-lightest) !important;
+
+  &::after {
+    background-color: var(--b3-theme-primary-lightest);
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    content: " ";
+    left: 0;
+    top: 0;
+    z-index: 3;
+    pointer-events: none;
+  }
 
   // 需要 !important，否则拖拽到闪卡无效果
   &__top {


### PR DESCRIPTION
用背景色的话会影响数据库和表格的内部元素的颜色显示，所以改成跟选中块一样用伪元素

![image](https://github.com/user-attachments/assets/fba3de38-ae85-415a-9784-6f734c5fb81c)
