### PR TITLE
Supports assets settings on mobile

### DIFF
--- a/app/src/mobile/menu/index.ts
+++ b/app/src/mobile/menu/index.ts
@@ -1,5 +1,6 @@
 import {popSearch} from "./search";
 import {initAppearance} from "../settings/appearance";
+import {initAssets} from "../settings/assets";
 import {closePanel} from "../util/closePanel";
 import {mountHelp, newDailyNote, newNotebook} from "../../util/mount";
 import {repos} from "../../config/repos";
@@ -111,6 +112,9 @@ export const initRightMenu = (app: App) => {
         <svg class="b3-menu__icon"><use xlink:href="#iconRiffCard"></use></svg><span class="b3-menu__label">${window.siyuan.languages.riffCard}</span>
     </div>
     ${aiHTML}
+    <div class="b3-menu__item${window.siyuan.config.readonly ? " fn__none" : ""}" id="menuAssets">
+        <svg class="b3-menu__icon"><use xlink:href="#iconImage"></use></svg><span class="b3-menu__label">${window.siyuan.languages.assets}</span>
+    </div>
     <div class="b3-menu__item${window.siyuan.config.readonly ? " fn__none" : ""}" id="menuAppearance">
         <svg class="b3-menu__icon"><use xlink:href="#iconTheme"></use></svg><span class="b3-menu__label">${window.siyuan.languages.appearance}</span>
     </div>
@@ -163,6 +167,11 @@ export const initRightMenu = (app: App) => {
                 break;
             } else if (target.id === "menuAppearance") {
                 initAppearance();
+                event.preventDefault();
+                event.stopPropagation();
+                break;
+            } else if (target.id === "menuAssets") {
+                initAssets();
                 event.preventDefault();
                 event.stopPropagation();
                 break;

--- a/app/src/mobile/settings/assets.ts
+++ b/app/src/mobile/settings/assets.ts
@@ -1,0 +1,14 @@
+import {openModel} from "../menu/model";
+import {image} from "../../config/image";
+
+export const initAssets = () => {
+    openModel({
+        title: window.siyuan.languages.assets,
+        icon: "iconImage",
+        html: image.genHTML(),
+        bindEvent(modelMainElement: HTMLElement) {
+            image.element = modelMainElement;
+            image.bindEvent();
+        }
+    });
+};


### PR DESCRIPTION
## Feature or bug? 特性或者缺陷？

:art: Supports assets settings on mobile 
移动小屏设备上增加了资源菜单，方便清理未引用的资源，这样就不需要弄个浏览器模式再切出去本地访问了。

https://github.com/siyuan-note/siyuan/issues/13930
https://github.com/siyuan-note/siyuan/issues/13622
https://ld246.com/article/1728526267894

## Multilingual or copywriting? 多语言或者文案？
应该是支持多语言的
理论上参考了另外几个菜单的实现，套用了model类直接引用了大屏的image.ts

## Dev branch!

已提交到 dev 分支。
