### PR TITLE
Add `data-close-counter` attribute

### DIFF
--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -857,6 +857,7 @@ data-type="navigation-root" data-path="/">
         this.closeElement.lastElementChild.innerHTML = closeHtml;
         const counterElement = this.closeElement.querySelector(".counter");
         counterElement.textContent = closeCounter.toString();
+        this.closeElement.dataset.closeCounter = closeCounter.toString();
         if (closeCounter) {
             counterElement.classList.remove("fn__none");
         } else {
@@ -898,7 +899,9 @@ data-type="navigation-root" data-path="/">
                         });
                         this.closeElement.lastElementChild.innerHTML = closeHTML;
                         const counterElement = this.closeElement.querySelector(".counter");
-                        counterElement.textContent = (parseInt(counterElement.textContent) + 1).toString();
+                        const closeCounter = (parseInt(counterElement.textContent) + 1).toString();
+                        counterElement.textContent = closeCounter;
+                        this.closeElement.dataset.closeCounter = closeCounter;
                         counterElement.classList.remove("fn__none");
                     }
                 }
@@ -908,8 +911,10 @@ data-type="navigation-root" data-path="/">
                 if (removeElement) {
                     removeElement.remove();
                     const counterElement = this.closeElement.querySelector(".counter");
-                    counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
-                    if (counterElement.textContent === "0") {
+                    const closeCounter = (parseInt(counterElement.textContent) - 1).toString();
+                    counterElement.textContent = closeCounter;
+                    this.closeElement.dataset.closeCounter = closeCounter;
+                    if (closeCounter === "0") {
                         counterElement.classList.add("fn__none");
                     }
                 }
@@ -952,8 +957,10 @@ data-type="navigation-root" data-path="/">
         const liElement = this.closeElement.querySelector(`li[data-url="${data.data.box.id}"]`) as HTMLElement;
         if (liElement) {
             const counterElement = this.closeElement.querySelector(".counter");
-            counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
-            if (counterElement.textContent === "0") {
+            const closeCounter = (parseInt(counterElement.textContent) - 1).toString();
+            counterElement.textContent = closeCounter;
+            this.closeElement.dataset.closeCounter = closeCounter;
+            if (closeCounter === "0") {
                 counterElement.classList.add("fn__none");
             }
             liElement.remove();

--- a/app/src/mobile/dock/MobileFiles.ts
+++ b/app/src/mobile/dock/MobileFiles.ts
@@ -354,6 +354,7 @@ export class MobileFiles extends Model {
         this.closeElement.lastElementChild.innerHTML = closeHtml;
         const counterElement = this.closeElement.querySelector(".counter");
         counterElement.textContent = closeCounter.toString();
+        this.closeElement.dataset.closeCounter = closeCounter.toString();
         if (closeCounter) {
             counterElement.classList.remove("fn__none");
         } else {
@@ -436,7 +437,9 @@ export class MobileFiles extends Model {
                         });
                         this.closeElement.lastElementChild.innerHTML = closeHTML;
                         const counterElement = this.closeElement.querySelector(".counter");
-                        counterElement.textContent = (parseInt(counterElement.textContent) + 1).toString();
+                        const closeCounter = (parseInt(counterElement.textContent) + 1).toString();
+                        counterElement.textContent = closeCounter;
+                        this.closeElement.dataset.closeCounter = closeCounter;
                         counterElement.classList.remove("fn__none");
                     }
                 }
@@ -446,8 +449,10 @@ export class MobileFiles extends Model {
                 if (removeElement) {
                     removeElement.remove();
                     const counterElement = this.closeElement.querySelector(".counter");
-                    counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
-                    if (counterElement.textContent === "0") {
+                    const closeCounter = (parseInt(counterElement.textContent) - 1).toString();
+                    counterElement.textContent = closeCounter;
+                    this.closeElement.dataset.closeCounter = closeCounter;
+                    if (closeCounter === "0") {
                         counterElement.classList.add("fn__none");
                     }
                 }
@@ -500,8 +505,10 @@ export class MobileFiles extends Model {
         if (liElement) {
             liElement.remove();
             const counterElement = this.closeElement.querySelector(".counter");
-            counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
-            if (counterElement.textContent === "0") {
+            const closeCounter = (parseInt(counterElement.textContent) - 1).toString();
+            counterElement.textContent = closeCounter;
+            this.closeElement.dataset.closeCounter = closeCounter;
+            if (closeCounter === "0") {
                 counterElement.classList.add("fn__none");
             }
         }


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/13887 Point 1

添加一个属性，使得已关闭的笔记本数量为 0 时用户可以通过添加 CSS 代码片段隐藏这个元素：

```css
.sy__file > .b3-list[data-close-counter="0"] {
    display: none;
}
```

![image](https://github.com/user-attachments/assets/5ada30af-ac99-4ec3-8617-0ecaaf980456)
