### PR TITLE
style: finetuning titlebar look-n-feel for PWA support

### DIFF
--- a/app/src/assets/scss/base.scss
+++ b/app/src/assets/scss/base.scss
@@ -105,9 +105,8 @@ html {
   border-bottom: .5px solid var(--b3-border-color);
 
   &--browser {
-    padding-left: 0;
-    margin-left: env(titlebar-area-x, 0);
-    width: env(titlebar-area-width, 100%);
+    padding-left: env(titlebar-area-x, 0);
+    padding-right: calc(100% - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
     height: env(titlebar-area-height, 32px);
   }
 


### PR DESCRIPTION
The previous patch (675e59c) introduce initial PWA WCO support, this patch finetunes the PWA titlebar support by ensure the bottom border of the titlebar is always visible and fill 100% page (window) width, with the following changes:

1. Use margin instead of padding to ensure 'width' fills 100% page width, so does the bottom border.
2. ~~Add extra 1px height to ensure the bottom border won't be covered by the window decoration overlay itself.~~ (Edit: no longer doing this change, see the discussion below)

Remaining PWA stuff:

The remaining PWA WCO part have inconsistent color with the actual color that SiYuan('s titlebar) uses, thus to make the PWA titlebar feel native, we still needs to set either:

- a "theme-color" `<meta>` attribute (suggested)
- a "theme_color" member in the PWA manifest

...which will be a seprated topic that won't be worked on in this patchset.

---

## Feature or bug? 特性或者缺陷？

不是特性也不算是缺陷，是对 675e59c 的微调来使得 PWA 标题栏具备更好的视觉效果。调整后的视觉效果如下：

![image](https://github.com/user-attachments/assets/7c02a2a5-628a-496e-97a3-c7a1dca3e9f4)

相比上一个PR（ https://github.com/siyuan-note/siyuan/pull/13771 ）的视觉效果：

![image](https://github.com/user-attachments/assets/d4a549ac-4aa3-4707-b368-6bcae5446228)

~~此修改旨在使标题栏的底部 border 可以撑满整个窗口，使标题栏的视觉效果看上去更自然。~~ Edit: 此修改目前仅旨在使标题栏盛满整个窗口的宽度，避免 https://github.com/siyuan-note/siyuan/issues/13226#issuecomment-2594551219 问题。此 PR 不再解决标题栏底部分割线被 WCO 遮挡的问题，原因参见下方的讨论。

需要注意，为了满足我自己的视觉效果需求，上面的第一个截图有额外的修改来使 PWA 的窗口装饰背景色和 SiYuan 自身的背景色保持一致。于此相关的变动的概要说明可参见最上面所附的说明（Remaining PWA stuff 部分），此 PR 未包含（也不会包含）关于修改 PWA 主题色的变动。

## Multilingual or copywriting? 多语言或者文案？

否。

## Dev branch!

已确认目标分支为 dev。
