### PR TITLE
Improve font size CSS and list item pseudo-element layout

### DIFF
--- a/app/src/assets/scss/component/_typography.scss
+++ b/app/src/assets/scss/component/_typography.scss
@@ -9,6 +9,7 @@
   font-variant-ligatures: no-common-ligatures;
   display: flex;
   flex-direction: column;
+  font-size: var(--b3-font-size-editor);
   font-family: var(--b3-font-family-protyle);
 
   img {

--- a/app/src/assets/scss/protyle/_protyle.scss
+++ b/app/src/assets/scss/protyle/_protyle.scss
@@ -344,7 +344,7 @@
 .protyle-title {
   margin: 34px 16px 0 24px;
   position: relative;
-  font-size: 16px;
+  font-size: var(--b3-font-size-editor);
   font-family: var(--b3-font-family-protyle);
   padding-left: 2px;
   border-radius: var(--b3-border-radius);

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -179,14 +179,18 @@
         &::after {
           content: "";
           position: absolute;
-          border-radius: 50%;
           top: 50%;
-          transition: var(--b3-transition);
           left: 50%;
+          height: max(14px, var(--b3-font-size-editor));
+          width: max(14px, var(--b3-font-size-editor));
+          margin: min(-7px, -1 * var(--b3-font-size-editor) / 2) 0 0 min(-7px, -1 * var(--b3-font-size-editor) / 2);
+          border-radius: 50%;
+          transition: var(--b3-transition);
         }
 
         svg {
           width: 34px;
+          height: max(14px, var(--b3-font-size-editor) - 8px);
           display: block;
           z-index: 1;
           position: relative;

--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -181,16 +181,16 @@
           position: absolute;
           top: 50%;
           left: 50%;
-          height: max(14px, var(--b3-font-size-editor));
-          width: max(14px, var(--b3-font-size-editor));
-          margin: min(-7px, -1 * var(--b3-font-size-editor) / 2) 0 0 min(-7px, -1 * var(--b3-font-size-editor) / 2);
+          height: max(14px, 1em);
+          width: max(14px, 1em);
+          margin: min(-7px, -.5em) 0 0 min(-7px, -.5em);
           border-radius: 50%;
           transition: var(--b3-transition);
         }
 
         svg {
           width: 34px;
-          height: max(14px, var(--b3-font-size-editor) - 8px);
+          height: max(14px, 1em - 8px);
           display: block;
           z-index: 1;
           position: relative;

--- a/app/src/util/assets.ts
+++ b/app/src/util/assets.ts
@@ -82,7 +82,7 @@ export const loadAssets = (data: Config.IAppearance) => {
     /// #if BROWSER
     if (!window.webkit?.messageHandlers && !window.JSAndroid && !window.JSHarmony &&
         ("serviceWorker" in window.navigator) && ("caches" in window) && ("fetch" in window) && navigator.serviceWorker) {
-        document.head.insertAdjacentHTML("afterbegin", `<meta name="theme-color" content="${getComputedStyle(document.body).getPropertyValue("--b3-toolbar-background").trim()}">`)
+        document.head.insertAdjacentHTML("afterbegin", `<meta name="theme-color" content="${getComputedStyle(document.body).getPropertyValue("--b3-toolbar-background").trim()}">`);
     }
     /// #endif
     setCodeTheme();
@@ -288,12 +288,10 @@ export const setInlineStyle = async (set = true) => {
 }`;
         }
     }
-    style += `.b3-typography, .protyle-wysiwyg, .protyle-title {font-size:${window.siyuan.config.editor.fontSize}px !important}
+    style += `\n:root{--b3-font-size-editor:${window.siyuan.config.editor.fontSize}px}
 .b3-typography code:not(.hljs), .protyle-wysiwyg span[data-type~=code] { font-variant-ligatures: ${window.siyuan.config.editor.codeLigatures ? "normal" : "none"} }
 .li > .protyle-action {height:${height + 8}px;line-height: ${height + 8}px}
 .protyle-wysiwyg [data-node-id].li > .protyle-action ~ .h1, .protyle-wysiwyg [data-node-id].li > .protyle-action ~ .h2, .protyle-wysiwyg [data-node-id].li > .protyle-action ~ .h3, .protyle-wysiwyg [data-node-id].li > .protyle-action ~ .h4, .protyle-wysiwyg [data-node-id].li > .protyle-action ~ .h5, .protyle-wysiwyg [data-node-id].li > .protyle-action ~ .h6 {line-height:${height + 8}px;}
-.protyle-wysiwyg [data-node-id].li > .protyle-action::after {height: ${window.siyuan.config.editor.fontSize}px;width: ${window.siyuan.config.editor.fontSize}px;margin:-${window.siyuan.config.editor.fontSize / 2}px 0 0 -${window.siyuan.config.editor.fontSize / 2}px}
-.protyle-wysiwyg [data-node-id].li > .protyle-action svg {height: ${Math.max(14, window.siyuan.config.editor.fontSize - 8)}px}
 .protyle-wysiwyg [data-node-id].li::before {height: calc(100% - ${height + 8}px);top:${(height + 8)}px}
 .protyle-wysiwyg [data-node-id] [spellcheck] {min-height:${height}px;}
 .protyle-wysiwyg .p,


### PR DESCRIPTION
style: 改进字号 CSS 和列表项的伪元素布局

- CSS 使用 --b3-font-size-editor 变量，插件或主题能直接使用或者修改
- 修了一下编辑器字号小于 14px 时列表项圆点的伪元素 margin 不对导致错位的问题