### PR TITLE
Kernel serve CalDAV service on path `/caldav/`

### DIFF
--- a/kernel/go.mod
+++ b/kernel/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dgraph-io/ristretto v1.0.0
 	github.com/djherbis/times v1.6.0
+	github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6
 	github.com/emersion/go-vcard v0.0.0-20241024213814-c9703dde27ff
 	github.com/emersion/go-webdav v0.5.1-0.20240713135526-7f8c17ad7135
 	github.com/emirpasic/gods v1.18.1
@@ -154,6 +155,7 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
+	github.com/teambition/rrule-go v1.8.2 // indirect
 	github.com/tetratelabs/wazero v1.7.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect

--- a/kernel/go.sum
+++ b/kernel/go.sum
@@ -89,6 +89,7 @@ github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5Jflh
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6 h1:kHoSgklT8weIDl6R6xFpBJ5IioRdBU1v2X2aCZRVCcM=
 github.com/emersion/go-ical v0.0.0-20240127095438-fc1c9d8fb2b6/go.mod h1:BEksegNspIkjCQfmzWgsgbu6KdeJ/4LwUZs7DMBzjzw=
 github.com/emersion/go-vcard v0.0.0-20230815062825-8fda7d206ec9/go.mod h1:HMJKR5wlh/ziNp+sHEDV2ltblO4JD2+IdDOWtGcQBTM=
 github.com/emersion/go-vcard v0.0.0-20241024213814-c9703dde27ff h1:4N8wnS3f1hNHSmFD5zgFkWCyA4L1kCDkImPAtK7D6tg=
@@ -375,6 +376,7 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/studio-b12/gowebdav v0.9.0 h1:1j1sc9gQnNxbXXM4M/CebPOX4aXYtr7MojAVcN4dHjU=
 github.com/studio-b12/gowebdav v0.9.0/go.mod h1:bHA7t77X/QFExdeAnDzK6vKM34kEZAcE1OX4MfiwjkE=
+github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
 github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
 github.com/tetratelabs/wazero v1.7.3 h1:PBH5KVahrt3S2AHgEjKu4u+LlDbbk+nsGE3KLucy6Rw=
 github.com/tetratelabs/wazero v1.7.3/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=

--- a/kernel/model/caldav.go
+++ b/kernel/model/caldav.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -647,7 +646,7 @@ func (o *CalendarObject) update() error {
 	o.Data.Path = PathJoinWithSlash(o.CalendarPath, addressFileInfo.Name())
 	o.Data.ModTime = addressFileInfo.ModTime()
 	o.Data.ContentLength = addressFileInfo.Size()
-	o.Data.ETag = fmt.Sprintf("%x-%x", addressFileInfo.ModTime(), addressFileInfo.Size())
+	o.Data.ETag = FileETag(addressFileInfo)
 
 	return nil
 }
@@ -655,17 +654,17 @@ func (o *CalendarObject) update() error {
 type CalDavBackend struct{}
 
 func (b *CalDavBackend) CurrentUserPrincipal(ctx context.Context) (string, error) {
-	logging.LogDebugf("CalDAV CurrentUserPrincipal")
+	// logging.LogDebugf("CalDAV CurrentUserPrincipal")
 	return CalDavUserPrincipalPath, nil
 }
 
 func (b *CalDavBackend) CalendarHomeSetPath(ctx context.Context) (string, error) {
-	logging.LogDebugf("CalDAV CalendarHomeSetPath")
+	// logging.LogDebugf("CalDAV CalendarHomeSetPath")
 	return CalDavHomeSetPath, nil
 }
 
 func (b *CalDavBackend) CreateCalendar(ctx context.Context, calendar *caldav.Calendar) (err error) {
-	logging.LogDebugf("CalDAV CreateCalendar -> calendar: %#v", calendar)
+	// logging.LogDebugf("CalDAV CreateCalendar -> calendar: %#v", calendar)
 	calendar.Path = PathCleanWithSlash(calendar.Path)
 
 	if err = calendars.Load(); err != nil {
@@ -673,23 +672,23 @@ func (b *CalDavBackend) CreateCalendar(ctx context.Context, calendar *caldav.Cal
 	}
 
 	err = calendars.CreateCalendar(calendar)
-	logging.LogDebugf("CalDAV CreateCalendar <- err: %s", err)
+	// logging.LogDebugf("CalDAV CreateCalendar <- err: %s", err)
 	return
 }
 
 func (b *CalDavBackend) ListCalendars(ctx context.Context) (calendars_ []caldav.Calendar, err error) {
-	logging.LogDebugf("CalDAV ListCalendars")
+	// logging.LogDebugf("CalDAV ListCalendars")
 	if err = calendars.Load(); err != nil {
 		return
 	}
 
 	calendars_, err = calendars.ListCalendars()
-	logging.LogDebugf("CalDAV ListCalendars <- calendars: %#v, err: %s", calendars_, err)
+	// logging.LogDebugf("CalDAV ListCalendars <- calendars: %#v, err: %s", calendars_, err)
 	return
 }
 
 func (b *CalDavBackend) GetCalendar(ctx context.Context, calendarPath string) (calendar *caldav.Calendar, err error) {
-	logging.LogDebugf("CalDAV GetCalendar -> calendarPath: %s", calendarPath)
+	// logging.LogDebugf("CalDAV GetCalendar -> calendarPath: %s", calendarPath)
 	calendarPath = PathCleanWithSlash(calendarPath)
 
 	if err = calendars.Load(); err != nil {
@@ -697,12 +696,12 @@ func (b *CalDavBackend) GetCalendar(ctx context.Context, calendarPath string) (c
 	}
 
 	calendar, err = calendars.GetCalendar(calendarPath)
-	logging.LogDebugf("CalDAV GetCalendar <- calendar: %#v, err: %s", calendar, err)
+	// logging.LogDebugf("CalDAV GetCalendar <- calendar: %#v, err: %s", calendar, err)
 	return
 }
 
 func (b *CalDavBackend) DeleteCalendar(ctx context.Context, calendarPath string) (err error) {
-	logging.LogDebugf("CalDAV DeleteCalendar -> calendarPath: %s", calendarPath)
+	// logging.LogDebugf("CalDAV DeleteCalendar -> calendarPath: %s", calendarPath)
 	calendarPath = PathCleanWithSlash(calendarPath)
 
 	if err = calendars.Load(); err != nil {
@@ -710,12 +709,12 @@ func (b *CalDavBackend) DeleteCalendar(ctx context.Context, calendarPath string)
 	}
 
 	err = calendars.DeleteCalendar(calendarPath)
-	logging.LogDebugf("CalDAV DeleteCalendar <- err: %s", err)
+	// logging.LogDebugf("CalDAV DeleteCalendar <- err: %s", err)
 	return
 }
 
 func (b *CalDavBackend) PutCalendarObject(ctx context.Context, objectPath string, calendar *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (calendarObject *caldav.CalendarObject, err error) {
-	logging.LogDebugf("CalDAV PutCalendarObject -> objectPath: %s, opts: %#v", objectPath, opts)
+	// logging.LogDebugf("CalDAV PutCalendarObject -> objectPath: %s, opts: %#v", objectPath, opts)
 	objectPath = PathCleanWithSlash(objectPath)
 
 	if err = calendars.Load(); err != nil {
@@ -723,12 +722,12 @@ func (b *CalDavBackend) PutCalendarObject(ctx context.Context, objectPath string
 	}
 
 	calendarObject, err = calendars.PutCalendarObject(objectPath, calendar, opts)
-	logging.LogDebugf("CalDAV PutCalendarObject <- calendarObject: %#v, err: %s", calendarObject, err)
+	// logging.LogDebugf("CalDAV PutCalendarObject <- calendarObject: %#v, err: %s", calendarObject, err)
 	return
 }
 
 func (b *CalDavBackend) ListCalendarObjects(ctx context.Context, calendarPath string, req *caldav.CalendarCompRequest) (calendarObjects []caldav.CalendarObject, err error) {
-	logging.LogDebugf("CalDAV ListCalendarObjects -> calendarPath: %s, req: %#v", calendarPath, req)
+	// logging.LogDebugf("CalDAV ListCalendarObjects -> calendarPath: %s, req: %#v", calendarPath, req)
 	calendarPath = PathCleanWithSlash(calendarPath)
 
 	if err = calendars.Load(); err != nil {
@@ -736,12 +735,12 @@ func (b *CalDavBackend) ListCalendarObjects(ctx context.Context, calendarPath st
 	}
 
 	calendarObjects, err = calendars.ListCalendarObjects(calendarPath, req)
-	logging.LogDebugf("CalDAV ListCalendarObjects <- calendarObjects: %#v, err: %s", calendarObjects, err)
+	// logging.LogDebugf("CalDAV ListCalendarObjects <- calendarObjects: %#v, err: %s", calendarObjects, err)
 	return
 }
 
 func (b *CalDavBackend) GetCalendarObject(ctx context.Context, objectPath string, req *caldav.CalendarCompRequest) (calendarObject *caldav.CalendarObject, err error) {
-	logging.LogDebugf("CalDAV GetCalendarObject -> objectPath: %s, req: %#v", objectPath, req)
+	// logging.LogDebugf("CalDAV GetCalendarObject -> objectPath: %s, req: %#v", objectPath, req)
 	objectPath = PathCleanWithSlash(objectPath)
 
 	if err = calendars.Load(); err != nil {
@@ -749,12 +748,12 @@ func (b *CalDavBackend) GetCalendarObject(ctx context.Context, objectPath string
 	}
 
 	calendarObject, err = calendars.GetCalendarObject(objectPath, req)
-	logging.LogDebugf("CalDAV GetCalendarObject <- calendarObject: %#v, err: %s", calendarObject, err)
+	// logging.LogDebugf("CalDAV GetCalendarObject <- calendarObject: %#v, err: %s", calendarObject, err)
 	return
 }
 
 func (b *CalDavBackend) QueryCalendarObjects(ctx context.Context, calendarPath string, query *caldav.CalendarQuery) (calendarObjects []caldav.CalendarObject, err error) {
-	logging.LogDebugf("CalDAV QueryCalendarObjects -> calendarPath: %s, query: %#v", calendarPath, query)
+	// logging.LogDebugf("CalDAV QueryCalendarObjects -> calendarPath: %s, query: %#v", calendarPath, query)
 	calendarPath = PathCleanWithSlash(calendarPath)
 
 	if err = calendars.Load(); err != nil {
@@ -762,12 +761,12 @@ func (b *CalDavBackend) QueryCalendarObjects(ctx context.Context, calendarPath s
 	}
 
 	calendarObjects, err = calendars.QueryCalendarObjects(calendarPath, query)
-	logging.LogDebugf("CalDAV QueryCalendarObjects <- calendarObjects: %#v, err: %s", calendarObjects, err)
+	// logging.LogDebugf("CalDAV QueryCalendarObjects <- calendarObjects: %#v, err: %s", calendarObjects, err)
 	return
 }
 
 func (b *CalDavBackend) DeleteCalendarObject(ctx context.Context, objectPath string) (err error) {
-	logging.LogDebugf("CalDAV DeleteCalendarObject -> objectPath: %s", objectPath)
+	// logging.LogDebugf("CalDAV DeleteCalendarObject -> objectPath: %s", objectPath)
 	objectPath = PathCleanWithSlash(objectPath)
 
 	if err = calendars.Load(); err != nil {
@@ -775,6 +774,6 @@ func (b *CalDavBackend) DeleteCalendarObject(ctx context.Context, objectPath str
 	}
 
 	err = calendars.DeleteCalendarObject(objectPath)
-	logging.LogDebugf("CalDAV DeleteCalendarObject <- err: %s", err)
+	// logging.LogDebugf("CalDAV DeleteCalendarObject <- err: %s", err)
 	return
 }

--- a/kernel/model/caldav.go
+++ b/kernel/model/caldav.go
@@ -17,9 +17,15 @@
 package model
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
 	"sync"
 
+	"github.com/88250/gulu"
 	"github.com/emersion/go-ical"
 	"github.com/emersion/go-webdav/caldav"
 	"github.com/siyuan-note/logging"
@@ -34,6 +40,8 @@ const (
 	CalDavDefaultCalendarPath = CalDavHomeSetPath + "/default"         // 3 resourceTypeCalendar
 
 	CalDavDefaultCalendarName = "default"
+
+	CalDavCalendarsMetaDataFilePath = CalDavHomeSetPath + "/calendars.json"
 
 	ICalendarFileExt = "." + ical.Extension // .ics
 )
@@ -67,7 +75,33 @@ var (
 		calendars:         sync.Map{},
 		calendarsMetaData: []*caldav.Calendar{},
 	}
+
+	ErrorCalDavPathInvalid = errors.New("CalDAV: path is invalid")
+
+	ErrorCalDavCalendarNotFound    = errors.New("CalDAV: calendar not found")
+	ErrorCalDavCalendarPathInvalid = errors.New("CalDAV: calendar path is invalid")
+
+	ErrorCalDavCalendarObjectNotFound    = errors.New("CalDAV: calendar object not found")
+	ErrorCalDavCalendarObjectPathInvalid = errors.New("CalDAV: calendar object path is invalid")
 )
+
+// CalendarsMetaDataFilePath returns the absolute path of the calendars' meta data file
+func CalendarsMetaDataFilePath() string {
+	return DavPath2DirectoryPath(CalDavCalendarsMetaDataFilePath)
+}
+
+// LoadCalendarObject loads a iCalendar file (*.ics)
+func LoadCalendarObject(filePath string) (calendar *ical.Calendar, err error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		logging.LogErrorf("read iCalendar file [%s] failed: %s", filePath, err)
+		return
+	}
+
+	decoder := ical.NewDecoder(bytes.NewReader(data))
+	calendar, err = decoder.Decode()
+	return
+}
 
 type Calendars struct {
 	loaded            bool
@@ -77,6 +111,173 @@ type Calendars struct {
 	calendarsMetaData []*caldav.Calendar
 }
 
+func (c *Calendars) load() error {
+	c.calendars.Clear()
+
+	// load calendars meta data file
+	calendarsMetaDataFilePath := CalendarsMetaDataFilePath()
+	metaData, err := os.ReadFile(calendarsMetaDataFilePath)
+	if os.IsNotExist(err) {
+		// create & save default calendar
+		c.calendarsMetaData = []*caldav.Calendar{&defaultCalendar}
+		if err := c.saveCalendarsMetaData(); err != nil {
+			return err
+		}
+	} else {
+		// load meta data file
+		c.calendarsMetaData = []*caldav.Calendar{}
+		if err = gulu.JSON.UnmarshalJSON(metaData, &c.calendarsMetaData); err != nil {
+			logging.LogErrorf("unmarshal address books meta data failed: %s", err)
+			return err
+		}
+	}
+
+	// load iCalendar files (*.ics)
+	wg := &sync.WaitGroup{}
+	wg.Add(len(c.calendarsMetaData))
+	for _, calendarMetaData := range c.calendarsMetaData {
+		calendar := &Calendar{
+			Changed:       false,
+			DirectoryPath: DavPath2DirectoryPath(calendarMetaData.Path),
+			MetaData:      calendarMetaData,
+			Objects:       sync.Map{},
+		}
+		c.calendars.Store(calendarMetaData.Path, calendar)
+		go func() {
+			defer wg.Done()
+			calendar.load()
+		}()
+	}
+	wg.Wait()
+
+	c.loaded = true
+	c.changed = false
+	return nil
+}
+
+// save all calendars
+func (c *Calendars) saveCalendarsMetaData() error {
+	return SaveMetaData(c.calendarsMetaData, CalendarsMetaDataFilePath())
+}
+
+func (c *Calendars) Load() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.loaded {
+		return c.load()
+	}
+	return nil
+}
+
+func (c *Calendars) CreateCalendar(calendarMetaData *caldav.Calendar) (err error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var calendar *Calendar
+
+	// update map
+	if value, ok := c.calendars.Load(calendarMetaData.Path); ok {
+		// update map item
+		calendar = value.(*Calendar)
+		calendar.MetaData = calendarMetaData
+	} else {
+		// insert map item
+		calendar = &Calendar{
+			Changed:       false,
+			DirectoryPath: DavPath2DirectoryPath(calendarMetaData.Path),
+			MetaData:      calendarMetaData,
+			Objects:       sync.Map{},
+		}
+		c.calendars.Store(calendarMetaData.Path, calendar)
+	}
+
+	var index = -1
+	for i, item := range c.calendarsMetaData {
+		if item.Path == calendarMetaData.Path {
+			index = i
+			break
+		}
+	}
+
+	if index >= 0 {
+		// update list
+		c.calendarsMetaData[index] = calendarMetaData
+	} else {
+		// insert list
+		c.calendarsMetaData = append(c.calendarsMetaData, calendarMetaData)
+	}
+
+	// create calendar directory
+	if err = os.MkdirAll(calendar.DirectoryPath, 0755); err != nil {
+		logging.LogErrorf("create directory [%s] failed: %s", calendar.DirectoryPath, err)
+		return
+	}
+
+	// save meta data
+	if err = c.saveCalendarsMetaData(); err != nil {
+		return
+	}
+
+	return
+}
+
+func (c *Calendars) ListCalendars() (calendars []caldav.Calendar, err error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for _, calendar := range c.calendarsMetaData {
+		calendars = append(calendars, *calendar)
+	}
+	return
+}
+
+func (c *Calendars) GetCalendar(calendarPath string) (calendar *caldav.Calendar, err error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if value, ok := calendars.calendars.Load(calendarPath); ok {
+		calendar = value.(*Calendar).MetaData
+		return
+	}
+
+	err = ErrorCalDavCalendarNotFound
+	return
+}
+
+func (c *Calendars) DeleteCalendar(calendarPath string) (err error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var calendar *Calendar
+
+	// delete map item
+	if value, loaded := c.calendars.LoadAndDelete(calendarPath); loaded {
+		calendar = value.(*Calendar)
+	}
+
+	// delete list item
+	for i, item := range c.calendarsMetaData {
+		if item.Path == calendarPath {
+			c.calendarsMetaData = append(c.calendarsMetaData[:i], c.calendarsMetaData[i+1:]...)
+			break
+		}
+	}
+
+	// remove address book directory
+	if err = os.RemoveAll(calendar.DirectoryPath); err != nil {
+		logging.LogErrorf("remove directory [%s] failed: %s", calendar.DirectoryPath, err)
+		return
+	}
+
+	// save meta data
+	if err = c.saveCalendarsMetaData(); err != nil {
+		return
+	}
+
+	return nil
+}
+
 type Calendar struct {
 	Changed       bool
 	DirectoryPath string
@@ -84,11 +285,93 @@ type Calendar struct {
 	Objects       sync.Map // id -> *CalendarObject
 }
 
+func (c *Calendar) load() error {
+	if err := os.MkdirAll(c.DirectoryPath, 0755); err != nil {
+		logging.LogErrorf("create directory [%s] failed: %s", c.DirectoryPath, err)
+		return err
+	}
+
+	entries, err := os.ReadDir(c.DirectoryPath)
+	if err != nil {
+		logging.LogErrorf("read dir [%s] failed: %s", c.DirectoryPath, err)
+		return err
+	}
+
+	wg := &sync.WaitGroup{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			filename := entry.Name()
+			ext := path.Ext(filename)
+			if ext == ICalendarFileExt {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					// create & load calendar object
+					calendarObjectFilePath := path.Join(c.DirectoryPath, filename)
+					calendarObject := &CalendarObject{
+						Changed:      false,
+						FilePath:     calendarObjectFilePath,
+						CalendarPath: c.MetaData.Path,
+					}
+					err = calendarObject.load()
+					if err != nil {
+						return
+					}
+
+					id := path.Base(filename)
+					c.Objects.Store(id, calendarObject)
+				}()
+			}
+		}
+	}
+	wg.Wait()
+	return nil
+}
+
 type CalendarObject struct {
 	Changed      bool
 	FilePath     string
 	CalendarPath string
 	Data         *caldav.CalendarObject
+}
+
+func (o *CalendarObject) load() error {
+	// load iCalendar file
+	calendarObjectData, err := LoadCalendarObject(o.FilePath)
+	if err != nil {
+		return err
+	}
+
+	// create address object
+	o.Data = &caldav.CalendarObject{
+		Data: calendarObjectData,
+	}
+
+	// update file info
+	err = o.update()
+	if err != nil {
+		return err
+	}
+
+	o.Changed = false
+	return nil
+}
+
+// update file info
+func (o *CalendarObject) update() error {
+	addressFileInfo, err := os.Stat(o.FilePath)
+	if err != nil {
+		logging.LogErrorf("get file [%s] info failed: %s", o.FilePath, err)
+		return err
+	}
+
+	o.Data.Path = PathJoinWithSlash(o.CalendarPath, addressFileInfo.Name())
+	o.Data.ModTime = addressFileInfo.ModTime()
+	o.Data.ContentLength = addressFileInfo.Size()
+	o.Data.ETag = fmt.Sprintf("%x-%x", addressFileInfo.ModTime(), addressFileInfo.Size())
+
+	return nil
 }
 
 type CalDavBackend struct{}
@@ -105,19 +388,45 @@ func (b *CalDavBackend) CalendarHomeSetPath(ctx context.Context) (string, error)
 
 func (b *CalDavBackend) CreateCalendar(ctx context.Context, calendar *caldav.Calendar) (err error) {
 	logging.LogDebugf("CalDAV CreateCalendar -> calendar: %#v", calendar)
-	// TODO: create calendar
+	if err = calendars.Load(); err != nil {
+		return
+	}
+
+	err = calendars.CreateCalendar(calendar)
+	logging.LogDebugf("CalDAV CreateCalendar <- err: %s", err)
 	return
 }
 
-func (b *CalDavBackend) ListCalendars(ctx context.Context) (calendars []caldav.Calendar, err error) {
+func (b *CalDavBackend) ListCalendars(ctx context.Context) (calendars_ []caldav.Calendar, err error) {
 	logging.LogDebugf("CalDAV ListCalendars")
-	// TODO: list calendars
+	if err = calendars.Load(); err != nil {
+		return
+	}
+
+	calendars_, err = calendars.ListCalendars()
+	logging.LogDebugf("CalDAV ListCalendars <- calendars: %#v, err: %s", calendars_, err)
 	return
 }
 
 func (b *CalDavBackend) GetCalendar(ctx context.Context, calendarPath string) (calendar *caldav.Calendar, err error) {
 	logging.LogDebugf("CalDAV GetCalendar -> calendarPath: %s", calendarPath)
-	// TODO: get calendar
+	if err = calendars.Load(); err != nil {
+		return
+	}
+
+	calendar, err = calendars.GetCalendar(calendarPath)
+	logging.LogDebugf("CalDAV GetCalendar <- calendar: %#v, err: %s", calendar, err)
+	return
+}
+
+func (b *CalDavBackend) DeleteCalendar(ctx context.Context, calendarPath string) (err error) {
+	logging.LogDebugf("CalDAV DeleteCalendar -> calendarPath: %s", calendarPath)
+	if err = calendars.Load(); err != nil {
+		return
+	}
+
+	err = calendars.DeleteCalendar(calendarPath)
+	logging.LogDebugf("CalDAV DeleteCalendar <- err: %s", err)
 	return
 }
 

--- a/kernel/model/caldav.go
+++ b/kernel/model/caldav.go
@@ -1,0 +1,107 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package model
+
+import (
+	"context"
+
+	"github.com/emersion/go-ical"
+	"github.com/emersion/go-webdav/caldav"
+	"github.com/siyuan-note/logging"
+)
+
+const (
+	// REF: https://developers.google.com/calendar/caldav/v2/guide
+	CalDavPrefixPath          = "/caldav"
+	CalDavPrincipalsPath      = CalDavPrefixPath + "/principals"       // 0 resourceTypeRoot
+	CalDavUserPrincipalPath   = CalDavPrincipalsPath + "/main"         // 1 resourceTypeUserPrincipal
+	CalDavHomeSetPath         = CalDavUserPrincipalPath + "/calendars" // 2 resourceTypeCalendarHomeSet
+	CalDavDefaultCalendarPath = CalDavHomeSetPath + "/default"         // 3 resourceTypeCalendar
+
+	ICalendarFileExt = ".ics"
+)
+
+type CalDavPathDepth int
+
+const (
+	calDavPathDepth_Root          CalDavPathDepth = 1 + iota // /caldav
+	calDavPathDepth_Principals                               // /caldav/principals
+	calDavPathDepth_UserPrincipal                            // /caldav/principals/main
+	calDavPathDepth_HomeSet                                  // /caldav/principals/main/calendars
+	calDavPathDepth_Calendar                                 // /caldav/principals/main/calendars/default
+	calDavPathDepth_Object                                   // /caldav/principals/main/calendars/default/id.ics
+)
+
+type CalDavBackend struct{}
+
+func (b *CalDavBackend) CurrentUserPrincipal(ctx context.Context) (string, error) {
+	logging.LogDebugf("CalDAV CurrentUserPrincipal")
+	return CalDavUserPrincipalPath, nil
+}
+
+func (b *CalDavBackend) CalendarHomeSetPath(ctx context.Context) (string, error) {
+	logging.LogDebugf("CalDAV CalendarHomeSetPath")
+	return CalDavHomeSetPath, nil
+}
+
+func (b *CalDavBackend) CreateCalendar(ctx context.Context, calendar *caldav.Calendar) (err error) {
+	logging.LogDebugf("CalDAV CreateCalendar -> calendar: %#v", calendar)
+	// TODO: create calendar
+	return
+}
+
+func (b *CalDavBackend) ListCalendars(ctx context.Context) (calendars []caldav.Calendar, err error) {
+	logging.LogDebugf("CalDAV ListCalendars")
+	// TODO: list calendars
+	return
+}
+
+func (b *CalDavBackend) GetCalendar(ctx context.Context, path string) (calendar *caldav.Calendar, err error) {
+	logging.LogDebugf("CalDAV GetCalendar -> path: %s", path)
+	// TODO: get calendar
+	return
+}
+
+func (b *CalDavBackend) GetCalendarObject(ctx context.Context, path string, req *caldav.CalendarCompRequest) (calendarObjects *caldav.CalendarObject, err error) {
+	logging.LogDebugf("CalDAV GetCalendarObject -> path: %s, req: %#v", path, req)
+	// TODO: get calendar object
+	return
+}
+
+func (b *CalDavBackend) ListCalendarObjects(ctx context.Context, path string, req *caldav.CalendarCompRequest) (calendarObjects []caldav.CalendarObject, err error) {
+	logging.LogDebugf("CalDAV ListCalendarObjects -> path: %s, req: %#v", path, req)
+	// TODO: list calendar objects
+	return
+}
+
+func (b *CalDavBackend) QueryCalendarObjects(ctx context.Context, path string, query *caldav.CalendarQuery) (calendarObjects []caldav.CalendarObject, err error) {
+	logging.LogDebugf("CalDAV QueryCalendarObjects -> path: %s, query: %#v", path, query)
+	// TODO: query calendar objects
+	return
+}
+
+func (b *CalDavBackend) PutCalendarObject(ctx context.Context, path string, calendar *ical.Calendar, opts *caldav.PutCalendarObjectOptions) (calendarObject *caldav.CalendarObject, err error) {
+	logging.LogDebugf("CalDAV PutCalendarObject -> path: %s, opts: %#v", path, opts)
+	// TODO: put calendar object
+	return
+}
+
+func (b *CalDavBackend) DeleteCalendarObject(ctx context.Context, path string) (err error) {
+	logging.LogDebugf("CalDAV DeleteCalendarObject -> path: %s", path)
+	// TODO: delete calendar object
+	return
+}

--- a/kernel/model/carddav.go
+++ b/kernel/model/carddav.go
@@ -777,7 +777,7 @@ func (o *AddressObject) update() error {
 	o.Data.Path = PathJoinWithSlash(o.BookPath, addressFileInfo.Name())
 	o.Data.ModTime = addressFileInfo.ModTime()
 	o.Data.ContentLength = addressFileInfo.Size()
-	o.Data.ETag = fmt.Sprintf("%x-%x", addressFileInfo.ModTime(), addressFileInfo.Size())
+	o.Data.ETag = FileETag(addressFileInfo)
 
 	return nil
 }

--- a/kernel/model/carddav.go
+++ b/kernel/model/carddav.go
@@ -47,7 +47,7 @@ const (
 
 	CardDavAddressBooksMetaDataFilePath = CardDavHomeSetPath + "/address-books.json"
 
-	VCardFileExt = ".vcf"
+	VCardFileExt = "." + vcard.Extension // .vcf
 )
 
 type CardDavPathDepth int
@@ -63,14 +63,13 @@ const (
 
 var (
 	addressBookMaxResourceSize      int64 = 0
-	addressBookContentType                = "text/vcard"
 	addressBookSupportedAddressData       = []carddav.AddressDataType{
 		{
-			ContentType: addressBookContentType,
+			ContentType: vcard.MIMEType,
 			Version:     "3.0",
 		},
 		{
-			ContentType: addressBookContentType,
+			ContentType: vcard.MIMEType,
 			Version:     "4.0",
 		},
 	}
@@ -99,6 +98,23 @@ var (
 	ErrorAddressNotFound                 = errors.New("CardDAV: address not found")
 	ErrorAddressFileExtensionNameInvalid = errors.New("CardDAV: address file extension name is invalid")
 )
+
+// ImportVCardFile imports a address book from a vCard file (*.vcf)
+func ImportAddressBook(addressBookPath, cardContent string) (addresses []*AddressObject, err error) {
+	// TODO: Check whether the path is valid (PathDepth: Address)
+	// TODO: Check whether the address book exists
+	// TODO: Decode the card content
+	// TODO: Save the cards to the file system
+	return
+}
+
+// ExportAddressBook exports a address book to a vCard file (*.vcf)
+func ExportAddressBook(addressBookPath string) (cardContent string, err error) {
+	// TODO: Check whether the path is valid (PathDepth: AddressBook)
+	// TODO: Check whether the address book exists
+	// TODO: Encode the card content
+	return
+}
 
 // CardDavPath2DirectoryPath converts CardDAV path to absolute path of the file system
 func CardDavPath2DirectoryPath(cardDavPath string) string {
@@ -791,8 +807,8 @@ func (b *CardDavBackend) CurrentUserPrincipal(ctx context.Context) (string, erro
 	return CardDavUserPrincipalPath, nil
 }
 
-func (b *CardDavBackend) AddressBookHomeSetDirectoryPath(ctx context.Context) (string, error) {
-	// logging.LogDebugf("CardDAV AddressBookHomeSetDirectoryPath")
+func (b *CardDavBackend) AddressBookHomeSetPath(ctx context.Context) (string, error) {
+	// logging.LogDebugf("CardDAV AddressBookHomeSetPath")
 	return CardDavHomeSetPath, nil
 }
 

--- a/kernel/model/dav.go
+++ b/kernel/model/dav.go
@@ -1,0 +1,65 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package model
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/88250/gulu"
+	"github.com/emersion/go-webdav/caldav"
+	"github.com/emersion/go-webdav/carddav"
+	"github.com/siyuan-note/logging"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+// PathJoinWithSlash joins the elements to a path with slash ('/') character
+func PathJoinWithSlash(elems ...string) string {
+	return filepath.ToSlash(filepath.Join(elems...))
+}
+
+// PathCleanWithSlash cleans the path
+func PathCleanWithSlash(p string) string {
+	return filepath.ToSlash(filepath.Clean(p))
+}
+
+// DavPath2DirectoryPath converts CalDAV/CardDAV path to absolute path of the file system
+func DavPath2DirectoryPath(davPath string) string {
+	return PathJoinWithSlash(util.DataDir, "storage", davPath)
+}
+
+func SaveMetaData[T []*caldav.Calendar | []*carddav.AddressBook](metaData T, metaDataFilePath string) error {
+	data, err := gulu.JSON.MarshalIndentJSON(metaData, "", "  ")
+	if err != nil {
+		logging.LogErrorf("marshal address books meta data failed: %s", err)
+		return err
+	}
+
+	dirPath := path.Dir(metaDataFilePath)
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		logging.LogErrorf("create directory [%s] failed: %s", dirPath, err)
+		return err
+	}
+
+	if err := os.WriteFile(metaDataFilePath, data, 0755); err != nil {
+		logging.LogErrorf("write file [%s] failed: %s", metaDataFilePath, err)
+		return err
+	}
+
+	return nil
+}

--- a/kernel/model/dav.go
+++ b/kernel/model/dav.go
@@ -17,9 +17,12 @@
 package model
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/88250/gulu"
 	"github.com/emersion/go-webdav/caldav"
@@ -62,4 +65,13 @@ func SaveMetaData[T []*caldav.Calendar | []*carddav.AddressBook](metaData T, met
 	}
 
 	return nil
+}
+
+// FileETag generates an ETag for a file
+func FileETag(fileInfo fs.FileInfo) string {
+	return fmt.Sprintf(
+		"%s-%x",
+		fileInfo.ModTime().Format(time.RFC3339),
+		fileInfo.Size(),
+	)
 }

--- a/kernel/model/session.go
+++ b/kernel/model/session.go
@@ -305,7 +305,9 @@ func CheckAuth(c *gin.Context) {
 	}
 
 	// WebDAV BasicAuth Authenticate
-	if strings.HasPrefix(c.Request.RequestURI, "/webdav") || strings.HasPrefix(c.Request.RequestURI, "/carddav") {
+	if strings.HasPrefix(c.Request.RequestURI, "/webdav") ||
+		strings.HasPrefix(c.Request.RequestURI, "/caldav") ||
+		strings.HasPrefix(c.Request.RequestURI, "/carddav") {
 		c.Header(BasicAuthHeaderKey, BasicAuthHeaderValue)
 		c.AbortWithStatus(http.StatusUnauthorized)
 		return

--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -721,7 +721,7 @@ func serveCalDAV(ginServer *gin.Engine) {
 
 	ginGroup := ginServer.Group(model.CalDavPrefixPath, model.CheckAuth, model.CheckAdminRole)
 	ginGroup.Match(CalDavMethods, "/*path", func(c *gin.Context) {
-		logging.LogDebugf("CalDAV -> [%s] %s", c.Request.Method, c.Request.URL.String())
+		// logging.LogDebugf("CalDAV -> [%s] %s", c.Request.Method, c.Request.URL.String())
 		if util.ReadOnly {
 			switch c.Request.Method {
 			case http.MethodPost,

--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/88250/gulu"
+	"github.com/emersion/go-webdav/caldav"
 	"github.com/emersion/go-webdav/carddav"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-contrib/sessions"
@@ -49,7 +50,7 @@ import (
 )
 
 const (
-	MethodMkcol     = "MKCOL"
+	MethodMkCol     = "MKCOL"
 	MethodCopy      = "COPY"
 	MethodMove      = "MOVE"
 	MethodLock      = "LOCK"
@@ -82,13 +83,31 @@ var (
 		http.MethodPut,
 		http.MethodDelete,
 
-		MethodMkcol,
+		MethodMkCol,
 		MethodCopy,
 		MethodMove,
 		MethodLock,
 		MethodUnlock,
 		MethodPropFind,
 		MethodPropPatch,
+	}
+	CalDavMethods = []string{
+		http.MethodOptions,
+		http.MethodHead,
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+
+		MethodMkCol,
+		MethodCopy,
+		MethodMove,
+		// MethodLock,
+		// MethodUnlock,
+		MethodPropFind,
+		MethodPropPatch,
+
+		MethodReport,
 	}
 	CardDavMethods = []string{
 		http.MethodOptions,
@@ -98,9 +117,9 @@ var (
 		http.MethodPut,
 		http.MethodDelete,
 
-		MethodMkcol,
-		// MethodCopy,
-		// MethodMove,
+		MethodMkCol,
+		MethodCopy,
+		MethodMove,
 		// MethodLock,
 		// MethodUnlock,
 		MethodPropFind,
@@ -137,6 +156,7 @@ func Serve(fastMode bool) {
 	serveAppearance(ginServer)
 	serveWebSocket(ginServer)
 	serveWebDAV(ginServer)
+	serveCalDAV(ginServer)
 	serveCardDAV(ginServer)
 	serveExport(ginServer)
 	serveWidgets(ginServer)
@@ -673,7 +693,7 @@ func serveWebDAV(ginServer *gin.Engine) {
 			case http.MethodPost,
 				http.MethodPut,
 				http.MethodDelete,
-				MethodMkcol,
+				MethodMkCol,
 				MethodCopy,
 				MethodMove,
 				MethodLock,
@@ -687,6 +707,41 @@ func serveWebDAV(ginServer *gin.Engine) {
 	})
 }
 
+func serveCalDAV(ginServer *gin.Engine) {
+	// REF: https://github.com/emersion/hydroxide/blob/master/carddav/carddav.go
+	handler := caldav.Handler{
+		Backend: &model.CalDavBackend{},
+		Prefix:  model.CalDavPrincipalsPath,
+	}
+
+	ginServer.Match(CalDavMethods, "/.well-known/caldav", func(c *gin.Context) {
+		logging.LogDebugf("CalDAV [/.well-known/caldav]")
+		handler.ServeHTTP(c.Writer, c.Request)
+	})
+
+	ginGroup := ginServer.Group(model.CalDavPrefixPath, model.CheckAuth, model.CheckAdminRole)
+	ginGroup.Match(CalDavMethods, "/*path", func(c *gin.Context) {
+		logging.LogDebugf("CalDAV -> [%s] %s", c.Request.Method, c.Request.URL.String())
+		if util.ReadOnly {
+			switch c.Request.Method {
+			case http.MethodPost,
+				http.MethodPut,
+				http.MethodDelete,
+				MethodMkCol,
+				MethodCopy,
+				MethodMove,
+				MethodLock,
+				MethodUnlock,
+				MethodPropPatch:
+				c.AbortWithError(http.StatusForbidden, fmt.Errorf(model.Conf.Language(34)))
+				return
+			}
+		}
+		handler.ServeHTTP(c.Writer, c.Request)
+		// logging.LogDebugf("CalDAV <- [%s] %v", c.Request.Method, c.Writer.Status())
+	})
+}
+
 func serveCardDAV(ginServer *gin.Engine) {
 	// REF: https://github.com/emersion/hydroxide/blob/master/carddav/carddav.go
 	handler := carddav.Handler{
@@ -695,18 +750,18 @@ func serveCardDAV(ginServer *gin.Engine) {
 	}
 
 	ginServer.Match(CardDavMethods, "/.well-known/carddav", func(c *gin.Context) {
+		// logging.LogDebugf("CardDAV [/.well-known/carddav]")
 		handler.ServeHTTP(c.Writer, c.Request)
 	})
 
 	ginGroup := ginServer.Group(model.CardDavPrefixPath, model.CheckAuth, model.CheckAdminRole)
 	ginGroup.Match(CardDavMethods, "/*path", func(c *gin.Context) {
-		// logging.LogDebugf("CardDAV -> [%s] %s", c.Request.Method, c.Request.URL.String())
 		if util.ReadOnly {
 			switch c.Request.Method {
 			case http.MethodPost,
 				http.MethodPut,
 				http.MethodDelete,
-				MethodMkcol,
+				MethodMkCol,
 				MethodCopy,
 				MethodMove,
 				MethodLock,
@@ -739,6 +794,7 @@ func shortReqMsg(msg []byte) []byte {
 func corsMiddleware() gin.HandlerFunc {
 	allowMethods := strings.Join(HttpMethods, ", ")
 	allowWebDavMethods := strings.Join(WebDavMethods, ", ")
+	allowCalDavMethods := strings.Join(CalDavMethods, ", ")
 	allowCardDavMethods := strings.Join(CardDavMethods, ", ")
 
 	return func(c *gin.Context) {
@@ -747,13 +803,19 @@ func corsMiddleware() gin.HandlerFunc {
 		c.Header("Access-Control-Allow-Headers", "origin, Content-Length, Content-Type, Authorization")
 		c.Header("Access-Control-Allow-Private-Network", "true")
 
-		if strings.HasPrefix(c.Request.RequestURI, "/webdav/") {
+		if strings.HasPrefix(c.Request.RequestURI, "/webdav") {
 			c.Header("Access-Control-Allow-Methods", allowWebDavMethods)
 			c.Next()
 			return
 		}
 
-		if strings.HasPrefix(c.Request.RequestURI, "/carddav/") {
+		if strings.HasPrefix(c.Request.RequestURI, "/caldav") {
+			c.Header("Access-Control-Allow-Methods", allowCalDavMethods)
+			c.Next()
+			return
+		}
+
+		if strings.HasPrefix(c.Request.RequestURI, "/carddav") {
 			c.Header("Access-Control-Allow-Methods", allowCardDavMethods)
 			c.Next()
 			return

--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -715,7 +715,7 @@ func serveCalDAV(ginServer *gin.Engine) {
 	}
 
 	ginServer.Match(CalDavMethods, "/.well-known/caldav", func(c *gin.Context) {
-		logging.LogDebugf("CalDAV [/.well-known/caldav]")
+		// logging.LogDebugf("CalDAV -> [%s] %s", c.Request.Method, c.Request.URL.String())
 		handler.ServeHTTP(c.Writer, c.Request)
 	})
 
@@ -771,6 +771,7 @@ func serveCardDAV(ginServer *gin.Engine) {
 				return
 			}
 		}
+		// TODO: Can't handle Thunderbird's PROPFIND request with prop <current-user-privilege-set/>
 		handler.ServeHTTP(c.Writer, c.Request)
 		// logging.LogDebugf("CardDAV <- [%s] %v", c.Request.Method, c.Writer.Status())
 	})


### PR DESCRIPTION
- 内核在 `/caldav` 路径下提供 `CalDAV` 服务
  The kernel provides `CalDAV` service on path `/caldav`.
- 该服务可管理 `*.ics` 文件
  This service can manage `*.ics` files.
  - `<workspace>/data/storage/caldav/principals/<principal>/<home-set>/<calendar>/<event-id>.ics`

参考 | Reference:
- [CalDAV API Developer's Guide  |  Google Calendar  |  Google for Developers](https://developers.google.com/calendar/caldav/v2/guide)
- [RFC 4791 - Calendaring Extensions to WebDAV (CalDAV)](https://datatracker.ietf.org/doc/html/rfc4791)
- [RFC 5545 - Internet Calendaring and Scheduling Core Object Specification (iCalendar)](https://datatracker.ietf.org/doc/html/rfc5545)

依赖 | Dependency:
- [caldav package - github.com/emersion/go-webdav/caldav - Go Packages](https://pkg.go.dev/github.com/emersion/go-webdav/caldav)
- [ical package - github.com/emersion/go-ical - Go Packages](https://pkg.go.dev/github.com/emersion/go-ical)

关联 | Relevance:
- https://github.com/siyuan-note/siyuan/pull/12895#issuecomment-2437638683
- #12412