### PR TITLE
Hide the "Closed notebooks" element if no notebooks exist

### DIFF
--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -859,8 +859,10 @@ data-type="navigation-root" data-path="/">
         counterElement.textContent = closeCounter.toString();
         if (closeCounter) {
             counterElement.classList.remove("fn__none");
+            counterElement.parentElement.parentElement.classList.remove("fn__none");
         } else {
             counterElement.classList.add("fn__none");
+            counterElement.parentElement.parentElement.classList.add("fn__none");
         }
         window.siyuan.storage[Constants.LOCAL_FILESPATHS].forEach((item: IFilesPath) => {
             item.openPaths.forEach((openPath) => {
@@ -900,6 +902,7 @@ data-type="navigation-root" data-path="/">
                         const counterElement = this.closeElement.querySelector(".counter");
                         counterElement.textContent = (parseInt(counterElement.textContent) + 1).toString();
                         counterElement.classList.remove("fn__none");
+                        counterElement.parentElement.parentElement.classList.remove("fn__none");
                     }
                 }
             });
@@ -911,6 +914,7 @@ data-type="navigation-root" data-path="/">
                     counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
                     if (counterElement.textContent === "0") {
                         counterElement.classList.add("fn__none");
+                        counterElement.parentElement.parentElement.classList.add("fn__none");
                     }
                 }
             }
@@ -955,6 +959,7 @@ data-type="navigation-root" data-path="/">
             counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
             if (counterElement.textContent === "0") {
                 counterElement.classList.add("fn__none");
+                counterElement.parentElement.parentElement.classList.add("fn__none");
             }
             liElement.remove();
         }

--- a/app/src/mobile/dock/MobileFiles.ts
+++ b/app/src/mobile/dock/MobileFiles.ts
@@ -356,8 +356,10 @@ export class MobileFiles extends Model {
         counterElement.textContent = closeCounter.toString();
         if (closeCounter) {
             counterElement.classList.remove("fn__none");
+            counterElement.parentElement.parentElement.classList.remove("fn__none");
         } else {
             counterElement.classList.add("fn__none");
+            counterElement.parentElement.parentElement.classList.add("fn__none");
         }
         window.siyuan.storage[Constants.LOCAL_FILESPATHS].forEach((item: IFilesPath) => {
             item.openPaths.forEach((openPath) => {
@@ -438,6 +440,7 @@ export class MobileFiles extends Model {
                         const counterElement = this.closeElement.querySelector(".counter");
                         counterElement.textContent = (parseInt(counterElement.textContent) + 1).toString();
                         counterElement.classList.remove("fn__none");
+                        counterElement.parentElement.parentElement.classList.remove("fn__none");
                     }
                 }
             });
@@ -449,6 +452,7 @@ export class MobileFiles extends Model {
                     counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
                     if (counterElement.textContent === "0") {
                         counterElement.classList.add("fn__none");
+                        counterElement.parentElement.parentElement.classList.add("fn__none");
                     }
                 }
             }
@@ -503,6 +507,7 @@ export class MobileFiles extends Model {
             counterElement.textContent = (parseInt(counterElement.textContent) - 1).toString();
             if (counterElement.textContent === "0") {
                 counterElement.classList.add("fn__none");
+                counterElement.parentElement.parentElement.classList.add("fn__none");
             }
         }
         setNoteBook((notebooks: INotebook[]) => {


### PR DESCRIPTION
fix #13887 Point 1

不存在已关闭的笔记本时，隐藏 `已关闭的笔记本` 元素

如果用户需要在没有笔记本的时候也显示元素，可以添加 CSS 代码片段：

```css
.sy__file > .b3-list.fn__flex-column {
    display: flex !important;
}
```