### PR TITLE
style: Improve dragover style of file tree

### DIFF
--- a/app/src/assets/scss/base.scss
+++ b/app/src/assets/scss/base.scss
@@ -311,6 +311,11 @@ html {
     opacity: .38;
   }
 
+  .dragover:not([data-type="navigation-root"]):not([data-subtype="h1"])::after {
+    width: calc(100% - var(--file-toggle-width));
+    left: var(--file-toggle-width);
+  }
+
   .dragover__top,
   .dragover__bottom {
     box-shadow: none !important;


### PR DESCRIPTION
.dragover 的样式没有跟 .dragover__top 和 .dragover__bottom 对齐，拖拽的过程中感觉有点晃眼睛，所以改进一下：

[video.webm](https://github.com/user-attachments/assets/b20d7ab9-2f61-4964-a3cc-4b4ac7f31392)
