### PR TITLE
Improve the style of folded lists

### DIFF
--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -153,6 +153,10 @@
           background-color: var(--b3-list-hover);
         }
 
+        & > div:nth-child(2) {
+          margin-bottom: 0;
+        }
+
         & > div:nth-child(3):not(.protyle-attr),
         & > div:nth-child(3) ~ div:not(.protyle-attr) {
           display: none;


### PR DESCRIPTION
折叠的列表会产生多余的 margin-bottom：

![Image](https://github.com/user-attachments/assets/4148d423-a8d9-4438-a918-f0bc2533ea2e)