### PR TITLE
fix: Improve /menu

### DIFF
--- a/app/src/util/upDownHint.ts
+++ b/app/src/util/upDownHint.ts
@@ -1,5 +1,7 @@
 const isNormalItem = (currentHintElement: HTMLElement, className: string) => {
-    return currentHintElement.classList.contains("fn__none") || !currentHintElement.classList.contains(className);
+    return currentHintElement.classList.contains("fn__none") || !currentHintElement.classList.contains(className) ||
+    // https://github.com/siyuan-note/siyuan/issues/12518
+    currentHintElement.getBoundingClientRect().height === 0;
 };
 
 export const upDownHint = (listElement: Element, event: KeyboardEvent, classActiveName = "b3-list-item--focus", defaultElement?: Element) => {


### PR DESCRIPTION
斜杠菜单，如果选项隐藏了 (display:none)，按上下方向键时就跳过

关联 https://github.com/siyuan-note/siyuan/issues/12518 和 https://github.com/zxkmm/siyuan_rmv_btn/issues/1#issuecomment-2661019033