### PR TITLE
Improve drag block to database highlighting

### DIFF
--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -125,14 +125,26 @@
     position: relative;
     font-size: 87.5%;
 
-    &.dragover__bottom {
-      border-bottom-color: var(--b3-theme-primary-lighter);
+    &.dragover__top::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: -2.5px;
+      height: 4px;
+      background-color: var(--b3-theme-primary-lighter);
       z-index: 3;
     }
 
-    &.dragover__top {
+    &.dragover__bottom::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -2.5px;
+      height: 4px;
+      background-color: var(--b3-theme-primary-lighter);
       z-index: 3;
-      box-shadow: 0 -3px 0 var(--b3-theme-primary-lighter), inset 0 2px 0 var(--b3-theme-primary-lighter) !important;
     }
 
     &:hover [data-type="block-more"] {

--- a/app/src/assets/scss/business/_drag.scss
+++ b/app/src/assets/scss/business/_drag.scss
@@ -2,12 +2,12 @@
   background-color: var(--b3-theme-primary-lightest) !important;
 
   // 需要 !important，否则拖拽到闪卡无效果
-  &__top {
+  &__top:not(.av__row) {
     border-radius: 0 !important;
     box-shadow: 0 -3px 0 var(--b3-theme-primary-lighter), inset 0 1px 0 var(--b3-theme-primary-lighter) !important;
   }
 
-  &__bottom {
+  &__bottom:not(.av__row) {
     border-radius: 0 !important;
     box-shadow: 0 2px 0 var(--b3-theme-primary-lighter), inset 0 -2px 0 var(--b3-theme-primary-lighter) !important;
   }


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/13251

---

还有一个问题需要解决，但我不会改：

- 拖拽块（或当前数据库条目）到 .av__row--util 元素上时，应该在前一个元素（也就是最后一个 .av__row 元素）上添加 .dragover__bottom 类名
- 目前会在 .av__row--util 元素上添加 .dragover__top 或 .dragover__bottom 类名，不符合预期

---

另外，是两个都用 `::before` 或者 `::after`，还是一个用 `::before` 另一个用 `::after` ，我拿不定主意