### PR TITLE
issue #15034 half fix

### DIFF
--- a/kernel/api/system.go
+++ b/kernel/api/system.go
@@ -171,9 +171,14 @@ func getEmojiConf(c *gin.Context) {
 				}
 
 				if !util.IsValidUploadFileName(html.UnescapeString(name)) {
+					emojiFullName := customConfDir + "/" + name
+					fullPathFilteredName := customConfDir + "/" + util.FilterUploadFileName(name)
 					// XSS through emoji name https://github.com/siyuan-note/siyuan/issues/15034
 					logging.LogWarnf("invalid custom emoji name [%s]", name)
-					continue
+					logging.LogErrorf("renaming invalid file to [%s] in emojis", fullPathFilteredName)
+					if removeErr := os.Rename(emojiFullName, fullPathFilteredName); nil != removeErr {
+						logging.LogErrorf("renaming invalid file to [%s] failed: %s", fullPathFilteredName, removeErr)
+					}
 				}
 
 				if customEmoji.IsDir() {
@@ -195,9 +200,14 @@ func getEmojiConf(c *gin.Context) {
 						}
 
 						if !util.IsValidUploadFileName(html.UnescapeString(name)) {
+							emojiFullName := customConfDir + "/" + name
+							fullPathFilteredName := customConfDir + "/" + util.FilterUploadFileName(name)
 							// XSS through emoji name https://github.com/siyuan-note/siyuan/issues/15034
 							logging.LogWarnf("invalid custom emoji name [%s]", name)
-							continue
+							logging.LogErrorf("renaming invalid file to [%s] in emojis", fullPathFilteredName)
+							if removeErr := os.Rename(emojiFullName, fullPathFilteredName); nil != removeErr {
+								logging.LogErrorf("renaming invalid file to [%s] failed: %s", fullPathFilteredName, removeErr)
+							}
 						}
 
 						addCustomEmoji(customEmoji.Name()+"/"+name, &items)

--- a/kernel/model/import.go
+++ b/kernel/model/import.go
@@ -559,11 +559,13 @@ func ImportSY(zipPath, boxID, toPath string) (err error) {
 	// 将包含的自定义表情统一移动到 data/emojis/ 下
 	filelock.Walk(filepath.Join(unzipRootPath, "emojis"), func(path string, d fs.DirEntry, err error) error {
 		if !util.IsValidUploadFileName(d.Name()) {
+			emojiFullName := unzipRootPath + "emojis/" + name
+			fullPathFilteredName := unzipRootPath + "emojis/" + util.FilterUploadFileName(name)
 			// XSS through emoji name https://github.com/siyuan-note/siyuan/issues/15034
-			logging.LogErrorf("remove invalid file [%s] in emojis", path)
-			if removeErr := os.Remove(path); nil != removeErr {
-				logging.LogErrorf("remove invalid file [%s] failed: %s", path, removeErr)
-				return nil
+			logging.LogWarnf("invalid custom emoji name [%s]", name)
+			logging.LogErrorf("renaming invalid file to [%s] in emojis", fullPathFilteredName)
+			if removeErr := os.Rename(emojiFullName, fullPathFilteredName); nil != removeErr {
+				logging.LogErrorf("renaming invalid file to [%s] failed: %s", fullPathFilteredName, removeErr)
 			}
 		}
 		return nil

--- a/kernel/util/file.go
+++ b/kernel/util/file.go
@@ -207,6 +207,7 @@ func FilterUploadFileName(name string) string {
 	ret = strings.ReplaceAll(ret, "#", "")
 	ret = strings.ReplaceAll(ret, "%", "")
 	ret = strings.ReplaceAll(ret, "$", "")
+	ret = strings.ReplaceAll(ret, ";", "")
 	ret = TruncateLenFileName(ret)
 	return ret
 }


### PR DESCRIPTION
## bug
its the half fix for https://github.com/siyuan-note/siyuan/issues/15034
the code is renaming and sanitizing the XSS payload named emoji files.
everything works fine, the only thing left is this fix should be executed before the **ImportData** function in `kernel/model/import.go` or before emoji is loaded on the frontend otherwise, the XSS still execute whenever someone imports the zip file.