### PR TITLE
Support SIYUAN_WORKSPACE_PATH in Docker

### DIFF
--- a/kernel/entrypoint.sh
+++ b/kernel/entrypoint.sh
@@ -28,12 +28,16 @@ else
     adduser --uid "${PUID}" --ingroup "${group_name}" --disabled-password --gecos "" "${user_name}"
 fi
 
-# Parse command line arguments for --workspace option
+# Parse command line arguments for --workspace option or SIYUAN_WORKSPACE_PATH env variable
 # Store other arguments in ARGS for later use
+if [[ -v "${SIYUAN_WORKSPACE_PATH}" ]]; then
+    WORKSPACE_DIR="${SIYUAN_WORKSPACE_PATH}"
+fi
 ARGS=""
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --workspace=*) WORKSPACE_DIR="${1#*=}"; shift ;;
+        --workspace) WORKSPACE_DIR="${2}"; shift; shift ;;
         *) ARGS="$ARGS $1"; shift ;;
     esac
 done


### PR DESCRIPTION
The current entrypoint fails if the user uses
--workspace /my/workspace with a space instead
of an equals.

This change supports that format as well as the
SIYUAN_WORKSPACE_PATH env variable.

```
SIYUAN_WORKSPACE_PATH=/should/be/ignored ./stuff.sh --workspace /my/workspace --workspace-prefix --fla g-equal=3 --flag-no-equal 4
WORKSPACE_DIR: /my/workspace
ARGS:  --workspace-prefix --flag-equal=3 --flag-no-equal 4

SIYUAN_WORKSPACE_PATH=/my/workspace ./stuff.sh --workspace-prefix --flag-equal=3 --flag-no-equal
4
WORKSPACE_DIR: /siyuan/workspace
ARGS:  --workspace-prefix --flag-equal=3 --flag-no-equal 4

SIYUAN_WORKSPACE_PATH=/should/be/ignored ./stuff.sh --workspace=/my/workspace --workspace-prefix --fla g-equal=3 --flag-no-equal 4
WORKSPACE_DIR: /my/workspace
ARGS:  --workspace-prefix --fla g-equal=3 --flag-no-equal 4
```

## Feature or bug? 特性或者缺陷？

Bug fix

## Multilingual or copywriting? 多语言或者文案？

Please submit directly, we will evaluate.
请直接提交，我们会进行评估。

## Dev branch!

