### PR TITLE
fix: 未打开文档时点击大纲会弹出 `未找到 ID 为 [] 的内容块`

### DIFF
--- a/app/src/layout/dock/Outline.ts
+++ b/app/src/layout/dock/Outline.ts
@@ -178,7 +178,7 @@ export class Outline extends Model {
                             break;
                     }
                     break;
-                } else if (target.isSameNode(this.headerElement.nextElementSibling) || target.classList.contains("block__icons")) {
+                } else if (this.blockId && (target.isSameNode(this.headerElement.nextElementSibling) || target.classList.contains("block__icons"))) {
                     openFileById({
                         app: options.app,
                         id: this.blockId,


### PR DESCRIPTION
fix https://ld246.com/article/1738820297928