### PR TITLE
Avoid window controls overlay covering SiYuan toolbar buttons

### DIFF
--- a/app/src/assets/scss/base.scss
+++ b/app/src/assets/scss/base.scss
@@ -106,6 +106,9 @@ html {
 
   &--browser {
     padding-left: 0;
+    margin-left: env(titlebar-area-x, 0);
+    width: env(titlebar-area-width, 100%);
+    height: env(titlebar-area-height, 32px);
   }
 
   #windowControls {


### PR DESCRIPTION
Since we already declares "window-controls-overlay" in our PWA manifest file, we also need to care about the actual place taken by the window controls overlay.

See also:

- https://web.dev/articles/window-controls-overlay

Resolve: https://github.com/siyuan-note/siyuan/issues/13226

Screenshot after patch:

![image](https://github.com/user-attachments/assets/d4a549ac-4aa3-4707-b368-6bcae5446228)

------

## Feature or bug? 特性或者缺陷？

Bug. 缺陷。

## Multilingual or copywriting? 多语言或者文案？

文案无关。

## Dev branch!

已核查目标分支为 dev。
