### PR TITLE
Improve resizing image width by dragging

### DIFF
--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -471,11 +471,12 @@ export class WYSIWYG {
                 return;
             }
             const documentSelf = document;
-            const rect = protyle.element.getBoundingClientRect();
-            const mostLeft = rect.left + (parseInt(protyle.wysiwyg.element.style.paddingLeft) || 24) + 1;
-            // 不能用 firstElement，否则 https://ld246.com/article/1668758661338
-            const mostRight = mostLeft + (protyle.wysiwyg.element.clientWidth - (parseInt(protyle.wysiwyg.element.style.paddingLeft) || 24) - (parseInt(protyle.wysiwyg.element.style.paddingRight) || 16)) - 2;
-            const mostBottom = rect.bottom;
+            const protyleRect = protyle.element.getBoundingClientRect();
+            const wysiwygRect = protyle.wysiwyg.element.getBoundingClientRect();
+            const wysiwygStyle = window.getComputedStyle(protyle.wysiwyg.element);
+            const mostLeft = wysiwygRect.left + (parseFloat(wysiwygStyle.paddingLeft) || 24) + 1;
+            const mostRight = wysiwygRect.right - (parseFloat(wysiwygStyle.paddingRight) || 16) - 2;
+            const mostBottom = protyleRect.bottom;
             const y = event.clientY;
             const contentRect = protyle.contentElement.getBoundingClientRect();
             // av col resize
@@ -812,7 +813,7 @@ export class WYSIWYG {
             } else if (event.clientX < mostLeft) {
                 clentX = mostLeft;
             }
-            const mostTop = rect.top + (protyle.options.render.breadcrumb ? protyle.breadcrumb.element.parentElement.clientHeight : 0);
+            const mostTop = protyleRect.top + (protyle.options.render.breadcrumb ? protyle.breadcrumb.element.parentElement.clientHeight : 0);
 
             let mouseElement: Element;
             let moveCellElement: HTMLElement;


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/14490

例如用这个 CSS，然后拖拽图片，图片还没达到编辑器右侧就不能拉大了：

```css
.protyle-content, .protyle-wysiwyg {
    margin-left: 150px;
    margin-right: 50px;
}
```