### PR TITLE
fix: 打开链接菜单时隐藏 tooltip

### DIFF
--- a/app/src/menus/protyle.ts
+++ b/app/src/menus/protyle.ts
@@ -60,6 +60,7 @@ import {getFirstBlock} from "../protyle/wysiwyg/getBlock";
 import {popSearch} from "../mobile/menu/search";
 import {showMessage} from "../dialog/message";
 import {img3115} from "../boot/compatibleVersion";
+import {hideTooltip} from "../dialog/tooltip";
 
 const renderAssetList = (element: Element, k: string, position: IPosition, exts: string[] = []) => {
     fetchPost("/api/search/searchAsset", {
@@ -1374,6 +1375,7 @@ export const linkMenu = (protyle: IProtyle, linkElement: HTMLElement, focusText 
     if (!nodeElement) {
         return;
     }
+    hideTooltip();
     hideElements(["util", "toolbar", "hint"], protyle);
     const id = nodeElement.getAttribute("data-node-id");
     let html = nodeElement.outerHTML;


### PR DESCRIPTION
tooltip 很长的时候，菜单会被挡住

[video.webm](https://github.com/user-attachments/assets/d6a60cd9-e12c-4801-b8ce-9b43a4a9b15d)
