### PR TITLE
fix: 代码块内 `Ctrl+A` 全选文本时不应选中末尾的换行符

### DIFF
--- a/app/src/protyle/util/selection.ts
+++ b/app/src/protyle/util/selection.ts
@@ -61,7 +61,8 @@ export const selectAll = (protyle: IProtyle, nodeElement: Element, range: Range)
             }
         } else {
             position = getSelectionOffset(editElement, nodeElement, range);
-            if (position.start !== 0 || position.end !== editElement.textContent.length) {
+            const isCode = editElement.parentElement.classList.contains("hljs");
+            if (position.start !== 0 || position.end !== (!isCode ? editElement.textContent.length : editElement.textContent.length - 1)) {
                 // 全选后 rang 不对 https://ld246.com/article/1654848722251
                 let firstChild = editElement.firstChild;
                 while (firstChild) {
@@ -97,6 +98,9 @@ export const selectAll = (protyle: IProtyle, nodeElement: Element, range: Range)
                         }
                         lastChild = lastChild.lastChild as HTMLElement;
                     }
+                }
+                if (isCode && lastChild.textContent?.charAt(lastChild.textContent.length - 1) === "\n") {
+                    range.setEnd(range.endContainer, lastChild.textContent.length - 1);
                 }
                 // 列表回车后，左键全选无法选中
                 focusByRange(range);

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -415,9 +415,7 @@ export class WYSIWYG {
                         html = tempElement.innerHTML;
                     }
                     // 不能使用 commonAncestorContainer https://ld246.com/article/1643282894693
-                    if (hasClosestByAttribute(range.startContainer, "data-type", "NodeCodeBlock")) {
-                        textPlain = tempElement.textContent.replace(/\n$/, "");
-                    } else if (hasClosestByMatchTag(range.startContainer, "CODE")) {
+                    if (hasClosestByAttribute(range.startContainer, "data-type", "NodeCodeBlock") || hasClosestByMatchTag(range.startContainer, "CODE")) {
                         textPlain = tempElement.textContent;
                     } else {
                         textPlain = range.toString();

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -416,9 +416,9 @@ export class WYSIWYG {
                     }
                     // 不能使用 commonAncestorContainer https://ld246.com/article/1643282894693
                     if (hasClosestByAttribute(range.startContainer, "data-type", "NodeCodeBlock")) {
-                        textPlain = tempElement.textContent.replace(Constants.ZWSP, "").replace(/\n$/, "");
+                        textPlain = tempElement.textContent.replace(/\n$/, "");
                     } else if (hasClosestByMatchTag(range.startContainer, "CODE")) {
-                        textPlain = tempElement.textContent.replace(Constants.ZWSP, "");
+                        textPlain = tempElement.textContent;
                     } else {
                         textPlain = range.toString();
                     }


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/13994

fix https://github.com/siyuan-note/siyuan/pull/14002 （后面已经替换零宽空格了，前面就不需要替换了）