### PR TITLE
Support importing markdown zip on the browser

### DIFF
--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -761,24 +761,43 @@ export const genImportMenu = (notebookId: string, pathString: string) => {
         id: "import",
         icon: "iconDownload",
         label: window.siyuan.languages.import,
-        submenu: [{
-            id: "importSiYuanZip",
-            icon: "iconSiYuan",
-            label: 'SiYuan .sy.zip<input class="b3-form__upload" type="file" accept="application/zip">',
-            bind: (element) => {
-                element.querySelector(".b3-form__upload").addEventListener("change", (event: InputEvent & {
-                    target: HTMLInputElement
-                }) => {
-                    const formData = new FormData();
-                    formData.append("file", event.target.files[0]);
-                    formData.append("notebook", notebookId);
-                    formData.append("toPath", pathString);
-                    fetchPost("/api/import/importSY", formData, () => {
-                        reloadDocTree();
+        submenu: [
+            {
+                id: "importSiYuanZip",
+                icon: "iconSiYuan",
+                label: 'SiYuan .sy.zip<input class="b3-form__upload" type="file" accept="application/zip">',
+                bind: (element) => {
+                    element.querySelector(".b3-form__upload").addEventListener("change", (event: InputEvent & {
+                        target: HTMLInputElement
+                    }) => {
+                        const formData = new FormData();
+                        formData.append("file", event.target.files[0]);
+                        formData.append("notebook", notebookId);
+                        formData.append("toPath", pathString);
+                        fetchPost("/api/import/importSY", formData, () => {
+                            reloadDocTree();
+                        });
                     });
-                });
-            }
-        },
+                }
+            },
+            {
+                id: "importMarkdownZip",
+                icon: "iconMarkdown",
+                label: 'Markdown .zip<input class="b3-form__upload" type="file" accept="application/zip">',
+                bind: (element) => {
+                    element.querySelector(".b3-form__upload").addEventListener("change", (event: InputEvent & {
+                        target: HTMLInputElement
+                    }) => {
+                        const formData = new FormData();
+                        formData.append("file", event.target.files[0]);
+                        formData.append("notebook", notebookId);
+                        formData.append("toPath", pathString);
+                        fetchPost("/api/import/importZipMd", formData, () => {
+                            reloadDocTree();
+                        });
+                    });
+                }
+            },
             /// #if !BROWSER
             importstdmd("Markdown " + window.siyuan.languages.doc, true),
             importstdmd("Markdown " + window.siyuan.languages.folder)

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -320,6 +320,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/export/exportAttributeView", model.CheckAuth, model.CheckAdminRole, exportAttributeView)
 
 	ginServer.Handle("POST", "/api/import/importStdMd", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, importStdMd)
+	ginServer.Handle("POST", "/api/import/importZipMd", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, importZipMd)
 	ginServer.Handle("POST", "/api/import/importData", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, importData)
 	ginServer.Handle("POST", "/api/import/importSY", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, importSY)
 


### PR DESCRIPTION
## 特性或者缺陷？

思源笔记的 Docker Web 端不支持 Markdown 的导入，要导入一个/多个Markdown文档，需要：
1. 使用本地客户端，导入Markdown文件夹
2. 用客户端导出 `sy.zip`（或者使用s3同步）
3. 把导出的 `sy.zip` 通过web端的界面上传（或者在web端执行更新，拉取s3的结果）

现有的有关讨论：
- [急需思源笔记网页版（docker) 导入功能](https://ld246.com/article/1659634995637)
- #14677 

这样：
- 用户可以通过web端直接上传notion、我来等笔记软件导出的zip归档
- 如果用户需要上传单个Markdown，可以把该Markdown和图片资源用zip直接打包即可
- 如果需要批量上传多个Markdown，可以把所有的Markdown和图片资源用zip直接打包即可

## 实现逻辑

通过实现API：`/api/import/importZipMd`，用户可以上传自己的 zip 文件，上传到server解压到临时文件夹，然后调用`model.ImportFromLocalPath(notebook, unzipPath, toPath)` 来进行。

实现效果如下：

https://github.com/user-attachments/assets/21527554-3ec8-40ea-aa11-7d42d62dd515


## 补充建议
似乎没有找到icon的ZIP，不太确定这些都是在哪里定义的，如果可以稍微改改会好些。

## Dev branch!

Any changes should be submitted to the dev branch.
任何改动，请提交到 dev 分支。
