### PR TITLE
Improve tooltip

### DIFF
--- a/app/src/dialog/tooltip.ts
+++ b/app/src/dialog/tooltip.ts
@@ -20,8 +20,6 @@ export const showTooltip = (message: string, target: Element, tooltipClass?: str
 
     if (tooltipClass) {
         messageElement.classList.add("tooltip--" + tooltipClass);
-    } else {
-        messageElement.className = "tooltip";
     }
 
     let left = targetRect.left;

--- a/app/src/dialog/tooltip.ts
+++ b/app/src/dialog/tooltip.ts
@@ -14,11 +14,11 @@ export const showTooltip = (message: string, target: Element, tooltipClass?: str
         document.body.insertAdjacentHTML("beforeend", `<div class="tooltip" id="tooltip">${message}</div>`);
         messageElement = document.getElementById("tooltip");
     } else {
+        messageElement.className = "tooltip";
         messageElement.innerHTML = message;
     }
 
     if (tooltipClass) {
-        messageElement.className = "tooltip";
         messageElement.classList.add("tooltip--" + tooltipClass);
     } else {
         messageElement.className = "tooltip";

--- a/app/src/dialog/tooltip.ts
+++ b/app/src/dialog/tooltip.ts
@@ -18,6 +18,7 @@ export const showTooltip = (message: string, target: Element, tooltipClass?: str
     }
 
     if (tooltipClass) {
+        messageElement.className = "tooltip";
         messageElement.classList.add("tooltip--" + tooltipClass);
     } else {
         messageElement.className = "tooltip";


### PR DESCRIPTION
悬浮提示的内容改变前先重置一次类名，避免以下问题：

从备注跳到链接时，还保留着备注的类名

[video.webm](https://github.com/user-attachments/assets/1a48f597-c564-46b1-91f7-ade824f2eeb9)
