### PR TITLE
Improve tab drag highlighting

### DIFF
--- a/app/src/assets/scss/business/_layout.scss
+++ b/app/src/assets/scss/business/_layout.scss
@@ -182,8 +182,6 @@
         background-color: var(--b3-theme-primary-lightest);
         position: absolute;
         z-index: 100;
-        height: 100%;
-        width: 100%;
         transition: var(--b3-transition);
       }
     }

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -326,9 +326,9 @@ export class Wnd {
             const x = event.clientX - rect.left;
             const y = event.clientY - rect.top;
 
-            if (x < width / 3 && x / y < 2 * width / height && x / (height - y) < 2 * width / height) {
+            if (x < width / 6 || x < width / 3 && (x - width / 6) / y < width / height && (x - width / 6) / (height - y) < width / height) {
                 dragElement.setAttribute("style", "height:100%;width:50%;right:50%;bottom:0;left:0;top:0");
-            } else if (x > width * 2 / 3 && (width - x) / y < 2 * width / height && (width - x) / (height - y) < 2 * width / height) {
+            } else if (x > width * 5 / 6 || x > width * 2 / 3 && (width * 5 / 6 - x) / y < width / height && (width * 5 / 6 - x) / (height - y) < width / height) {
                 dragElement.setAttribute("style", "height:100%;width:50%;right:0;bottom:0;left:50%;top:0");
             } else if (y < height / 6) {
                 dragElement.setAttribute("style", "height:50%;width:100%;right:0;bottom:50%;left:0;top:0");

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -320,6 +320,25 @@ export class Wnd {
             saveLayout();
         });
 
+        const updateDragElementStyle = (event: DragEvent, rect: DOMRect, dragElement: HTMLElement) => {
+            const height = rect.height;
+            const width = rect.width;
+            const x = event.clientX - rect.left;
+            const y = event.clientY - rect.top;
+
+            if (x < width / 3 && x / y < 2 * width / height && x / (height - y) < 2 * width / height) {
+                dragElement.setAttribute("style", "height:100%;width:50%;right:50%;bottom:0;left:0;top:0");
+            } else if (x > width * 2 / 3 && (width - x) / y < 2 * width / height && (width - x) / (height - y) < 2 * width / height) {
+                dragElement.setAttribute("style", "height:100%;width:50%;right:0;bottom:0;left:50%;top:0");
+            } else if (y < height / 6) {
+                dragElement.setAttribute("style", "height:50%;width:100%;right:0;bottom:50%;left:0;top:0");
+            } else if (y > height * 5 / 6) {
+                dragElement.setAttribute("style", "height:50%;width:100%;right:0;bottom:0;left:0;top:50%");
+            } else {
+                dragElement.setAttribute("style", "height:100%;width:100%;right:0;bottom:0;left:0;top:0");
+            }
+        };
+
         this.element.addEventListener("dragenter", (event: DragEvent & { target: HTMLElement }) => {
             if (event.dataTransfer.types.includes(Constants.SIYUAN_DROP_TAB)) {
                 const tabHeadersElement = hasClosestByClassName(event.target, "layout-tab-bar");
@@ -329,7 +348,8 @@ export class Wnd {
                 const tabPanelsElement = hasClosestByClassName(event.target, "layout-tab-container", true);
                 if (tabPanelsElement) {
                     dragElement.classList.remove("fn__none");
-                    dragElement.setAttribute("style", "height:100%;width:100%;right:auto;bottom:auto");
+                    const rect = dragElement.parentElement.getBoundingClientRect();
+                    updateDragElementStyle(event, rect, dragElement);
                 }
             }
         });
@@ -340,24 +360,12 @@ export class Wnd {
                 return;
             }
             const rect = dragElement.parentElement.getBoundingClientRect();
-            const height = rect.height;
-            const width = rect.width;
-            const x = event.clientX - rect.left;
-            const y = event.clientY - rect.top;
-            if (x <= width / 8 || (x <= width / 3 && x > width / 8 && y >= height / 8 && y <= height * 7 / 8)) {
-                dragElement.setAttribute("style", "height:100%;width:50%;right:50%;bottom:0;left:0;top:0");
-            } else if (x >= width * 7 / 8 || (x >= width * 2 / 3 && x < width * 7 / 8 && y >= height / 8 && y <= height * 7 / 8)) {
-                dragElement.setAttribute("style", "height:100%;width:50%;right:0;bottom:0;left:50%;top:0");
-            } else if (y <= height / 8) {
-                dragElement.setAttribute("style", "height:50%;width:100%;right:0;bottom:50%;left:0;top:0");
-            } else if (y >= height * 7 / 8) {
-                dragElement.setAttribute("style", "height:50%;width:100%;right:0;bottom:0;left:0;top:50%");
-            } else {
-                dragElement.setAttribute("style", "height:100%;width:100%;right:0;bottom:0;top:0;left:0");
-            }
+            updateDragElementStyle(event, rect, dragElement);
         });
+
         dragElement.addEventListener("dragleave", () => {
             dragElement.classList.add("fn__none");
+            dragElement.removeAttribute("style");
         });
         dragElement.addEventListener("drop", (event: DragEvent & { target: HTMLElement }) => {
             dragElement.classList.add("fn__none");
@@ -374,6 +382,7 @@ export class Wnd {
             }
             /// #endif
             if (!oldTab) {
+                dragElement.removeAttribute("style");
                 return;
             }
 
@@ -406,10 +415,12 @@ export class Wnd {
                 /// #if !BROWSER
                 setTabPosition();
                 /// #endif
+                dragElement.removeAttribute("style");
                 return;
             }
 
             if (targetWndElement.contains(document.querySelector(`[data-id="${tabData.id}"]`))) {
+                dragElement.removeAttribute("style");
                 return;
             }
             if (targetWnd) {
@@ -418,6 +429,8 @@ export class Wnd {
                 targetWnd.moveTab(oldTab);
                 resizeTabs();
             }
+
+            dragElement.removeAttribute("style");
         });
     }
 

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -326,9 +326,9 @@ export class Wnd {
             const x = event.clientX - rect.left;
             const y = event.clientY - rect.top;
 
-            if (x < width / 6 || x < width / 3 && (x - width / 6) / y < width / height && (x - width / 6) / (height - y) < width / height) {
+            if (x < width / 3 && (x - width / 6) / y < width / height && x / (height - y) < 2 * width / height) {
                 dragElement.setAttribute("style", "height:100%;width:50%;right:50%;bottom:0;left:0;top:0");
-            } else if (x > width * 5 / 6 || x > width * 2 / 3 && (width * 5 / 6 - x) / y < width / height && (width * 5 / 6 - x) / (height - y) < width / height) {
+            } else if (x > width * 2 / 3 && (width * 5 / 6 - x) / y < width / height && (width - x) / (height - y) < 2 * width / height) {
                 dragElement.setAttribute("style", "height:100%;width:50%;right:0;bottom:0;left:50%;top:0");
             } else if (y < height / 6) {
                 dragElement.setAttribute("style", "height:50%;width:100%;right:0;bottom:50%;left:0;top:0");


### PR DESCRIPTION
:art: 改进页签拖拽高亮

主要改进两个问题：

1. 从上方或左侧将页签拖入 protyle 时动画方向的一点问题
2. 从下方或右侧将页签拖入 protyle 时会出现预期外的滚动条

问题的录屏：

[video.webm](https://github.com/user-attachments/assets/417b7424-4d75-4525-883f-c5ea3dd8dadb)

然后还把位置判断的部分改了，之前的区域是方形的，现在改成梯形：

![bdabc1b1955551b07f596542198a8b16](https://github.com/user-attachments/assets/d7d4e29e-275f-490b-ad80-2d7877b0e2e1)

另外，有的地方我没看懂所以不知道有没有改对