### PR TITLE
Refactor setCurrent func scroll policy

### DIFF
--- a/.github/workflows/auto_aur_release_stable.yml
+++ b/.github/workflows/auto_aur_release_stable.yml
@@ -66,13 +66,6 @@ jobs:
               install -Dm755 \${_pkgname} "\${pkgdir}/\${_installdir}/siyuan.AppImage"
               install -Dm644 "squashfs-root/resources/stage/icon.png" "\${pkgdir}/usr/share/icons/hicolor/512x512/apps/siyuan-bin.png"
               install -Dm644 "squashfs-root/siyuan.desktop" "\${pkgdir}/usr/share/applications/siyuan-bin.desktop"
-
-              if [ ! -f "${pkgdir}/usr/bin/siyuan" ]; then
-                mkdir -p "${pkgdir}/usr/bin"
-                echo '#!/bin/sh' > "${pkgdir}/usr/bin/siyuan"
-                echo "exec ${_installdir}/siyuan.AppImage" >> "${pkgdir}/usr/bin/siyuan"
-                chmod 755 "${pkgdir}/usr/bin/siyuan"
-              fi
           }
           EOF
 

--- a/.github/workflows/auto_aur_release_stable.yml
+++ b/.github/workflows/auto_aur_release_stable.yml
@@ -66,6 +66,13 @@ jobs:
               install -Dm755 \${_pkgname} "\${pkgdir}/\${_installdir}/siyuan.AppImage"
               install -Dm644 "squashfs-root/resources/stage/icon.png" "\${pkgdir}/usr/share/icons/hicolor/512x512/apps/siyuan-bin.png"
               install -Dm644 "squashfs-root/siyuan.desktop" "\${pkgdir}/usr/share/applications/siyuan-bin.desktop"
+
+              if [ ! -f "${pkgdir}/usr/bin/siyuan" ]; then
+                mkdir -p "${pkgdir}/usr/bin"
+                echo '#!/bin/sh' > "${pkgdir}/usr/bin/siyuan"
+                echo "exec ${_installdir}/siyuan.AppImage" >> "${pkgdir}/usr/bin/siyuan"
+                chmod 755 "${pkgdir}/usr/bin/siyuan"
+              fi
           }
           EOF
 

--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -1004,19 +1004,21 @@ export class Files extends Model {
 
     private setCurrent(target: HTMLElement, isScroll = true) {
         if (!target) {
+            console.log("setCurrent target is null so return");
             return;
         }
         this.element.querySelectorAll("li").forEach((liItem) => {
             liItem.classList.remove("b3-list-item--focus");
         });
         target.classList.add("b3-list-item--focus");
+
         if (isScroll) {
-            let offsetTop = target.offsetTop;
-            // https://github.com/siyuan-note/siyuan/issues/8749
-            if (target.parentElement.classList.contains("file-tree__sliderDown") && target.offsetParent) {
-                offsetTop = (target.offsetParent as HTMLElement).offsetTop;
-            }
-            this.element.scrollTop = offsetTop - this.element.clientHeight / 2 - this.actionsElement.clientHeight;
+            const targetRect = target.getBoundingClientRect();
+            const containerRect = this.element.getBoundingClientRect();
+            
+            const relativeTop = targetRect.top - containerRect.top + this.element.scrollTop;
+            
+            this.element.scrollTop = relativeTop - this.element.clientHeight / 2 - this.actionsElement.clientHeight;
         }
     }
 

--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -1004,7 +1004,6 @@ export class Files extends Model {
 
     private setCurrent(target: HTMLElement, isScroll = true) {
         if (!target) {
-            console.log("setCurrent target is null so return");
             return;
         }
         this.element.querySelectorAll("li").forEach((liItem) => {


### PR DESCRIPTION
- Refactor setCurrent func scroll policy, because previous one can be interference by custom css pseudo elem.
- the workaround in #8749 seems not needed anymore after this approach. But i don't know previous issue so pls double check for me.
- ref. https://github.com/zxkmm/siyuan_doctree_compress/issues/18
- ref. https://developer.mozilla.org/docs/Web/API/Element/getBoundingClientRect