### PR TITLE
Using the middle button to close a tab triggers pasting on Linux

### DIFF
--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -102,17 +102,19 @@ export class Wnd {
                     event.stopPropagation();
                     event.preventDefault();
                     // 阻止 Linux 中键粘贴
-                    const activeElement = document.activeElement;
-                    window.addEventListener("paste", (e) => {
-                        e.preventDefault(); 
-                        e.stopPropagation();
-                    }, {
-                        capture: true,
-                        once: true
-                    });
-                    // 保持原有焦点
-                    if (activeElement instanceof HTMLElement) {
-                        activeElement.focus();
+                    if ("linux" === window.siyuan.config.system.os) {
+                        const activeElement = document.activeElement;
+                        window.addEventListener("paste", (e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }, {
+                            capture: true,
+                            once: true
+                        });
+                        // 保持原有焦点
+                        if (activeElement instanceof HTMLElement) {
+                            activeElement.focus();
+                        }
                     }
                     break;
                 }

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -101,20 +101,26 @@ export class Wnd {
                     window.siyuan.menus.menu.remove();
                     event.stopPropagation();
                     event.preventDefault();
-                    // 阻止 Linux 中键粘贴
-                    if ("linux" === window.siyuan.config.system.os) {
-                        const activeElement = document.activeElement;
-                        window.addEventListener("paste", (e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                        }, {
-                            capture: true,
-                            once: true
+                    const activeElement = document.activeElement;
+                    const pasteHandler = (e: ClipboardEvent) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                    };
+                    window.addEventListener("paste", pasteHandler, {
+                        capture: true,
+                        once: true
+                    });
+
+                    // 如果在短时间内没有 paste 事件发生,移除监听
+                    setTimeout(() => {
+                        window.removeEventListener("paste", pasteHandler, {
+                            capture: true
                         });
-                        // 保持原有焦点
-                        if (activeElement instanceof HTMLElement) {
-                            activeElement.focus();
-                        }
+                    }, 250);
+
+                    // 保持原有焦点
+                    if (activeElement instanceof HTMLElement) {
+                        activeElement.focus();
                     }
                     break;
                 }

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -101,6 +101,10 @@ export class Wnd {
                     window.siyuan.menus.menu.remove();
                     event.stopPropagation();
                     event.preventDefault();
+                    // 阻止 Linux 中键粘贴
+                    setTimeout(() => {
+                        window.getSelection().removeAllRanges();
+                    });
                     break;
                 }
                 target = target.parentElement;

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -102,14 +102,22 @@ export class Wnd {
                     event.stopPropagation();
                     event.preventDefault();
                     // 阻止 Linux 中键粘贴
-                    setTimeout(() => {
-                        window.getSelection().removeAllRanges();
+                    const activeElement = document.activeElement;
+                    window.addEventListener("paste", (e) => {
+                        e.preventDefault(); 
+                        e.stopPropagation();
+                    }, {
+                        capture: true,
+                        once: true
                     });
+                    // 保持原有焦点
+                    if (activeElement instanceof HTMLElement) {
+                        activeElement.focus();
+                    }
                     break;
                 }
                 target = target.parentElement;
             }
-
         });
         this.headersElement.addEventListener("mousewheel", (event: WheelEvent) => {
             this.headersElement.scrollLeft = this.headersElement.scrollLeft + event.deltaY;


### PR DESCRIPTION
解决Linux中使用中键关闭标签页时会触发粘贴的问题(#13309)

## Feature or bug? 特性或者缺陷？

解决https://github.com/siyuan-note/siyuan/issues/13309 中提到的问题，通过在关闭标签页操作中拦截粘贴事件解决该问题，这样不会影响其他场景下的中键粘贴功能

## 现有问题

Linux中，使用中键关闭标签页时会触发中键粘贴功能，如下视频所示：

https://github.com/user-attachments/assets/b7b12d9c-8e90-44c8-a82b-7fdd4cc740cc


## 修复后在X11上的测试

https://github.com/user-attachments/assets/5d9db3c1-c4c6-4efb-b7a4-b4de09623f39

## 修复后在Wayland上的测试

https://github.com/user-attachments/assets/0dd509b7-74ed-4227-b65d-009b9570b374
