### PR TITLE
perf: 移除不必要的字体预加载

### DIFF
--- a/app/src/assets/template/app/index.tpl
+++ b/app/src/assets/template/app/index.tpl
@@ -5,8 +5,6 @@
     <!-- https://electronjs.org/docs/tutorial/security#csp-meta-tag
     <meta http-equiv="Content-Security-Policy" content="script-src 'self'"/>-->
     <style id="editorAttr" type="text/css"></style>
-    <link rel="preload" href="../../../appearance/fonts/Noto-COLRv1-2.047/Noto-COLRv1.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="../../../appearance/fonts/JetBrainsMono-2.304/JetBrainsMono-Regular.woff2" as="font" type="font/woff2" crossorigin>
     <script src="../../protyle/js/pdf/pdf.min.mjs?v=4.7.85" type="module"></script>
 </head>
 <body class="fn__flex-column">


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/13672

这个字体被加载了但是没有地方会使用

![Image](https://github.com/user-attachments/assets/b91329af-8516-4b3a-adb2-4dfdef1c9eb9)

这两行直接删掉应该就没问题了：

```html
<link rel="preload" href="../../../appearance/fonts/Noto-COLRv1-2.047/Noto-COLRv1.woff2" as="font" type="font/woff2" crossorigin>
<link rel="preload" href="../../../appearance/fonts/JetBrainsMono-2.304/JetBrainsMono-Regular.woff2" as="font" type="font/woff2" crossorigin>
```