### PR TITLE
改进光标样式

### DIFF
--- a/app/src/assets/scss/component/_dialog.scss
+++ b/app/src/assets/scss/component/_dialog.scss
@@ -54,6 +54,7 @@
   }
 
   &__header {
+    cursor: default;
     padding: 9px 24px;
     line-height: 24px;
     font-size: 16px;


### PR DESCRIPTION
这里是不能选中文本的：

![image](https://github.com/user-attachments/assets/68d9a263-7a5f-44d7-ad96-64300e50c644)

![image](https://github.com/user-attachments/assets/2ea93218-54f6-4374-871d-bbb8720570f4)
