### PR TITLE
Improve theme switching

### DIFF
--- a/app/src/util/assets.ts
+++ b/app/src/util/assets.ts
@@ -40,7 +40,19 @@ export const loadAssets = (data: Config.IAppearance) => {
     const defaultThemeAddress = `/appearance/themes/${data.mode === 1 ? "midnight" : "daylight"}/theme.css?v=${Constants.SIYUAN_VERSION}`;
     if (defaultStyleElement) {
         if (!defaultStyleElement.getAttribute("href").startsWith(defaultThemeAddress)) {
-            defaultStyleElement.setAttribute("href", defaultThemeAddress);
+            const newStyleElement = document.createElement("link");
+            newStyleElement.id = "themeDefaultStyleNew";
+            newStyleElement.rel = "stylesheet";
+            newStyleElement.href = defaultThemeAddress;
+            
+            // 等待新样式表加载完成再移除旧样式表
+            new Promise((resolve) => {
+                newStyleElement.onload = resolve;
+                defaultStyleElement.parentNode.insertBefore(newStyleElement, defaultStyleElement);
+            }).then(() => {
+                defaultStyleElement.remove();
+                newStyleElement.id = "themeDefaultStyle";
+            });
         }
     } else {
         addStyle(defaultThemeAddress, "themeDefaultStyle");


### PR DESCRIPTION
我观察到一个现象：切换外观模式的时候界面字号会抖动。发现问题来源于默认主题切换过程中 CSS 变量 `--b3-font-size: 14px;` 短暂空缺——新的样式表需要短暂的加载时间。

因此将逻辑改进为：新样式表加载完成之后再移除旧样式表