### PR TITLE
Open the Explorer window in the foreground

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -764,6 +764,9 @@ app.whenReady().then(() => {
     ipcMain.on("siyuan-open-folder", (event, filePath) => {
         shell.showItemInFolder(filePath);
     });
+    ipcMain.on("siyuan-open-path", (event, filePath) => {
+        shell.openPath(filePath);
+    });
     ipcMain.on("siyuan-first-quit", () => {
         app.exit();
     });

--- a/app/src/config/about.ts
+++ b/app/src/config/about.ts
@@ -12,6 +12,7 @@ import {showMessage} from "../dialog/message";
 import {Dialog} from "../dialog";
 import {confirmDialog} from "../dialog/confirmDialog";
 import {setKey} from "../sync/syncGuide";
+import {openPath} from "../util/pathName";
 
 export const about = {
     element: undefined as Element,
@@ -259,7 +260,7 @@ ${checkUpdateHTML}
                 if (url.startsWith("http")) {
                     shell.openExternal(url);
                 } else {
-                    shell.openPath(url);
+                    openPath(url);
                 }
                 /// #else
                 window.open(url);

--- a/app/src/config/appearance.ts
+++ b/app/src/config/appearance.ts
@@ -11,6 +11,7 @@ import {openSnippets} from "./util/snippets";
 import {loadAssets} from "../util/assets";
 import {resetFloatDockSize} from "../layout/dock/util";
 import {confirmDialog} from "../dialog/confirmDialog";
+import {openPath} from "../util/pathName";
 
 export const appearance = {
     element: undefined as Element,
@@ -233,13 +234,13 @@ export const appearance = {
         });
         /// #if !BROWSER
         appearance.element.querySelector("#appearanceOpenIcon").addEventListener("click", () => {
-            shell.openPath(path.join(window.siyuan.config.system.confDir, "appearance", "icons"));
+            openPath(path.join(window.siyuan.config.system.confDir, "appearance", "icons"));
         });
         appearance.element.querySelector("#appearanceOpenTheme").addEventListener("click", () => {
-            shell.openPath(path.join(window.siyuan.config.system.confDir, "appearance", "themes"));
+            openPath(path.join(window.siyuan.config.system.confDir, "appearance", "themes"));
         });
         appearance.element.querySelector("#appearanceOpenEmoji").addEventListener("click", () => {
-            shell.openPath(path.join(window.siyuan.config.system.dataDir, "emojis"));
+            openPath(path.join(window.siyuan.config.system.dataDir, "emojis"));
         });
         /// #endif
         appearance.element.querySelectorAll("select").forEach(item => {

--- a/app/src/config/bazaar.ts
+++ b/app/src/config/bazaar.ts
@@ -19,6 +19,7 @@ import {uninstall} from "../plugin/uninstall";
 import {afterLoadPlugin, loadPlugin, loadPlugins, reloadPlugin} from "../plugin/loader";
 import {loadAssets} from "../util/assets";
 import {addScript} from "../protyle/util/addScript";
+import {openPath} from "../util/pathName";
 
 export const bazaar = {
     element: undefined as Element,
@@ -625,9 +626,9 @@ export const bazaar = {
                     /// #if !BROWSER
                     const dirName = dataObj.bazaarType;
                     if (dirName === "icons" || dirName === "themes") {
-                        shell.openPath(path.join(window.siyuan.config.system.confDir, "appearance", dirName, dataObj.name));
+                        openPath(path.join(window.siyuan.config.system.confDir, "appearance", dirName, dataObj.name));
                     } else {
-                        shell.openPath(path.join(window.siyuan.config.system.dataDir, dirName, dataObj.name));
+                        openPath(path.join(window.siyuan.config.system.dataDir, dirName, dataObj.name));
                     }
                     /// #endif
                     event.preventDefault();

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -50,6 +50,7 @@ export abstract class Constants {
     public static readonly SIYUAN_OPEN_URL: string = "siyuan-open-url";
     public static readonly SIYUAN_OPEN_WINDOW: string = "siyuan-open-window";
     public static readonly SIYUAN_OPEN_FOLDER: string = "siyuan-open-folder";
+    public static readonly SIYUAN_OPEN_PATH: string = "siyuan-open-path";
     public static readonly SIYUAN_OPEN_FILE: string = "siyuan-open-file";
 
     public static readonly SIYUAN_EXPORT_PDF: string = "siyuan-export-pdf";

--- a/app/src/editor/util.ts
+++ b/app/src/editor/util.ts
@@ -5,7 +5,7 @@ import {getInstanceById, getWndByLayout, pdfIsLoading, setPanelFocus} from "../l
 import {getDockByType} from "../layout/tabUtil";
 import {getAllModels, getAllTabs} from "../layout/getAll";
 import {highlightById, scrollCenter} from "../util/highlightById";
-import {getDisplayName, pathPosix, showFileInFolder} from "../util/pathName";
+import {getDisplayName, openPath, pathPosix, showFileInFolder} from "../util/pathName";
 import {Constants} from "../constants";
 import {setEditMode} from "../protyle/util/setEditMode";
 import {Files} from "../layout/dock/Files";
@@ -695,7 +695,7 @@ export const openBy = (url: string, type: "folder" | "app") => {
     if (url.startsWith("assets/")) {
         fetchPost("/api/asset/resolveAssetPath", {path: url.replace(/\.pdf\?page=\d{1,}$/, ".pdf")}, (response) => {
             if (type === "app") {
-                shell.openPath(response.data);
+                openPath(response.data);
             } else if (type === "folder") {
                 showFileInFolder(response.data);
             }
@@ -713,7 +713,7 @@ export const openBy = (url: string, type: "folder" | "app") => {
     // 拖入文件名包含 `)` 、`(` 的文件以 `file://` 插入后链接解析错误 https://github.com/siyuan-note/siyuan/issues/5786
     address = address.replace(/\\\)/g, ")").replace(/\\\(/g, "(");
     if (type === "app") {
-        shell.openPath(address);
+        openPath(address);
     } else if (type === "folder") {
         if ("windows" === window.siyuan.config.system.os) {
             if (!address.startsWith("\\\\")) { // \\ 开头的路径是 Windows 网络共享路径 https://github.com/siyuan-note/siyuan/issues/5980

--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -1,10 +1,10 @@
 import {copySubMenu, exportMd, movePathToMenu, openFileAttr, renameMenu,} from "./commonMenuItem";
 /// #if !BROWSER
-import {FileFilter, ipcRenderer, shell} from "electron";
+import {FileFilter, ipcRenderer} from "electron";
 import * as path from "path";
 /// #endif
 import {MenuItem} from "./Menu";
-import {getDisplayName, getNotebookName, getTopPaths, pathPosix} from "../util/pathName";
+import {getDisplayName, getNotebookName, getTopPaths, openPath, pathPosix} from "../util/pathName";
 import {hideMessage, showMessage} from "../dialog/message";
 import {fetchPost, fetchSyncPost} from "../util/fetch";
 import {onGetnotebookconf} from "./onGetnotebookconf";
@@ -362,7 +362,7 @@ export const initNavigationMenu = (app: App, liElement: HTMLElement) => {
         icon: "iconFolder",
         label: window.siyuan.languages.showInFolder,
         click: () => {
-            shell.openPath(path.join(window.siyuan.config.system.dataDir, notebookId));
+            openPath(path.join(window.siyuan.config.system.dataDir, notebookId));
         }
     }).element);
     /// #endif

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -21,6 +21,12 @@ export const showFileInFolder = (filePath: string) => {
     /// #endif
 };
 
+export const openPath  = (filePath: string) => {
+    /// #if !BROWSER
+    ipcRenderer.send(Constants.SIYUAN_OPEN_PATH, filePath);
+    /// #endif
+};
+
 export const getIdZoomInByPath = () => {
     const searchParams = new URLSearchParams(window.location.search);
     const PWAURL = searchParams.get("url");


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/12652

- openPath 是随便命名的，也许不合适
- 也许把 shell.openPath 合并到 siyuan-open-folder 更好

~如果要合并的话先说一下，我想用这个 PR 顺便更新一下设置里的这段话：“思源笔记已累计发版 661 次，解决用户需求与反馈 11877 次，提交代码 14796 次”~