### PR TITLE
Improve export menu

### DIFF
--- a/app/src/menus/commonMenuItem.ts
+++ b/app/src/menus/commonMenuItem.ts
@@ -530,12 +530,12 @@ export const exportMd = (id: string) => {
                 });
             }
         }, {
-            id: "exportMarkdown",
-            label: "Markdown",
-            icon: "iconMarkdown",
+            id: "exportSiYuanZip",
+            label: "SiYuan .sy.zip",
+            icon: "iconSiYuan",
             click: () => {
                 const msgId = showMessage(window.siyuan.languages.exporting, -1);
-                fetchPost("/api/export/exportMd", {
+                fetchPost("/api/export/exportSY", {
                     id,
                 }, response => {
                     hideMessage(msgId);
@@ -543,12 +543,12 @@ export const exportMd = (id: string) => {
                 });
             }
         }, {
-            id: "exportSiYuanZip",
-            label: "SiYuan .sy.zip",
-            icon: "iconSiYuan",
+            id: "exportMarkdown",
+            label: "Markdown .zip",
+            icon: "iconMarkdown",
             click: () => {
                 const msgId = showMessage(window.siyuan.languages.exporting, -1);
-                fetchPost("/api/export/exportSY", {
+                fetchPost("/api/export/exportMd", {
                     id,
                 }, response => {
                     hideMessage(msgId);

--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -158,7 +158,7 @@ const initMultiMenu = (selectItemElements: NodeListOf<Element>, app: App) => {
         icon: "iconUpload",
         submenu: [{
             id: "exportMarkdown",
-            label: "Markdown",
+            label: "Markdown .zip",
             icon: "iconMarkdown",
             click: () => {
                 const msgId = showMessage(window.siyuan.languages.exporting, -1);
@@ -374,19 +374,6 @@ export const initNavigationMenu = (app: App, liElement: HTMLElement) => {
         type: "submenu",
         icon: "iconUpload",
         submenu: [{
-            id: "exportMarkdown",
-            label: "Markdown",
-            icon: "iconMarkdown",
-            click: () => {
-                const msgId = showMessage(window.siyuan.languages.exporting, -1);
-                fetchPost("/api/export/exportNotebookMd", {
-                    notebook: notebookId
-                }, response => {
-                    hideMessage(msgId);
-                    openByMobile(response.data.zip);
-                });
-            }
-        }, {
             id: "exportSiYuanZip",
             label: "SiYuan .sy.zip",
             icon: "iconSiYuan",
@@ -394,6 +381,19 @@ export const initNavigationMenu = (app: App, liElement: HTMLElement) => {
                 const msgId = showMessage(window.siyuan.languages.exporting, -1);
                 fetchPost("/api/export/exportNotebookSY", {
                     id: notebookId,
+                }, response => {
+                    hideMessage(msgId);
+                    openByMobile(response.data.zip);
+                });
+            }
+        }, {
+            id: "exportMarkdown",
+            label: "Markdown .zip",
+            icon: "iconMarkdown",
+            click: () => {
+                const msgId = showMessage(window.siyuan.languages.exporting, -1);
+                fetchPost("/api/export/exportNotebookMd", {
+                    notebook: notebookId
                 }, response => {
                     hideMessage(msgId);
                     openByMobile(response.data.zip);


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/pull/14950

1. 导出的 `Markdown` 文案更改为 `Markdown .zip`
2. 导出菜单的选项顺序改为与导入菜单一致

	![image](https://github.com/user-attachments/assets/a8e3ef24-045e-4eb2-86e5-5ad178f758c4)
	
	![image](https://github.com/user-attachments/assets/d57efd6b-f9d4-43dd-b6be-2c54c1f0ab48)
