### PR TITLE
Improve ChangeAttrViewLayout

### DIFF
--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -150,18 +150,20 @@ func ChangeAttrViewLayout(blockID, avID string, layout av.LayoutType) (err error
 	view.LayoutType = newLayout
 	err = av.SaveAttributeView(attrView)
 
-	node, tree, err := getNodeByBlockID(nil, blockID)
-	if err != nil {
-		return
-	}
+	blockIDs := treenode.GetMirrorAttrViewBlockIDs(avID)
+	for _, blockID := range blockIDs {
+		node, tree, err := getNodeByBlockID(nil, blockID)
+		if err != nil {
+			continue
+		}
 
-	node.AttributeViewType = string(view.LayoutType)
-	attrs := parse.IAL2Map(node.KramdownIAL)
-	attrs[av.NodeAttrView] = view.ID
-	err = setNodeAttrs(node, tree, attrs)
-	if err != nil {
-		logging.LogWarnf("set node [%s] attrs failed: %s", blockID, err)
-		return
+		node.AttributeViewType = string(view.LayoutType)
+		attrs := parse.IAL2Map(node.KramdownIAL)
+		attrs[av.NodeAttrView] = view.ID
+		err = setNodeAttrs(node, tree, attrs)
+		if err != nil {
+			logging.LogWarnf("set node [%s] attrs failed: %s", blockID, err)
+		}
 	}
 
 	ReloadAttrView(avID)


### PR DESCRIPTION
将数据库视图布局从表格切换到画廊，只有当前操作的数据库块属性 data-av-type 从 table 变为 gallery ，镜像数据库没变化：

[video.webm](https://github.com/user-attachments/assets/fd36223c-3229-437d-8ba1-86a4d0d1545a)
