### PR TITLE
Set the auth code via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ docker run -d \
 * `workspace_dir_host`: The workspace folder path on the host
 * `workspace_dir_container`: The path of the workspace folder in the container, as specified in `--workspace`
 * `accessAuthCode`: Access authorization code (please **be sure to modify**, otherwise anyone can access your data)
+  * In alternative, it's possible to set the auth code via the `SIYUAN_ACCESS_AUTH_CODE` env variable. The commandline will always have the priority, if both are set.
 
 To simplify things, it is recommended to configure the workspace folder path to be consistent on the host and container, such as having both `workspace_dir_host` and `workspace_dir_container` configured as `/siyuan/workspace`. The corresponding startup command would be:
 

--- a/README_ja_JP.md
+++ b/README_ja_JP.md
@@ -207,6 +207,7 @@ docker run -d \
 * `workspace_dir_host`: ホスト上のワークスペースフォルダーのパス
 * `workspace_dir_container`: コンテナ内のワークスペースフォルダーのパス、`--workspace` で指定されたものと同じ
 * `accessAuthCode`: アクセス認証コード（**必ず変更してください**、そうしないと誰でもデータにアクセスできます）
+  * また、`SIYUAN_ACCESS_AUTH_CODE` 環境変数を設定することで認証コードを指定することもできます。両方が設定されている場合、コマンドラインの値が優先されます。
 
 簡略化するために、ホストとコンテナでワークスペースフォルダーのパスを一致させることをお勧めします。たとえば、`workspace_dir_host` と `workspace_dir_container` の両方を `/siyuan/workspace` に設定します。対応する起動コマンドは次のようになります：
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -212,6 +212,7 @@ docker run -d \
 * `workspace_dir_host`：宿主机上的工作空间文件夹路径
 * `workspace_dir_container`：容器内工作空间文件夹路径，和后面 `--workspace` 指定成一样的
 * `accessAuthCode`：访问授权码，请**务必修改**，否则任何人都可以读写你的数据
+  * 另外，也可以通过 `SIYUAN_ACCESS_AUTH_CODE` 环境变量设置授权码。如果两者都设置了，命令行的值将优先。
 
 为了简化，建议将 workspace 文件夹路径在宿主机和容器上配置为一致的，比如将 `workspace_dir_host` 和 `workspace_dir_container` 都配置为 `/siyuan/workspace`，对应的启动命令示例：
 


### PR DESCRIPTION
## Feature or bug? 特性或者缺陷？

Feature, as outlined in Issue #14140

## In what scenarios do you need this feature?

In a docker installation, it is somewhat cumbersome to set the auth key via commandline.

## Describe the optimal solution

It would be nice to be able to set it via an environment variable, like

docker run -d \
  -v myvolume:/siyuan/workspace \
  -p 6806:6806 \
  -e SIYUAN_ACCESS_AUTH_CODE=abcd \
  siyuan:latest \
  --workspace /siyuan/workspace

## Describe the candidate solution

If both the env var and the commandline switch are provided, in my code, the commandline has priority.
