### PR TITLE
fix: 选中块之后无法通过快捷键复制块引用

### DIFF
--- a/app/src/boot/globalEvent/keydown.ts
+++ b/app/src/boot/globalEvent/keydown.ts
@@ -507,10 +507,10 @@ const editKeydown = (app: App, event: KeyboardEvent) => {
     if (!isFileFocus && matchHotKey(window.siyuan.config.keymap.editor.general.copyBlockRef.custom, event)) {
         event.preventDefault();
         event.stopPropagation();
-        if (hasClosestByClassName(range.startContainer, "protyle-title")) {
+        if (hasClosestByClassName(range?.startContainer, "protyle-title")) {
             copyTextByType([protyle.block.rootID], "ref");
         } else {
-            const nodeElement = hasClosestBlock(range.startContainer);
+            const nodeElement = hasClosestBlock(range?.startContainer);
             if (!nodeElement) {
                 return false;
             }
@@ -519,16 +519,17 @@ const editKeydown = (app: App, event: KeyboardEvent) => {
                 copyPNGByLink(selectImgElement.querySelector("img").getAttribute("src"));
                 return true;
             }
+            const selectBlocks = protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select");
+            if (selectBlocks.length !== 0) {
+                copyTextByType(Array.from(selectBlocks).map(item => item.getAttribute("data-node-id")), "ref");
+                return true;
+            }
             if (range.toString() !== "") {
                 getContentByInlineHTML(range, (content) => {
                     writeText(`((${nodeElement.getAttribute("data-node-id")} "${content.trim()}"))`);
                 });
             } else {
-                const ids = Array.from(protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select")).map(item => item.getAttribute("data-node-id"));
-                if (ids.length === 0) {
-                    ids.push(nodeElement.getAttribute("data-node-id"));
-                }
-                copyTextByType(ids, "ref");
+                copyTextByType([nodeElement.getAttribute("data-node-id")], "ref");
             }
         }
         return true;

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -2144,9 +2144,8 @@ export class WYSIWYG {
                 event.stopPropagation();
             }
 
-            // https://github.com/siyuan-note/siyuan/issues/8918
-            if ((event.key === "ArrowLeft" || event.key === "ArrowRight" ||
-                    event.key === "Alt" || event.key === "Shift") &&    // 选中后 alt+shift+arrowRight 会导致光标和选中块不一致
+            // 按下方向键后块高亮跟随光标移动 https://github.com/siyuan-note/siyuan/issues/8918
+            if ((event.key === "ArrowLeft" || event.key === "ArrowRight") &&
                 nodeElement && !nodeElement.classList.contains("protyle-wysiwyg--select")) {
                 const selectElements = Array.from(protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select"));
                 let containRange = false;


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/13956

- 如果焦点不在编辑器内，按快捷键后无法访问startContainer，会报错
- 优先获取选中块的块引用，其次获取选中文本的块引用