### PR TITLE
Cannot drag the dots of the list item while holding down Shift

### DIFF
--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -189,6 +189,7 @@
           display: block;
           z-index: 1;
           position: relative;
+          pointer-events: none;
         }
 
         &--order::after {


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/12542

相关：

- https://github.com/siyuan-note/siyuan/issues/9236
- https://github.com/siyuan-note/siyuan/issues/3294#issuecomment-1236123148

参考信息：

按住 Shift 拖拽列表项的圆点时，实际上拖拽的是里面的 svg 元素，无法触发 dragstart 事件

- [javascript - Cannot perform Shift + Drag on a div element containing an embedded SVG image - Stack Overflow](https://stackoverflow.com/questions/72389012/cannot-perform-shift-drag-on-a-div-element-containing-an-embedded-svg-image)
- [Drag is not working with shift Key for child of draggable [41469770] - Chromium](https://issues.chromium.org/issues/41469770)