### PR TITLE
fix: 改进文档树和大纲拖拽排序

### DIFF
--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -515,14 +515,19 @@ export class Files extends Model {
                 ) &&
                 // 防止文档拖拽到笔记本外
                 !(!sourceOnlyRoot && targetType === "navigation-root")) {
-                const nodeRect = liElement.getBoundingClientRect();
-                if (event.clientY > nodeRect.top + 20) {
-                    liElement.classList.add("dragover__bottom");
-                    event.preventDefault();
-                } else if (event.clientY < nodeRect.bottom - 20) {
-                    liElement.classList.add("dragover__top");
-                    event.preventDefault();
+                const nodeRect = (liElement as HTMLElement).getBoundingClientRect();
+                if (targetType === "navigation-root" && sourceOnlyRoot) {
+                    if (event.clientY > nodeRect.top + nodeRect.height / 2) {
+                        (liElement as HTMLElement).classList.add("dragover__bottom");
+                    } else {
+                        (liElement as HTMLElement).classList.add("dragover__top");
+                    }
+                } else if (event.clientY > nodeRect.top + nodeRect.height * 3 / 4) {
+                    (liElement as HTMLElement).classList.add("dragover__bottom");
+                } else if (event.clientY < nodeRect.bottom - nodeRect.height * 3 / 4) {
+                    (liElement as HTMLElement).classList.add("dragover__top");
                 }
+                event.preventDefault();
             }
             if (liElement.classList.contains("dragover__top") || liElement.classList.contains("dragover__bottom") ||
                 (targetType === "navigation-root" && sourceOnlyRoot)) {

--- a/app/src/layout/dock/Outline.ts
+++ b/app/src/layout/dock/Outline.ts
@@ -274,9 +274,9 @@ export class Outline extends Model {
                     return;
                 }
                 const selectRect = selectItem.getBoundingClientRect();
-                if (moveEvent.clientY > selectRect.bottom - 10) {
+                if (moveEvent.clientY > selectRect.top + selectRect.height * 3 / 4) {
                     selectItem.classList.add("dragover__bottom");
-                } else if (moveEvent.clientY < selectRect.top + 10) {
+                } else if (moveEvent.clientY < selectRect.bottom - selectRect.height * 3 / 4) {
                     selectItem.classList.add("dragover__top");
                 } else {
                     selectItem.classList.add("dragover");


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/13901

改进了插入位置的判定，动态获取元素高度而不是写死数值（有的主题和插件会修改元素高度，然后插入位置的判断就有问题）