### PR TITLE
app: Allow lower sync interval for local sync

### DIFF
--- a/app/src/config/repos.ts
+++ b/app/src/config/repos.ts
@@ -524,7 +524,7 @@ export const repos = {
         const syncIntervalElement = repos.element.querySelector("#syncInterval") as HTMLInputElement;
         syncIntervalElement.addEventListener("change", () => {
             let interval = parseInt(syncIntervalElement.value);
-            if (30 > interval) {
+            if (30 > interval && window.siyuan.config.sync.provider != 4) {
                 interval = 30;
             }
             if (43200 < interval) {


### PR DESCRIPTION
 * The interval lock doesn't make much sense for a local disk where there's no overhead to writing to it more frequently.