### PR TITLE
Improve the ghosting of list items

### DIFF
--- a/app/src/assets/scss/base.scss
+++ b/app/src/assets/scss/base.scss
@@ -386,5 +386,12 @@ html {
   }
 }
 
+.dragghost [data-node-id] {
+  &.protyle-wysiwyg--select::after,
+  &.protyle-wysiwyg--hl::after {
+    display: none;
+  }
+}
+
 // 需放置最后，否则 https://github.com/siyuan-note/siyuan/issues/7056
 @import "util/responsive";

--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -129,8 +129,8 @@ export class Gutter {
             const ghostElement = document.createElement("div");
             ghostElement.className = protyle.wysiwyg.element.className + " dragghost";
             selectElements.forEach(item => {
-                const type = item.getAttribute("data-type");
                 if (item.querySelector("iframe")) {
+                    const type = item.getAttribute("data-type");
                     const embedElement = genEmptyElement();
                     embedElement.classList.add("protyle-wysiwyg--select");
                     getContenteditableElement(embedElement).innerHTML = `<svg class="svg"><use xlink:href="${buttonElement.querySelector("use").getAttribute("xlink:href")}"></use></svg> ${getLangByType(type)}`;
@@ -141,7 +141,12 @@ export class Gutter {
             });
             ghostElement.setAttribute("style", `position:fixed;opacity:.1;width:${selectElements[0].clientWidth}px;padding:0;`);
             document.body.append(ghostElement);
-            event.dataTransfer.setDragImage(ghostElement, 0, 0);
+            if (selectElements[0].classList.contains("li") && selectElements[0].getAttribute("data-subtype") === "u") {
+                const actionElement = selectElements[0].querySelector(".protyle-action");
+                event.dataTransfer.setDragImage(ghostElement, actionElement.clientWidth / 2, actionElement.clientHeight / 2);
+            } else {
+                event.dataTransfer.setDragImage(ghostElement, 0, 0);
+            }
             setTimeout(() => {
                 ghostElement.remove();
             });

--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -127,7 +127,7 @@ export class Gutter {
             }
 
             const ghostElement = document.createElement("div");
-            ghostElement.className = protyle.wysiwyg.element.className;
+            ghostElement.className = protyle.wysiwyg.element.className + " dragghost";
             selectElements.forEach(item => {
                 const type = item.getAttribute("data-type");
                 if (item.querySelector("iframe")) {

--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -141,7 +141,7 @@ export class Gutter {
             });
             ghostElement.setAttribute("style", `position:fixed;opacity:.1;width:${selectElements[0].clientWidth}px;padding:0;`);
             document.body.append(ghostElement);
-            if (selectElements[0].classList.contains("li") && selectElements[0].getAttribute("data-subtype") === "u") {
+            if (selectElements[0].classList.contains("li")) {
                 const actionElement = selectElements[0].querySelector(".protyle-action");
                 event.dataTransfer.setDragImage(ghostElement, actionElement.clientWidth / 2, actionElement.clientHeight / 2);
             } else {

--- a/app/src/protyle/util/editorCommonEvent.ts
+++ b/app/src/protyle/util/editorCommonEvent.ts
@@ -9,9 +9,9 @@ import {
 } from "./hasClosest";
 import {Constants} from "../../constants";
 import {paste} from "./paste";
-import {cancelSB, genEmptyElement, genSBElement, getLangByType, insertEmptyBlock} from "../../block/util";
+import {cancelSB, genEmptyElement, genSBElement, insertEmptyBlock} from "../../block/util";
 import {transaction, turnsIntoOneTransaction} from "../wysiwyg/transaction";
-import {getContenteditableElement, getTopAloneElement} from "../wysiwyg/getBlock";
+import {getTopAloneElement} from "../wysiwyg/getBlock";
 import {updateListOrder} from "../wysiwyg/list";
 import {fetchPost, fetchSyncPost} from "../../util/fetch";
 import {onGet} from "./onGet";

--- a/app/src/protyle/util/editorCommonEvent.ts
+++ b/app/src/protyle/util/editorCommonEvent.ts
@@ -9,9 +9,9 @@ import {
 } from "./hasClosest";
 import {Constants} from "../../constants";
 import {paste} from "./paste";
-import {cancelSB, genEmptyElement, genSBElement, insertEmptyBlock} from "../../block/util";
+import {cancelSB, genEmptyElement, genSBElement, getLangByType, insertEmptyBlock} from "../../block/util";
 import {transaction, turnsIntoOneTransaction} from "../wysiwyg/transaction";
-import {getTopAloneElement} from "../wysiwyg/getBlock";
+import {getContenteditableElement, getTopAloneElement} from "../wysiwyg/getBlock";
 import {updateListOrder} from "../wysiwyg/list";
 import {fetchPost, fetchSyncPost} from "../../util/fetch";
 import {onGet} from "./onGet";
@@ -32,6 +32,7 @@ import {zoomOut} from "../../menus/protyle";
 import {webUtils} from "electron";
 /// #endif
 import {addDragFill} from "../render/av/cell";
+import {processClonePHElement} from "../render/util";
 
 const moveToNew = (protyle: IProtyle, sourceElements: Element[], targetElement: Element, newSourceElement: Element,
                    isSameDoc: boolean, isBottom: boolean, isCopy: boolean) => {
@@ -816,6 +817,16 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                 window.siyuan.dragElement = undefined;
                 event.preventDefault();
             } else if (target.classList.contains("protyle-action")) {
+                const ghostElement = document.createElement("div");
+                ghostElement.className = protyle.wysiwyg.element.className + " dragghost";
+                ghostElement.append(processClonePHElement(target.parentElement.cloneNode(true) as Element));
+                ghostElement.setAttribute("style", `position:fixed;opacity:.1;width:${target.parentElement.clientWidth}px;padding:0;`);
+                document.body.append(ghostElement);
+                event.dataTransfer.setDragImage(ghostElement, target.clientWidth / 2, target.clientHeight / 2);
+                setTimeout(() => {
+                    ghostElement.remove();
+                });
+
                 window.siyuan.dragElement = protyle.wysiwyg.element;
                 event.dataTransfer.setData(`${Constants.SIYUAN_DROP_GUTTER}NodeListItem${Constants.ZWSP}${target.parentElement.getAttribute("data-subtype")}${Constants.ZWSP}${[target.parentElement.getAttribute("data-node-id")]}`,
                     protyle.wysiwyg.element.innerHTML);


### PR DESCRIPTION
fix #11920

效果：

1. 去掉选中块的伪元素高亮，文本更清晰
2. 选中的首个块是列表项时，拖拽过程中圆点显示在光标正下方，便于判断位置

[video.webm](https://github.com/user-attachments/assets/32328c17-71f6-4674-b61e-bf8e685f4c3c)
