### PR TITLE
fix: 鼠标在 .protyle-scroll 上无法滚动文档

### DIFF
--- a/app/src/assets/scss/protyle/_protyle.scss
+++ b/app/src/assets/scss/protyle/_protyle.scss
@@ -10,6 +10,7 @@
   top: 30px;
   width: 16px;
   bottom: 9px; // 下图标 hover 时，需要留出一定的空间
+  pointer-events: none;
 
   svg {
     height: 16px;
@@ -24,6 +25,7 @@
     opacity: 0;
     cursor: pointer;
     color: var(--b3-border-color);
+    pointer-events: auto;
 
     &:hover {
       color: var(--b3-theme-on-surface);
@@ -51,6 +53,7 @@
     top: calc(50% - 8px);
     transform: rotate(90deg);
     z-index: 1;
+    pointer-events: auto;
 
     .b3-slider {
       width: var(--b3-dynamicscroll-width);


### PR DESCRIPTION
有时候滚动文档会把鼠标移到靠边的位置，但碰到 .protyle-scroll 就无法无法滚动文档了。

用 `pointer-events: none;` 把事件穿透到下方的文档。