### PR TITLE
Remove `title` attribute when converting the doc to a heading

### DIFF
--- a/kernel/model/heading.go
+++ b/kernel/model/heading.go
@@ -199,6 +199,7 @@ func Doc2Heading(srcID, targetID string, after bool) (srcTreeBox, srcTreePath st
 	heading := &ast.Node{ID: srcTree.Root.ID, Type: ast.NodeHeading, HeadingLevel: headingLevel, KramdownIAL: srcTree.Root.KramdownIAL}
 	heading.SetIALAttr("updated", util.CurrentTimeSecondsStr())
 	heading.AppendChild(&ast.Node{Type: ast.NodeText, Tokens: []byte(srcTree.Root.IALAttr("title"))})
+	heading.RemoveIALAttr("title")
 	heading.Box, heading.Path = targetTree.Box, targetTree.Path
 	if "" != tagIAL && 0 < len(tags) {
 		// 带标签的文档块转换为标题块时将标签移动到标题块下方 https://github.com/siyuan-note/siyuan/issues/6550


### PR DESCRIPTION
正常情况下只有文档标题（也是一级标题）才有 title 属性。

文档中的标题也有 title 属性影响了我的主题样式（通过 title 属性判断是否为文档标题）：

![image](https://github.com/user-attachments/assets/ef56e335-945c-4a83-87e4-e75bb74c5049)
