### PR TITLE
Export preview cannot copy images

### DIFF
--- a/app/src/assets/scss/component/_typography.scss
+++ b/app/src/assets/scss/component/_typography.scss
@@ -436,7 +436,7 @@
     vertical-align: top; // https://ld246.com/article/1647522074722
     margin: 0 auto;
     max-width: 100%;
-    user-select: none;
+    // user-select: none; 会导致图片无法复制 https://github.com/siyuan-note/siyuan/issues/15151
     word-break: keep-all;
     white-space: nowrap;
 


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/15151

经测试，在 Chrome 和 Firefox 上使用 `user-select: none;` 都会导致图片无法复制，故移除该样式

该样式添加于 https://github.com/siyuan-note/siyuan/commit/087aef84c43fcb58a08aea71ac3caa6bc982e5e2