### PR TITLE
Refactor setCurrentById of Outline func scroll policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ app/stage/build
 app/build
 app/src/types/dist
 app/kernel*
+app/SiYuan-Kernel
 ios
 pprof
 

--- a/app/src/layout/dock/Outline.ts
+++ b/app/src/layout/dock/Outline.ts
@@ -489,8 +489,6 @@ export class Outline extends Model {
             const targetRect = currentElement.getBoundingClientRect();
             const containerRect = this.element.getBoundingClientRect();
             const relativeTop = targetRect.top - containerRect.top + this.element.scrollTop;
-
-            console.log("1111", relativeTop, this.element.scrollTop, this.element.clientHeight);
             
             this.element.scrollTop = relativeTop - this.element.clientHeight / 2 - 30;
         }

--- a/app/src/layout/dock/Outline.ts
+++ b/app/src/layout/dock/Outline.ts
@@ -485,7 +485,14 @@ export class Outline extends Model {
         }
         if (currentElement) {
             currentElement.classList.add("b3-list-item--focus");
-            this.element.scrollTop = currentElement.offsetTop - this.element.clientHeight / 2 - 30;
+        
+            const targetRect = currentElement.getBoundingClientRect();
+            const containerRect = this.element.getBoundingClientRect();
+            const relativeTop = targetRect.top - containerRect.top + this.element.scrollTop;
+
+            console.log("1111", relativeTop, this.element.scrollTop, this.element.clientHeight);
+            
+            this.element.scrollTop = relativeTop - this.element.clientHeight / 2 - 30;
         }
     }
 


### PR DESCRIPTION
抱歉，之前没有意识到文档树和大纲滚动是分在两边处理的，然后用户升级后发现文档树修好了大纲没修好。所以现在大纲也有了。
- ref. https://github.com/siyuan-note/siyuan/pull/14265
- ref. https://github.com/zxkmm/siyuan_doctree_compress/issues/25#issuecomment-2708220325
