### PR TITLE
Improve export preview mode CSS variable value filling

### DIFF
--- a/app/src/assets/scss/component/_typography.scss
+++ b/app/src/assets/scss/component/_typography.scss
@@ -523,6 +523,34 @@
   .protyle-icons {
     display: none;
   }
+
+  &[data-copy-to="mp-wechat"] {
+    input[type="checkbox"] {
+      display: none;
+    }
+
+    li {
+      &.protyle-task:not(.protyle-task--done) {
+        list-style-type: "▢";
+      }
+
+      &.protyle-task--done {
+        list-style-type: "☑︎";
+      }
+    }
+
+    pre {
+      margin: 16px 0;
+    }
+  }
+}
+
+// 暗黑模式
+section.b3-typography {
+  &[data-copy-to="mp-wechat"] {
+    background-color: var(--b3-theme-background);
+    padding: 10px;
+  }
 }
 
 .protyle {

--- a/app/src/config/appearance.ts
+++ b/app/src/config/appearance.ts
@@ -11,6 +11,9 @@ import {loadAssets} from "../util/assets";
 import {resetFloatDockSize} from "../layout/dock/util";
 import {confirmDialog} from "../dialog/confirmDialog";
 import {useShell} from "../util/pathName";
+/// #if !MOBILE
+import {getAllEditor} from "../layout/getAll";
+/// #endif
 
 export const appearance = {
     element: undefined as Element,
@@ -263,6 +266,25 @@ export const appearance = {
             });
             return;
         }
+
+        // #if !MOBILE
+        // 外观模式或主题改变之后，重新加载所有将 CSS 变量替换为实际值的导出预览
+        if (data.mode !== window.siyuan.config.appearance.mode ||
+            (data.mode === window.siyuan.config.appearance.mode && (
+                    (data.mode === 0 && window.siyuan.config.appearance.themeLight !== data.themeLight) ||
+                    (data.mode === 1 && window.siyuan.config.appearance.themeDark !== data.themeDark))
+            )
+        ) {
+            getAllEditor().forEach(editor => {
+                if (editor.protyle.preview && !editor.protyle.preview.element.classList.contains("fn__none") &&
+                    editor.protyle.preview.previewElement.classList.contains("b3-typography--fill")
+                ) {
+                    editor.protyle.preview.render(editor.protyle);
+                }
+            });
+        }
+        /// #endif
+
         window.siyuan.config.appearance = data;
         if (appearance.element) {
             const modeElement = appearance.element.querySelector("#mode") as HTMLSelectElement;

--- a/app/src/config/appearance.ts
+++ b/app/src/config/appearance.ts
@@ -277,7 +277,7 @@ export const appearance = {
         ) {
             getAllEditor().forEach(editor => {
                 if (editor.protyle.preview && !editor.protyle.preview.element.classList.contains("fn__none") &&
-                    editor.protyle.preview.previewElement.classList.contains("b3-typography--fill")
+                    editor.protyle.preview.previewElement.dataset.fillCssVar === "true"
                 ) {
                     editor.protyle.preview.render(editor.protyle);
                 }

--- a/app/src/protyle/preview/index.ts
+++ b/app/src/protyle/preview/index.ts
@@ -124,7 +124,9 @@ export class Preview {
                     if (actionCustom) {
                         actionCustom.click(type);
                     } else if ((type === "mp-wechat" || type === "zhihu" || type === "yuque")) {
-                        this.copyToX(this.element.lastElementChild.cloneNode(true) as HTMLElement, protyle, type);
+                        const clonedElement = this.element.lastElementChild.cloneNode(true) as HTMLElement;
+                        const backgroundColor = getComputedStyle(this.element).backgroundColor;
+                        this.copyToX(clonedElement, protyle, type, backgroundColor);
                     } else if (type === "desktop") {
                         previewElement.style.width = "";
                         previewElement.style.padding = protyle.wysiwyg.element.style.padding;
@@ -215,7 +217,7 @@ export class Preview {
         });
     }
 
-    private async copyToX(copyElement: HTMLElement, protyle: IProtyle, type?: string) {
+    private async copyToX(copyElement: HTMLElement, protyle: IProtyle, type?: string, backgroundColor?: string) {
         // fix math render
         if (type === "mp-wechat") {
             this.link2online(copyElement);
@@ -285,15 +287,32 @@ export class Preview {
             });
             return;
         }
-        // 防止背景色被粘贴到公众号中
-        copyElement.style.backgroundColor = "#fff";
-        // 代码背景
-        copyElement.querySelectorAll("code").forEach((item) => {
-            item.style.backgroundImage = "none";
-        });
+
+        if (window.siyuan.config.appearance.mode === 1) {
+            // 暗黑模式添加一层 section 设置背景色
+            const sectionElement = document.createElement("section");
+            sectionElement.innerHTML = copyElement.innerHTML;
+            // 背景色可以粘贴到公众号中，不会粘贴到知乎
+            if (!backgroundColor || backgroundColor === "rgba(0, 0, 0, 0)" || backgroundColor === "transparent") {
+                backgroundColor = "#1e1e1e";
+            }
+            sectionElement.style.backgroundColor = backgroundColor;
+            sectionElement.style.padding = "10px";
+            copyElement.innerHTML = "";
+            copyElement.removeAttribute("style");
+            copyElement.appendChild(sectionElement);
+            // b3-typography 类名移动，否则选择器不匹配
+            sectionElement.classList.add("b3-typography");
+            copyElement.classList.add("b3-typography--copy");
+            copyElement.classList.remove("b3-typography");
+        } else {
+            // 明亮模式防止背景色被粘贴到公众号中
+            copyElement.style.backgroundColor = "#fff";
+        }
+
         this.element.append(copyElement);
-        // 最后一个块是公式块时无法复制下来
-        copyElement.insertAdjacentHTML("beforeend", "<p>&zwj;</p>");
+        // 最后一个块是公式块时无法复制下来；section 元素后面还需要一个其他元素才能被复制
+        copyElement.insertAdjacentHTML("beforeend", "<p style='background-color: transparent;'> &zwj;</p>");
         let cloneRange;
         if (getSelection().rangeCount > 0) {
             cloneRange = getSelection().getRangeAt(0).cloneRange();

--- a/app/src/protyle/preview/index.ts
+++ b/app/src/protyle/preview/index.ts
@@ -322,7 +322,7 @@ export class Preview {
 
         this.element.append(copyElement);
         // 最后一个块是公式块时无法复制下来；section 元素后面还需要一个其他元素才能被复制
-        copyElement.insertAdjacentHTML("beforeend", "<p style='background-color: transparent;'> &zwj;</p>");
+        copyElement.insertAdjacentHTML("beforeend", "<p style='background-color: transparent;'>&zwj;</p>");
         let cloneRange;
         if (getSelection().rangeCount > 0) {
             cloneRange = getSelection().getRangeAt(0).cloneRange();

--- a/app/src/protyle/preview/index.ts
+++ b/app/src/protyle/preview/index.ts
@@ -190,6 +190,11 @@ export class Preview {
             }, response => {
                 const oldScrollTop = protyle.preview.previewElement.scrollTop;
                 protyle.preview.previewElement.innerHTML = response.data.html;
+                if (response.data.fillCSSVar) {
+                    protyle.preview.previewElement.classList.add("b3-typography--fill");
+                } else {
+                    protyle.preview.previewElement.classList.remove("b3-typography--fill");
+                }
                 processRender(protyle.preview.previewElement);
                 highlightRender(protyle.preview.previewElement);
                 avRender(protyle.preview.previewElement, protyle);
@@ -288,7 +293,7 @@ export class Preview {
             return;
         }
 
-        if (window.siyuan.config.appearance.mode === 1) {
+        if (!copyElement.classList.contains("b3-typography--fill") && window.siyuan.config.appearance.mode === 1) {
             // 暗黑模式添加一层 section 设置背景色
             const sectionElement = document.createElement("section");
             sectionElement.innerHTML = copyElement.innerHTML;

--- a/app/src/protyle/preview/index.ts
+++ b/app/src/protyle/preview/index.ts
@@ -315,6 +315,11 @@ export class Preview {
             copyElement.style.backgroundColor = "#fff";
         }
 
+        // 代码块之间没有间距
+        copyElement.querySelectorAll("pre").forEach((item: HTMLElement) => {
+            item.style.margin = "16px 0";
+        });
+
         this.element.append(copyElement);
         // 最后一个块是公式块时无法复制下来；section 元素后面还需要一个其他元素才能被复制
         copyElement.insertAdjacentHTML("beforeend", "<p style='background-color: transparent;'> &zwj;</p>");

--- a/kernel/api/export.go
+++ b/kernel/api/export.go
@@ -29,6 +29,7 @@ import (
 	"github.com/88250/gulu"
 	"github.com/88250/lute/parse"
 	"github.com/gin-gonic/gin"
+	"github.com/mssola/useragent"
 	"github.com/siyuan-note/logging"
 	"github.com/siyuan-note/siyuan/kernel/model"
 	"github.com/siyuan-note/siyuan/kernel/util"
@@ -622,9 +623,23 @@ func exportPreview(c *gin.Context) {
 	}
 
 	id := arg["id"].(string)
-	stdHTML := model.Preview(id)
+
+	userAgentStr := c.GetHeader("User-Agent")
+	fillCSSVar := true
+	if userAgentStr != "" {
+		ua := useragent.New(userAgentStr)
+		name, _ := ua.Browser()
+		// Chrome、Edge、SiYuan 桌面端不需要替换 CSS 变量
+		isMobile := strings.Contains(userAgentStr, " ios/") || strings.Contains(userAgentStr, " android/")
+		if !isMobile && (name == "Chrome" || name == "Edge" || strings.Contains(userAgentStr, "Electron") || strings.Contains(userAgentStr, "SiYuan/")) {
+			fillCSSVar = false
+		}
+	}
+
+	stdHTML := model.Preview(id, fillCSSVar)
 	ret.Data = map[string]interface{}{
-		"html": stdHTML,
+		"html":       stdHTML,
+		"fillCSSVar": fillCSSVar,
 	}
 }
 

--- a/kernel/api/export.go
+++ b/kernel/api/export.go
@@ -630,8 +630,7 @@ func exportPreview(c *gin.Context) {
 		ua := useragent.New(userAgentStr)
 		name, _ := ua.Browser()
 		// Chrome、Edge、SiYuan 桌面端不需要替换 CSS 变量
-		isMobile := strings.Contains(userAgentStr, " ios/") || strings.Contains(userAgentStr, " android/")
-		if !isMobile && (name == "Chrome" || name == "Edge" || strings.Contains(userAgentStr, "Electron") || strings.Contains(userAgentStr, "SiYuan/")) {
+		if !ua.Mobile() && (name == "Chrome" || name == "Edge" || strings.Contains(userAgentStr, "Electron") || strings.Contains(userAgentStr, "SiYuan/")) {
 			fillCSSVar = false
 		}
 	}

--- a/kernel/model/export.go
+++ b/kernel/model/export.go
@@ -571,7 +571,7 @@ func ExportResources(resourcePaths []string, mainName string) (exportFilePath st
 	return
 }
 
-func Preview(id string) (retStdHTML string) {
+func Preview(id string, fillCSSVar bool) (retStdHTML string) {
 	blockRefMode := Conf.Export.BlockRefMode
 	tree, _ := LoadTreeByBlockID(id)
 	tree = exportTree(tree, false, false, true,
@@ -599,7 +599,9 @@ func Preview(id string) (retStdHTML string) {
 	md := treenode.FormatNode(tree.Root, luteEngine)
 	tree = parse.Parse("", []byte(md), luteEngine.ParseOptions)
 	// 使用实际主题样式值替换样式变量 Use real theme style value replace var in preview mode https://github.com/siyuan-note/siyuan/issues/11458
-	fillThemeStyleVar(tree)
+	if fillCSSVar {
+		fillThemeStyleVar(tree)
+	}
 	luteEngine.RenderOptions.ProtyleMarkNetImg = false
 	retStdHTML = luteEngine.ProtylePreview(tree, luteEngine.RenderOptions)
 

--- a/kernel/model/theme.go
+++ b/kernel/model/theme.go
@@ -31,8 +31,18 @@ import (
 	"github.com/vanng822/css"
 )
 
+// 将文档中的 CSS 变量替换为具体的主题样式值
 func fillThemeStyleVar(tree *parse.Tree) {
-	themeStyles := getThemeStyleVar(Conf.Appearance.ThemeLight)
+	if nil == tree || nil == tree.Root {
+		return
+	}
+
+	var themeStyles map[string]string
+	if 1 == Conf.Appearance.Mode {
+		themeStyles = getThemeStyleVar(Conf.Appearance.ThemeDark, true)
+	} else {
+		themeStyles = getThemeStyleVar(Conf.Appearance.ThemeLight, false)
+	}
 	if 1 > len(themeStyles) {
 		return
 	}
@@ -42,6 +52,7 @@ func fillThemeStyleVar(tree *parse.Tree) {
 			return ast.WalkContinue
 		}
 
+		// 遍历节点的 Kramdown IAL (Inline Attribute List) 属性
 		for _, ial := range n.KramdownIAL {
 			if "style" != ial[0] {
 				continue
@@ -54,13 +65,12 @@ func fillThemeStyleVar(tree *parse.Tree) {
 				for style, name := range styles {
 					buf.WriteString(style)
 					buf.WriteString(": ")
-					value := themeStyles[name]
-					if strings.Contains(value, "var(") {
-						name = gulu.Str.SubStringBetween(value, "(", ")")
-						value = themeStyles[name]
-					}
+
+					// 解析嵌套的 CSS 变量
+					value := resolveNestedCSSVar(themeStyles, name)
+
 					if "" == value {
-						// 回退为变量
+						// 回退为原始 var() 形式
 						buf.WriteString("var(")
 						buf.WriteString(name)
 						buf.WriteString(")")
@@ -78,12 +88,48 @@ func fillThemeStyleVar(tree *parse.Tree) {
 	})
 }
 
+// 递归解析嵌套的 CSS 变量
+func resolveNestedCSSVar(themeStyles map[string]string, varName string) string {
+	visited := make(map[string]bool) // 循环引用检测
+	maxDepth := 10                   // 防止无限嵌套
+
+	currentName := varName
+	for depth := 0; depth < maxDepth; depth++ {
+		if visited[currentName] {
+			return ""
+		}
+		visited[currentName] = true
+
+		value, exists := themeStyles[currentName]
+		if !exists {
+			return ""
+		}
+
+		// 如果不包含嵌套变量，直接返回最终值
+		if !strings.Contains(value, "var(") {
+			return value
+		}
+
+		// 提取嵌套变量名：var(--variable-name) -> --variable-name
+		nestedVarName := gulu.Str.SubStringBetween(value, "(", ")")
+		if "" == nestedVarName {
+			return value
+		}
+
+		currentName = nestedVarName
+	}
+
+	return ""
+}
+
+// 从 CSS 选择器值中解析出样式属性和对应的 CSS 变量名
 func getStyleVarName(value *css.CSSValue) (ret map[string]string) {
 	ret = map[string]string{}
 
 	var start, end int
 	var style, name string
 	for i, t := range value.Tokens {
+		// 获取样式属性名
 		if scanner.TokenIdent == t.Type && 0 == start {
 			style = strings.TrimSpace(t.Value)
 			continue
@@ -96,6 +142,7 @@ func getStyleVarName(value *css.CSSValue) (ret map[string]string) {
 		if scanner.TokenChar == t.Type && ")" == t.Value {
 			end = i
 
+			// 提取 var() 中的变量名
 			if 0 < start && 0 < end {
 				for _, tt := range value.Tokens[start+1 : end] {
 					name += tt.Value
@@ -110,23 +157,78 @@ func getStyleVarName(value *css.CSSValue) (ret map[string]string) {
 	return
 }
 
-func getThemeStyleVar(theme string) (ret map[string]string) {
+// 获取主题的样式变量映射表
+func getThemeStyleVar(theme string, isDarkMode bool) (ret map[string]string) {
 	ret = map[string]string{}
 
-	data, err := os.ReadFile(filepath.Join(util.ThemesPath, theme, "theme.css"))
-	if err != nil {
-		logging.LogErrorf("read theme [%s] css file failed: %s", theme, err)
-		return
-	}
+	var cssContent string
 
-	styleSheet := css.Parse(string(data))
-	for _, rule := range styleSheet.GetCSSRuleList() {
-		for _, style := range rule.Style.Styles {
-			ret[style.Property] = strings.TrimSpace(style.Value.Text())
-			// 如果两个短横线开头 CSS 解析器有问题，--b3-theme-primary: #3575f0; 会被解析为 -b3-theme-primary:- #3575f0
-			// 这里两种解析都放到结果中
-			ret["-"+style.Property] = strings.TrimSpace(strings.TrimPrefix(style.Value.Text(), "-"))
+	// 第三方主题可能缺少基础变量，先加载默认主题作为基础
+	defaultTheme := map[bool]string{false: "daylight", true: "midnight"}[isDarkMode]
+	if theme != defaultTheme {
+		defaultData, err := os.ReadFile(filepath.Join(util.ThemesPath, defaultTheme, "theme.css"))
+		if err != nil {
+			logging.LogErrorf("read default theme [%s] css file failed: %s", defaultTheme, err)
+		} else {
+			cssContent = string(defaultData) + "\n"
 		}
 	}
-	return
+
+	// 拼接主题 CSS，后面的规则覆盖前面的规则
+	userData, err := os.ReadFile(filepath.Join(util.ThemesPath, theme, "theme.css"))
+	if err != nil {
+		logging.LogErrorf("read theme [%s] css file failed: %s", theme, err)
+		return ret
+	}
+	cssContent += string(userData)
+
+	// 解析拼接后的完整 CSS 内容
+	styleSheet := css.Parse(cssContent)
+	stylePriorities := map[string]int{}
+	currentMode := map[bool]string{false: "light", true: "dark"}[isDarkMode]
+	for _, rule := range styleSheet.GetCSSRuleList() {
+		priority := getSelectorPriority(rule.Style.Selector.Text(), currentMode)
+		for _, style := range rule.Style.Styles {
+			propName := style.Property
+			propValue := strings.TrimSpace(style.Value.Text())
+
+			if existingPriority, exists := stylePriorities[propName]; !exists || priority >= existingPriority {
+				ret[propName] = propValue
+				stylePriorities[propName] = priority
+			}
+
+			// 如果两个短横线开头 CSS 解析器有问题，--b3-theme-primary: #3575f0; 会被解析为 -b3-theme-primary:- #3575f0
+			// 这里两种解析都放到结果中
+			bugFixPropName := "-" + propName
+			bugFixPropValue := strings.TrimSpace(strings.TrimPrefix(propValue, "-"))
+			if existingPriority, exists := stylePriorities[bugFixPropName]; !exists || priority >= existingPriority {
+				ret[bugFixPropName] = bugFixPropValue
+				stylePriorities[bugFixPropName] = priority
+			}
+		}
+	}
+	return ret
+}
+
+// 粗略计算 CSS 选择器的优先级
+func getSelectorPriority(selector, currentMode string) int {
+	selector = strings.TrimSpace(strings.ToLower(selector))
+
+	modeSelectors := []string{
+		"[data-theme-mode=\"" + currentMode + "\"]",
+		"[data-theme-mode='" + currentMode + "']",
+		"[data-theme-mode=" + currentMode + "]",
+	}
+
+	for _, modeSelector := range modeSelectors {
+		if strings.Contains(selector, modeSelector) {
+			if strings.Contains(selector, ":root") || strings.Contains(selector, "html") {
+				return 2
+			} else {
+				return 1
+			}
+		}
+	}
+
+	return 0
 }


### PR DESCRIPTION
关联 https://github.com/siyuan-note/siyuan/issues/15026

目前存在的问题与改进方案：

---

01 在 Chrome 上“复制到公众号”，浏览器会自动把变量转换为实际值再写入剪贴板。但在 Firefox 上“复制到公众号”，剪贴板的 HTML 跟 DOM 一致，CSS 变量没有转换。

改进方案：

- 在 Chromium 内核的浏览器中的导出预览不将变量转换为实际值，能够保留原本的样式
- 在其他浏览器中的导出预览经过内核 `fillThemeStyleVar()` 处理，将变量转换为实际值

---

02 导出预览会始终从明亮主题 `Conf.Appearance.ThemeLight` 获取变量实际值，在暗黑模式下使用明亮主题的配色造成了不一致。

改进方案：

- 通过 `Conf.Appearance.Mode` 判断当前外观模式，然后获取外观模式对应的 `Conf.Appearance.ThemeLight` 或 `Conf.Appearance.ThemeDark`
- 切换外观模式或者切换主题之后重新加载所有导出预览

---

03 始终从 CSS 的最后一个变量定义中获取实际值，而不匹配选择器，无法区分明亮模式和暗黑模式的配色。

```css
html[data-theme-mode="dark"] {
    --color: #FFF;
}
:root[data-theme-mode="light"] {
    --color: #000;
}
```

比如从以上 CSS 中解析，无论当前的外观模式是什么，获取到的 `--color` 变量实际值都是最后出现的 `#000`

改进方案：

- 优先按选择器匹配解析 CSS 变量

  明亮模式常用的选择器：`:root[data-theme-mode="light"]` `html[data-theme-mode="light"]` `[data-theme-mode="light"]`（以及不用双引号）

  暗黑模式常用的选择器：`:root[data-theme-mode="dark"]` `html[data-theme-mode="dark"]` `[data-theme-mode="dark"]`（以及不用双引号）
- 如果没有匹配的选择器，则按原来的方式从最后一个变量定义中获取实际值

但目前仍然存在缺陷：多配色的主题，配色功能的实现方式不一致，获取变量实际值时没有办法匹配对应的配色。

需要原生实现与提供在单个外观模式中切换主题配色的功能，所有主题统一进行适配。具体方案有待讨论。

---

04 从主题的 `theme.css` 文件中解析变量，如果第三方主题中不存在该变量实际值，没有回退到默认主题的变量实际值。

改进方案：

- 将默认主题与第三方主题的 CSS 文件拼接，一起解析

---

05 在暗黑模式下“复制到公众号”，没有带编辑器背景色，白色的文字都看不清

改进方案：

- 公众号支持使用 section 元素，故暗黑模式添加一层 section 元素设置背景色
- Firefox 浏览器无法将 section 元素复制到剪贴板，但文字也不是白色的，所以忽略处理

---

06 变量嵌套的情况没有处理，比如：

```css
--b3-card-error-color: rgb(243, 153, 147);
--b3-font-color1: var(--b3-card-error-color);
color: var(--b3-font-color1)
```

改进方案：

- 递归解析嵌套的 CSS 变量

---

07 如果行级元素上有样式，则该样式无法导出。

比如普通文本有背景色，导出会生成 span 标签；但如果是粗体文本有背景色，导出只有纯文本 `**foo**`

问题记录到：https://github.com/siyuan-note/siyuan/issues/15104

---

相关文件：

- `app/src/config/appearance.ts`
- `app/src/protyle/preview/index.ts`
- `kernel/api/export.go`
- `kernel/model/export.go`
- `kernel/model/theme.go`

---

使用浅吟主题复制到公众号的效果：

- 手机明亮模式、思源明亮主题
- 手机明亮模式、思源暗黑主题
- 手机暗色模式、思源明亮主题
- 手机暗色模式、思源暗黑主题

![3e28d21517f1a5641d8c574e63567307](https://github.com/user-attachments/assets/4a206f7e-efc8-4adf-945d-d29faddd6505)
