### PR TITLE
Add Kernel API for subscribe broadcast message by SSE

### DIFF
--- a/kernel/api/broadcast.go
+++ b/kernel/api/broadcast.go
@@ -62,7 +62,7 @@ func (m *MessageID) Next() uint64 {
 }
 
 type MessageEvent struct {
-	ID   uint64 // event ID
+	ID   string // event ID
 	Type MessageType
 	Name string // channel name
 	Data []byte
@@ -190,11 +190,11 @@ func (s *EventSourceServer) Start() {
 
 // SendEvent sends a message to all subscribers
 func (s *EventSourceServer) SendEvent(event *MessageEvent) bool {
-	if event.ID == 0 {
+	if event.ID == "" {
 		switch event.Type {
 		case MessageTypeClose:
 		default:
-			event.ID = messageID.Next()
+			event.ID = strconv.FormatUint(messageID.Next(), 10)
 		}
 	}
 
@@ -248,14 +248,14 @@ func (s *EventSourceServer) Subscribe(c *gin.Context, messageEventChannel Messag
 					return false
 				case MessageTypeString:
 					s.SSEvent(c, &sse.Event{
-						Id:    string(event.ID),
+						Id:    event.ID,
 						Event: event.Name,
 						Retry: retry,
 						Data:  string(event.Data),
 					})
 				default:
 					s.SSEvent(c, &sse.Event{
-						Id:    string(event.ID),
+						Id:    event.ID,
 						Event: event.Name,
 						Retry: retry,
 						Data:  event.Data,
@@ -303,14 +303,14 @@ func (s *EventSourceServer) SubscribeAll(c *gin.Context, messageEventChannel Mes
 				return true
 			case MessageTypeString:
 				s.SSEvent(c, &sse.Event{
-					Id:    string(event.ID),
+					Id:    event.ID,
 					Event: event.Name,
 					Retry: retry,
 					Data:  string(event.Data),
 				})
 			default:
 				s.SSEvent(c, &sse.Event{
-					Id:    string(event.ID),
+					Id:    event.ID,
 					Event: event.Name,
 					Retry: retry,
 					Data:  event.Data,

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -457,6 +457,8 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/network/forwardProxy", model.CheckAuth, model.CheckAdminRole, forwardProxy)
 
 	ginServer.Handle("GET", "/ws/broadcast", model.CheckAuth, model.CheckAdminRole, broadcast)
+	ginServer.Handle("GET", "/es/broadcast/subscribe", model.CheckAuth, model.CheckAdminRole, EventSourceHandler, broadcastSubscribe)
+
 	ginServer.Handle("POST", "/api/broadcast/publish", model.CheckAuth, model.CheckAdminRole, broadcastPublish)
 	ginServer.Handle("POST", "/api/broadcast/postMessage", model.CheckAuth, model.CheckAdminRole, postMessage)
 	ginServer.Handle("POST", "/api/broadcast/getChannels", model.CheckAuth, model.CheckAdminRole, getChannels)

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -457,7 +457,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/network/forwardProxy", model.CheckAuth, model.CheckAdminRole, forwardProxy)
 
 	ginServer.Handle("GET", "/ws/broadcast", model.CheckAuth, model.CheckAdminRole, broadcast)
-	ginServer.Handle("GET", "/es/broadcast/subscribe", model.CheckAuth, model.CheckAdminRole, EventSourceHandler, broadcastSubscribe)
+	ginServer.Handle("GET", "/es/broadcast/subscribe", model.CheckAuth, model.CheckAdminRole, broadcastSubscribe)
 
 	ginServer.Handle("POST", "/api/broadcast/publish", model.CheckAuth, model.CheckAdminRole, broadcastPublish)
 	ginServer.Handle("POST", "/api/broadcast/postMessage", model.CheckAuth, model.CheckAdminRole, postMessage)

--- a/kernel/go.mod
+++ b/kernel/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.5
 	github.com/gin-contrib/gzip v1.0.1
 	github.com/gin-contrib/sessions v1.0.1
+	github.com/gin-contrib/sse v0.1.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-ole/go-ole v1.3.0
 	github.com/goccy/go-json v0.10.3
@@ -121,7 +122,6 @@ require (
 	github.com/ebitengine/purego v0.8.1 // indirect
 	github.com/fatih/set v0.2.1 // indirect
 	github.com/gigawattio/window v0.0.0-20180317192513-0f5467e35573 // indirect
-	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.22.1 // indirect

--- a/kernel/model/session.go
+++ b/kernel/model/session.go
@@ -437,8 +437,10 @@ func ControlConcurrency(c *gin.Context) {
 		strings.HasPrefix(reqPath, "/appearance/") ||
 		strings.HasPrefix(reqPath, "/export/") ||
 		strings.HasPrefix(reqPath, "/history/") ||
+
 		strings.HasPrefix(reqPath, "/api/query/") ||
 		strings.HasPrefix(reqPath, "/api/search/") ||
+		strings.HasPrefix(reqPath, "/api/network/") ||
 		strings.HasPrefix(reqPath, "/api/broadcast/") ||
 		strings.HasPrefix(reqPath, "/es/") {
 		c.Next()

--- a/kernel/model/session.go
+++ b/kernel/model/session.go
@@ -426,19 +426,32 @@ func ControlConcurrency(c *gin.Context) {
 	reqPath := c.Request.URL.Path
 
 	// Improve the concurrency of the kernel data reading interfaces https://github.com/siyuan-note/siyuan/issues/10149
-	if strings.HasPrefix(reqPath, "/stage/") || strings.HasPrefix(reqPath, "/assets/") || strings.HasPrefix(reqPath, "/appearance/") {
+	if strings.HasPrefix(reqPath, "/stage/") ||
+		strings.HasPrefix(reqPath, "/assets/") ||
+		strings.HasPrefix(reqPath, "/emojis/") ||
+		strings.HasPrefix(reqPath, "/plugins/") ||
+		strings.HasPrefix(reqPath, "/public/") ||
+		strings.HasPrefix(reqPath, "/snippets/") ||
+		strings.HasPrefix(reqPath, "/templates/") ||
+		strings.HasPrefix(reqPath, "/widgets/") ||
+		strings.HasPrefix(reqPath, "/appearance/") ||
+		strings.HasPrefix(reqPath, "/export/") ||
+		strings.HasPrefix(reqPath, "/history/") ||
+		strings.HasPrefix(reqPath, "/api/query/") ||
+		strings.HasPrefix(reqPath, "/api/search/") ||
+		strings.HasPrefix(reqPath, "/api/broadcast/") ||
+		strings.HasPrefix(reqPath, "/es/") {
 		c.Next()
 		return
 	}
 
 	parts := strings.Split(reqPath, "/")
 	function := parts[len(parts)-1]
-	if strings.HasPrefix(function, "get") || strings.HasPrefix(function, "list") ||
-		strings.HasPrefix(function, "search") || strings.HasPrefix(function, "render") || strings.HasPrefix(function, "ls") {
-		c.Next()
-		return
-	}
-	if strings.HasPrefix(function, "/api/query/") || strings.HasPrefix(function, "/api/search/") {
+	if strings.HasPrefix(function, "get") ||
+		strings.HasPrefix(function, "list") ||
+		strings.HasPrefix(function, "search") ||
+		strings.HasPrefix(function, "render") ||
+		strings.HasPrefix(function, "ls") {
 		c.Next()
 		return
 	}


### PR DESCRIPTION
REL: #9031 

当前广播消息监听 API `/ws/broadcast` 每次仅能订阅一个信道

新增内核 API `/es/broadcast/subscribe`，用户可以使用 [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) 同时订阅多个广播信道
The new kernel API `/es/broadcast/subscribe` allows users use [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) to subscribe multiple broadcast channels at the same time

使用示例 | Examples:
```js
// 订阅所有广播信道 | Subscribe to all broadcast channels
const es = new EventSource("/es/broadcast/subscribe");
es.addEventListener("channel-name", (e) => {
  console.log(e);
});

// 仅订阅广播信道 "ch1" | Subscribe to channel "ch1"
const es1 = new EventSource("/es/broadcast/subscribe?channel=ch1");
es1.addEventListener("ch1", (e) => {
  console.log(e);
});

// 同时订阅广播信道 "ch1" 与 "ch2" | Subscribe to channel "ch1" and "ch2"
const es12 = new EventSource("/es/broadcast/subscribe?channel=ch1&channel=ch2");
es12.addEventListener("ch1", (e) => {
  console.log(e);
});
es12.addEventListener("ch2", (e) => {
  console.log(e);
});

// 自定义连接断开后自动重连时间间隔 (单位: ms) | Custom automatic reconnection interval after disconnection (unit: ms)
const es_retry = new EventSource("/es/broadcast/subscribe?retry=1000");
```

数据格式 | Data format:
- 字符串消息 | string message: `abc` -> `abc`
  - 原格式
    raw
- 二进制消息 | binary message: `abc` -> `"YWJj"`
  - 使用双引号 `"` 包裹的 Base64 编码字符串
    A Base64-encoded string wrapped in quotation marks `"`

已测试 | Tested