### PR TITLE
Fake editable embed block

### DIFF
--- a/app/src/assets/scss/business/_block.scss
+++ b/app/src/assets/scss/business/_block.scss
@@ -20,6 +20,161 @@
       opacity: 1;
     }
 
+    &--embed {
+      // 嵌入块模式样式 - 完全匹配嵌入块外观
+      border: 1px dashed var(--b3-theme-on-surface-light) !important;
+      background-color: var(--b3-embed-background) !important;
+      box-shadow: none !important;
+      border-radius: var(--b3-border-radius) !important;  // 默认圆角
+      width: auto !important;  // 确保宽度由JS控制
+      max-width: none !important;  // 移除最大宽度限制
+      min-width: none !important;  // 移除最小宽度限制
+      min-height: auto !important;  // 🔑 关键修复：移除最小高度限制
+      padding: 0 !important;  // 移除浮窗本身的padding，让内容区域处理
+      box-sizing: border-box !important;  // 确保正确的盒模型
+      overflow: hidden !important;  // 🔑 禁止内部滚动
+      
+      // 🔑 强制覆盖移动端样式设置 - 使用更具体的选择器
+      // 空选择器用于确保优先级
+      
+      // 完全隐藏顶部工具栏区域
+      .block__icons {
+        display: none !important;
+      }
+      
+      // 隐藏拖拽控制点（除了顶部）
+      .resize__rd, .resize__ld, .resize__lt, .resize__rt, 
+      .resize__r, .resize__d, .resize__l {
+        display: none;
+      }
+      
+      // 🔑 优化顶部拖拽条，更容易触发转换
+      .resize__t {
+        cursor: move;
+        height: 12px !important;  // 🔑 显著增加拖拽区域高度
+        background: linear-gradient(to bottom, 
+          rgba(var(--b3-theme-primary-lighter-rgb), 0.15), 
+          rgba(var(--b3-theme-primary-lighter-rgb), 0.05));  // 🔑 渐变背景更明显
+        border-radius: var(--b3-border-radius) var(--b3-border-radius) 0 0;
+        transition: all 0.2s;
+        
+        &:hover {
+          background: linear-gradient(to bottom, 
+            rgba(var(--b3-theme-primary-rgb), 0.3), 
+            rgba(var(--b3-theme-primary-rgb), 0.1));  // 🔑 悬停时更明显
+        }
+        
+        // 🔑 添加拖拽提示图标
+        &::after {
+          content: "⋮⋮⋮";
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          font-size: 8px;
+          line-height: 4px;
+          letter-spacing: 2px;
+          color: var(--b3-theme-on-surface);
+          opacity: 0.4;
+          pointer-events: none;
+        }
+        
+        &:hover::after {
+          opacity: 0.8;
+          color: var(--b3-theme-primary);
+        }
+      }
+      
+      // 内容区域样式匹配嵌入块  
+      .block__content {
+        padding: 2px 4px !important;  // 🔑 恢复：匹配嵌入块的padding
+        background-color: transparent !important;
+        border-radius: 0 !important;
+        border: none !important;
+        box-shadow: none !important;
+        
+        // 移除内层边框和装饰
+        .protyle-content {
+          padding: 0 !important;
+          margin: 0 !important;
+          border: none !important;
+          background: transparent !important;
+        }
+        
+        // 🔑 protyle-wysiwyg移除padding，因为外层已有
+        .protyle-wysiwyg {
+          padding: 0 !important;  // 移除padding，外层已处理
+          margin: 0 !important;   // 确保没有额外margin
+        }
+        
+        // 🔑 关键修复：移除protyle的最小高度限制
+        .protyle {
+          min-height: auto !important;  // 移除155px最小高度
+          // 保持其他默认样式
+        }
+        
+        // 🔑 面包屑不额外添加padding，外层已处理
+        .protyle-breadcrumb {
+          margin: 0 !important;
+          // 不设置额外padding，使用外层的padding
+          
+          // 隐藏面包屑区域的额外按钮，只保留纯净的面包屑
+          .protyle-breadcrumb__space,
+          .block__icon,
+          .fn__flex-center,
+          button {
+            display: none !important;
+          }
+          
+          // 确保面包屑栏本身的显示由JS控制
+          .protyle-breadcrumb__bar {
+            margin: 0 !important;
+            padding: 0 !important;
+          }
+        }
+      }
+      
+      // 🔑 动态边框控制 - 根据裁剪状态调整样式
+      &.block__popover--embed-clipped-top {
+        border-top: none !important;
+        border-radius: 0 0 var(--b3-border-radius) var(--b3-border-radius) !important;
+      }
+      
+      &.block__popover--embed-clipped-bottom {
+        border-bottom: none !important;
+        border-radius: var(--b3-border-radius) var(--b3-border-radius) 0 0 !important;
+      }
+      
+      &.block__popover--embed-clipped-both {
+        border-top: none !important;
+        border-bottom: none !important;
+        border-radius: 0 !important;
+      }
+      
+      // 禁用浮窗内部所有滚动
+      .block__content {
+        overflow: hidden !important;
+        
+        // 🔑 只移除protyle的最小高度限制，保持其他默认样式
+        .protyle {
+          min-height: auto !important;  // 移除155px最小高度
+          // 保持其他默认样式不变
+        }
+      }
+      
+      .protyle-content {
+        overflow: hidden !important;
+        padding: 0 !important;
+        margin: 0 !important;
+      }
+      
+      // 🔑 wysiwyg元素只调整外层padding，保持内部结构不变
+      .protyle-wysiwyg {
+        // 只设置外层padding匹配嵌入块，不干扰内部节点布局
+        // 内部节点保持原有的默认样式
+      }
+    }
+
     & > .block__icons {
       border-radius: var(--b3-border-radius-b) var(--b3-border-radius-b) 0 0;
 
@@ -125,4 +280,9 @@
     padding: 4px;
     flex-shrink: 0;
   }
+}
+
+// 🔑 强制覆盖mobile.scss中的80vw宽度设置 - 使用双类名选择器提高优先级
+.block__popover.block__popover--embed {
+  width: auto !important;
 }

--- a/app/src/block/Panel.ts
+++ b/app/src/block/Panel.ts
@@ -17,6 +17,7 @@ import {App} from "../index";
 import {resize} from "../protyle/util/resize";
 import {checkFold} from "../util/noRelyPCFunction";
 import {updateHotkeyAfterTip} from "../protyle/util/compatibility";
+import {getRangeByPoint, focusByRange} from "../protyle/util/selection";
 
 export class BlockPanel {
     public element: HTMLElement;
@@ -31,6 +32,25 @@ export class BlockPanel {
     private observerResize: ResizeObserver;
     private observerLoad: IntersectionObserver;
     private originalRefBlockIDs: IObject;
+    private clickInfo?: {  // 🔑 存储点击位置信息
+        clientX: number,
+        clientY: number,
+        targetRect: DOMRect,
+        relativeX: number,
+        relativeY: number
+    };
+    // 添加嵌入块模式的事件处理器
+    private scrollHandler = () => {
+        if (this.element && this.element.classList.contains("block__popover--embed")) {
+            // 🔑 直接同步执行，确保零延迟跟随
+            this.updateEmbedPosition();
+        }
+    };
+    private resizeHandler = () => {
+        if (this.element && this.element.classList.contains("block__popover--embed")) {
+            this.updateEmbedPosition();
+        }
+    };
 
     // x,y 和 targetElement 二选一必传
     constructor(options: {
@@ -41,6 +61,13 @@ export class BlockPanel {
         originalRefBlockIDs?: IObject,  // isBacklink 为 true 时有效
         x?: number,
         y?: number,
+        clickInfo?: {  // 🔑 新增：点击位置信息
+            clientX: number,
+            clientY: number,
+            targetRect: DOMRect,
+            relativeX: number,
+            relativeY: number
+        }
     }) {
         this.id = genUUID();
         this.targetElement = options.targetElement;
@@ -50,6 +77,7 @@ export class BlockPanel {
         this.y = options.y;
         this.isBacklink = options.isBacklink;
         this.originalRefBlockIDs = options.originalRefBlockIDs;
+        this.clickInfo = options.clickInfo;  // 🔑 保存点击位置信息
 
         this.element = document.createElement("div");
         this.element.classList.add("block__popover");
@@ -142,13 +170,75 @@ export class BlockPanel {
             }
         });
         /// #if !MOBILE
-        moveResize(this.element, () => {
+        moveResize(this.element, (type) => {
+            // 拖拽时移除嵌入块模式
+            if (this.element.classList.contains("block__popover--embed")) {
+                // 保存当前位置和尺寸
+                const currentRect = this.element.getBoundingClientRect();
+                
+                // 🔑 动态计算工具栏高度，更准确
+                let toolbarHeight = 42; // 默认高度
+                const existingToolbar = this.element.querySelector(".block__icons");
+                if (existingToolbar) {
+                    const toolbarRect = existingToolbar.getBoundingClientRect();
+                    if (toolbarRect.height > 0) {
+                        toolbarHeight = toolbarRect.height;
+                    }
+                }
+                
+                // 🔑 先清理嵌入块模式，再移除样式类
+                this.cleanupEmbedMode();
+                this.element.classList.remove("block__popover--embed");
+                
+                // 🔑 计算最佳位置，确保工具栏可见且不超出屏幕
+                const newTop = Math.max(currentRect.top - toolbarHeight, 10);
+                const newLeft = Math.max(currentRect.left, 10);
+                const newWidth = Math.max(currentRect.width, 400); // 确保最小宽度
+                const newHeight = currentRect.height + toolbarHeight;
+                
+                // 🔑 设置转换后的位置和尺寸
+                this.element.style.left = newLeft + "px";
+                this.element.style.top = newTop + "px";
+                this.element.style.width = newWidth + "px";
+                this.element.style.height = newHeight + "px";
+                
+                // 🔑 设置普通浮窗的约束
+                this.element.style.maxWidth = Math.max(newWidth, 1024) + "px";
+                this.element.style.minWidth = "300px";
+                this.element.style.minHeight = "200px";
+                
+                // 🔑 确保浮窗可见性和层级
+                this.element.style.display = "";
+                this.element.style.zIndex = (++window.siyuan.zIndex).toString();
+                
+                // 🔑 触发resize事件，确保内容重新布局
+                setTimeout(() => {
+                    this.editors.forEach(editor => {
+                        if (editor && editor.protyle) {
+                            resize(editor.protyle);
+                        }
+                    });
+                }, 50);
+            }
+            
             const pinElement = this.element.firstElementChild.querySelector('[data-type="pin"]');
-            pinElement.setAttribute("aria-label", window.siyuan.languages.unpin);
-            pinElement.querySelector("use").setAttribute("xlink:href", "#iconUnpin");
+            if (pinElement) {
+                pinElement.setAttribute("aria-label", window.siyuan.languages.unpin);
+                const useElement = pinElement.querySelector("use");
+                if (useElement) {
+                    useElement.setAttribute("xlink:href", "#iconUnpin");
+                }
+            }
             this.element.setAttribute("data-pin", "true");
         });
         /// #endif
+
+        // 检测并设置嵌入块模式
+        if (this.targetElement && this.targetElement.classList.contains("protyle-wysiwyg__embed")) {
+            this.element.classList.add("block__popover--embed");
+            this.initEmbedMode();
+        }
+
         this.render();
     }
 
@@ -204,7 +294,346 @@ export class BlockPanel {
         });
     }
 
+    private initEmbedMode() {
+        // 设置初始样式和位置
+        this.updateEmbedPosition();
+        
+        // 检查嵌入块面包屑设置
+        this.checkEmbedBreadcrumb();
+        
+        // 监听滚动事件
+        const contentElement = hasClosestByClassName(this.targetElement, "protyle-content", true);
+        if (contentElement) {
+            // 🔑 移除被动监听器，确保实时响应
+            contentElement.addEventListener("scroll", this.scrollHandler);
+        }
+        
+        // 监听窗口大小变化
+        window.addEventListener("resize", this.resizeHandler);
+    }
+
+    private updateEmbedPosition() {
+        if (!this.targetElement || !document.body.contains(this.targetElement)) {
+            return;
+        }
+        
+        // 获取嵌入块容器（NodeBlockQueryEmbed）的位置，这是实际需要覆盖的元素
+        const embedContainer = this.targetElement.closest('[data-type="NodeBlockQueryEmbed"]') as HTMLElement;
+        if (!embedContainer) {
+            return;
+        }
+        
+        const targetRect = embedContainer.getBoundingClientRect();
+        const contentElement = hasClosestByClassName(this.targetElement, "protyle-content", true);
+        
+        // 检查是否完全不可见
+        if (contentElement) {
+            const contentRect = contentElement.getBoundingClientRect();
+            if (targetRect.bottom < contentRect.top || targetRect.top > contentRect.bottom) {
+                this.element.style.display = "none";
+                return;
+            }
+        }
+        
+        this.element.style.display = "";
+        
+        // 🔑 计算裁剪状态和偏移量
+        let clipTop = 0;
+        let clipBottom = 0;
+        let isTopClipped = false;
+        let isBottomClipped = false;
+        
+        if (contentElement) {
+            const contentRect = contentElement.getBoundingClientRect();
+            
+            if (targetRect.top < contentRect.top) {
+                clipTop = contentRect.top - targetRect.top;
+                isTopClipped = true;
+            }
+            
+            if (targetRect.bottom > contentRect.bottom) {
+                clipBottom = targetRect.bottom - contentRect.bottom;
+                isBottomClipped = true;
+            }
+        }
+        
+        // 🔑 应用动态边框样式类
+        this.element.classList.remove(
+            "block__popover--embed-clipped-top",
+            "block__popover--embed-clipped-bottom", 
+            "block__popover--embed-clipped-both"
+        );
+        
+        if (isTopClipped && isBottomClipped) {
+            this.element.classList.add("block__popover--embed-clipped-both");
+        } else if (isTopClipped) {
+            this.element.classList.add("block__popover--embed-clipped-top");
+        } else if (isBottomClipped) {
+            this.element.classList.add("block__popover--embed-clipped-bottom");
+        }
+        
+        // 🔑 新策略：始终根据嵌入块设置显示面包屑，不因裁剪而隐藏
+        // 这样可以保持内容的相对位置关系，面包屑会被自然裁剪
+        this.checkEmbedBreadcrumb();
+        
+        // 计算浮窗的实际显示区域（保持原始高度比例）
+        const visibleTop = Math.max(targetRect.top, contentElement ? contentElement.getBoundingClientRect().top : targetRect.top);
+        const visibleBottom = Math.min(targetRect.bottom, contentElement ? contentElement.getBoundingClientRect().bottom : targetRect.bottom);
+        const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+        
+        // 设置浮窗位置和尺寸
+        this.element.style.left = targetRect.left + "px";
+        this.element.style.top = visibleTop + "px";
+        this.element.style.width = targetRect.width + "px";
+        this.element.style.height = visibleHeight + "px";
+        this.element.style.maxWidth = "none";
+        this.element.style.minWidth = "none";
+        
+        // 🔑 强制设置宽度，确保覆盖所有CSS设置
+        this.element.style.setProperty("width", targetRect.width + "px", "important");
+        
+        // 🔑 关键：实现内容同步滚动，保持简单的偏移
+        this.syncEmbedContent(clipTop);
+    }
+
+    // 🔑 新增：更新面包屑可见性
+    private updateBreadcrumbVisibility(showBreadcrumb: boolean) {
+        if (!showBreadcrumb) {
+            // 顶部被裁剪时隐藏面包屑
+            const breadcrumbContainers = this.element.querySelectorAll(".protyle-breadcrumb");
+            breadcrumbContainers.forEach((container: HTMLElement) => {
+                container.style.display = "none";
+            });
+        } else {
+            // 根据嵌入块设置决定是否显示面包屑
+            this.checkEmbedBreadcrumb();
+        }
+    }
+
+    // 🔑 新增：同步嵌入块内容滚动
+    private syncEmbedContent(scrollOffset: number) {
+        if (!this.editors || this.editors.length === 0) {
+            return;
+        }
+
+        // 对所有编辑器应用滚动偏移
+        this.editors.forEach(editor => {
+            try {
+                const wysiwygElement = editor.protyle.wysiwyg.element;
+                if (wysiwygElement) {
+                    // 🔑 优化：使用transform替代margin，提供更精确的像素级定位
+                    if (scrollOffset > 0) {
+                        wysiwygElement.style.transform = `translateY(-${scrollOffset}px)`;
+                        wysiwygElement.style.marginTop = "";  // 清除可能的margin设置
+                    } else {
+                        wysiwygElement.style.transform = "";
+                        wysiwygElement.style.marginTop = "";
+                    }
+                }
+                
+                // 如果有面包屑，也需要同步偏移
+                const breadcrumbElement = this.element.querySelector(".protyle-breadcrumb");
+                if (breadcrumbElement) {
+                    if (scrollOffset > 0) {
+                        (breadcrumbElement as HTMLElement).style.transform = `translateY(-${scrollOffset}px)`;
+                        (breadcrumbElement as HTMLElement).style.marginTop = "";
+                    } else {
+                        (breadcrumbElement as HTMLElement).style.transform = "";
+                        (breadcrumbElement as HTMLElement).style.marginTop = "";
+                    }
+                }
+            } catch (error) {
+                console.warn("同步嵌入块内容失败:", error);
+            }
+        });
+    }
+
+    private checkEmbedBreadcrumb() {
+        if (!this.targetElement) return;
+        
+        // 从targetElement向上查找嵌入块容器
+        let embedBlockElement = this.targetElement;
+        while (embedBlockElement && embedBlockElement !== document.body) {
+            if (embedBlockElement.getAttribute("data-type") === "NodeBlockQueryEmbed") {
+                break;
+            }
+            embedBlockElement = embedBlockElement.parentElement;
+        }
+        
+        if (!embedBlockElement || embedBlockElement.getAttribute("data-type") !== "NodeBlockQueryEmbed") {
+            // 使用全局设置作为默认值
+            this.toggleBreadcrumb(window.siyuan.config.editor.embedBlockBreadcrumb);
+            return;
+        }
+        
+        // 检查面包屑设置
+        let showBreadcrumb: boolean | string = embedBlockElement.getAttribute("breadcrumb");
+        if (showBreadcrumb !== null) {
+            showBreadcrumb = showBreadcrumb === "true";
+        } else {
+            showBreadcrumb = window.siyuan.config.editor.embedBlockBreadcrumb;
+        }
+        
+        this.toggleBreadcrumb(showBreadcrumb);
+    }
+
+    private toggleBreadcrumb(show: boolean) {
+        // 根据设置动态显示/隐藏整个面包屑容器
+        setTimeout(() => {
+            // 控制整个面包屑容器，而不仅仅是面包屑栏
+            const breadcrumbContainers = this.element.querySelectorAll(".protyle-breadcrumb");
+            breadcrumbContainers.forEach((container: HTMLElement) => {
+                container.style.display = show ? "" : "none";
+            });
+            
+            // 同时也控制单独的面包屑栏（兼容不同的HTML结构）
+            const breadcrumbBars = this.element.querySelectorAll(".protyle-breadcrumb__bar");
+            breadcrumbBars.forEach((bar: HTMLElement) => {
+                bar.style.display = show ? "" : "none";
+            });
+        }, 100); // 延迟执行，确保内容已渲染
+    }
+
+    private cleanupEmbedMode() {
+        // 移除事件监听
+        const contentElement = hasClosestByClassName(this.targetElement, "protyle-content", true);
+        if (contentElement) {
+            contentElement.removeEventListener("scroll", this.scrollHandler);
+        }
+        window.removeEventListener("resize", this.resizeHandler);
+        
+        // 🔧 重置浮窗样式
+        this.element.style.display = "";
+        
+        // 🔑 移除所有嵌入块相关的强制样式
+        this.element.style.removeProperty("width");
+        this.element.style.removeProperty("left");
+        this.element.style.removeProperty("top");
+        this.element.style.removeProperty("height");
+        this.element.style.removeProperty("max-width");
+        this.element.style.removeProperty("min-width");
+        
+        // 🔑 移除动态边框样式类
+        this.element.classList.remove(
+            "block__popover--embed-clipped-top",
+            "block__popover--embed-clipped-bottom", 
+            "block__popover--embed-clipped-both"
+        );
+        
+        // 🔑 重置内容偏移和样式
+        this.editors.forEach(editor => {
+            try {
+                const wysiwygElement = editor.protyle.wysiwyg.element;
+                if (wysiwygElement) {
+                    wysiwygElement.style.marginTop = "";
+                    wysiwygElement.style.transform = "";
+                    // 🔑 清除可能的强制样式属性
+                    wysiwygElement.style.removeProperty("padding");
+                }
+                
+                // 🔑 重置protyle容器样式
+                const protyleElement = editor.protyle.element;
+                if (protyleElement) {
+                    protyleElement.style.removeProperty("min-height");
+                }
+                
+                // 🔑 重置protyle内容区域
+                const protyleContent = editor.protyle.contentElement;
+                if (protyleContent) {
+                    protyleContent.style.removeProperty("padding");
+                    protyleContent.style.removeProperty("margin");
+                    protyleContent.style.removeProperty("overflow");
+                }
+            } catch (error) {
+                console.warn("重置内容偏移失败:", error);
+            }
+        });
+        
+        // 重置面包屑偏移和样式
+        const breadcrumbElements = this.element.querySelectorAll(".protyle-breadcrumb");
+        breadcrumbElements.forEach((breadcrumbElement: HTMLElement) => {
+            breadcrumbElement.style.marginTop = "";
+            breadcrumbElement.style.transform = "";
+            breadcrumbElement.style.removeProperty("padding");
+            breadcrumbElement.style.display = ""; // 恢复显示
+        });
+        
+        // 重置面包屑栏
+        const breadcrumbBars = this.element.querySelectorAll(".protyle-breadcrumb__bar");
+        breadcrumbBars.forEach((bar: HTMLElement) => {
+            bar.style.display = "";
+        });
+        
+        // 🔑 重置block__content样式
+        const blockContent = this.element.querySelector(".block__content");
+        if (blockContent) {
+            (blockContent as HTMLElement).style.removeProperty("padding");
+            (blockContent as HTMLElement).style.removeProperty("margin");
+            (blockContent as HTMLElement).style.removeProperty("overflow");
+        }
+        
+        // 🔑 确保工具栏显示
+        const blockIcons = this.element.querySelector(".block__icons");
+        if (blockIcons) {
+            (blockIcons as HTMLElement).style.display = "";
+        }
+        
+        // 🔑 恢复普通浮窗的默认约束（如果不是通过拖拽切换的话）
+        if (!this.element.style.width) {
+            // 只有在没有明确设置宽度时才应用默认样式
+            this.element.style.width = "60vw";
+            this.element.style.maxWidth = "1024px";
+            this.element.style.minWidth = "";
+            this.element.style.height = "";
+            this.element.style.left = "";
+            this.element.style.top = "";
+        }
+    }
+
+    // 🔑 设置光标位置
+    private setCursorPosition(protyle: Protyle) {
+        if (!this.clickInfo || !this.element.classList.contains("block__popover--embed")) {
+            return;
+        }
+
+        try {
+            // 获取浮窗内的编辑器元素
+            const wysiwygElement = protyle.protyle.wysiwyg.element;
+            if (!wysiwygElement) {
+                return;
+            }
+
+            // 计算相对于浮窗编辑器的位置
+            const editorRect = wysiwygElement.getBoundingClientRect();
+            const relativeX = this.clickInfo.clientX - editorRect.left;
+            const relativeY = this.clickInfo.clientY - editorRect.top;
+
+            // 使用document.caretRangeFromPoint获取光标位置
+            const absoluteX = editorRect.left + relativeX;
+            const absoluteY = editorRect.top + relativeY;
+
+            // 确保坐标在编辑器范围内
+            if (relativeX >= 0 && relativeX <= editorRect.width && 
+                relativeY >= 0 && relativeY <= editorRect.height) {
+                
+                const range = getRangeByPoint(absoluteX, absoluteY);
+                if (range && wysiwygElement.contains(range.startContainer)) {
+                    // 设置光标位置
+                    focusByRange(range);
+                    protyle.protyle.toolbar.range = range;
+                }
+            }
+        } catch (error) {
+            console.warn("设置光标位置失败:", error);
+        }
+    }
+
     public destroy() {
+        // 清理嵌入块模式
+        if (this.element && this.element.classList.contains("block__popover--embed")) {
+            this.cleanupEmbedMode();
+        }
+        
         this.observerResize?.disconnect();
         this.observerLoad?.disconnect();
         window.siyuan.blockPanels.find((item, index) => {
@@ -292,20 +721,34 @@ export class BlockPanel {
                     }
                     let targetRect;
                     if (this.targetElement && this.targetElement.classList.contains("protyle-wysiwyg__embed")) {
-                        targetRect = this.targetElement.getBoundingClientRect();
-                        // 嵌入块过长时，单击弹出的悬浮窗位置居下 https://ld246.com/article/1634292738717
-                        let top = targetRect.top;
-                        const contentElement = hasClosestByClassName(this.targetElement, "protyle-content", true);
-                        if (contentElement) {
-                            const contentRectTop = contentElement.getBoundingClientRect().top;
-                            if (targetRect.top < contentRectTop) {
-                                top = contentRectTop;
+                        // 嵌入块模式下的特殊处理
+                        if (this.element.classList.contains("block__popover--embed")) {
+                            // 无感编辑模式：使用updateEmbedPosition来精确定位，不在这里设置高度
+                            this.updateEmbedPosition();
+                            
+                            // 🔑 设置光标位置（延迟执行，确保DOM已完全渲染）
+                            setTimeout(() => {
+                                if (this.editors.length > 0) {
+                                    this.setCursorPosition(this.editors[0]);
+                                }
+                            }, 100);
+                        } else {
+                            // 传统嵌入块浮窗模式
+                            targetRect = this.targetElement.getBoundingClientRect();
+                            // 嵌入块过长时，单击弹出的悬浮窗位置居下 https://ld246.com/article/1634292738717
+                            let top = targetRect.top;
+                            const contentElement = hasClosestByClassName(this.targetElement, "protyle-content", true);
+                            if (contentElement) {
+                                const contentRectTop = contentElement.getBoundingClientRect().top;
+                                if (targetRect.top < contentRectTop) {
+                                    top = contentRectTop;
+                                }
                             }
+                            // 单击嵌入块悬浮窗的位置最好是覆盖嵌入块
+                            // 防止图片撑高后悬浮窗显示不下，只能设置高度
+                            this.element.style.height = Math.min(window.innerHeight - Constants.SIZE_TOOLBAR_HEIGHT, targetRect.height + 42) + "px";
+                            setPosition(this.element, targetRect.left, Math.max(top - 42, Constants.SIZE_TOOLBAR_HEIGHT), -42, 0);
                         }
-                        // 单击嵌入块悬浮窗的位置最好是覆盖嵌入块
-                        // 防止图片撑高后悬浮窗显示不下，只能设置高度
-                        this.element.style.height = Math.min(window.innerHeight - Constants.SIZE_TOOLBAR_HEIGHT, targetRect.height + 42) + "px";
-                        setPosition(this.element, targetRect.left, Math.max(top - 42, Constants.SIZE_TOOLBAR_HEIGHT), -42, 0);
                     } else if (this.targetElement) {
                         if (this.targetElement.classList.contains("pdf__rect")) {
                             targetRect = this.targetElement.firstElementChild.getBoundingClientRect();

--- a/app/src/block/Panel.ts
+++ b/app/src/block/Panel.ts
@@ -317,13 +317,21 @@ export class BlockPanel {
             return;
         }
         
-        // 获取嵌入块容器（NodeBlockQueryEmbed）的位置，这是实际需要覆盖的元素
+        // 获取嵌入块容器（用于检查是否多结果）
         const embedContainer = this.targetElement.closest('[data-type="NodeBlockQueryEmbed"]') as HTMLElement;
         if (!embedContainer) {
             return;
         }
+
+        // 检查是否是多结果嵌入块
+        const embedResults = embedContainer.querySelectorAll('.protyle-wysiwyg__embed');
+        const isMultiResult = embedResults.length > 1;
+
+        // 根据是否多结果选择不同的定位目标
+        const targetRect = isMultiResult ? 
+            this.targetElement.getBoundingClientRect() : // 多结果：直接使用具体结果块
+            embedContainer.getBoundingClientRect();      // 单结果：使用整个容器
         
-        const targetRect = embedContainer.getBoundingClientRect();
         const contentElement = hasClosestByClassName(this.targetElement, "protyle-content", true);
         
         // 检查是否完全不可见

--- a/app/src/block/popover.ts
+++ b/app/src/block/popover.ts
@@ -279,7 +279,15 @@ const hidePopover = (event: MouseEvent & { path: HTMLElement[] }) => {
                                 return true;
                             }
                         });
-                        if (hasToolbar) {
+                        
+                        // 🔑 检查嵌入块无感编辑模式是否有焦点
+                        const hasEmbedFocus = item.element.classList.contains("block__popover--embed") && 
+                            item.editors.some(editItem => {
+                                const wysiwygElement = editItem.protyle.wysiwyg.element;
+                                return wysiwygElement && wysiwygElement.contains(document.activeElement);
+                            });
+                        
+                        if (hasToolbar || hasEmbedFocus) {
                             break;
                         }
                         item.destroy();
@@ -304,7 +312,15 @@ const hidePopover = (event: MouseEvent & { path: HTMLElement[] }) => {
                                 return true;
                             }
                         });
-                        if (hasToolbar) {
+                        
+                        // 🔑 检查嵌入块无感编辑模式是否有焦点
+                        const hasEmbedFocus = item.element.classList.contains("block__popover--embed") && 
+                            item.editors.some(editItem => {
+                                const wysiwygElement = editItem.protyle.wysiwyg.element;
+                                return wysiwygElement && wysiwygElement.contains(document.activeElement);
+                            });
+                        
+                        if (hasToolbar || hasEmbedFocus) {
                            break;
                         }
                         item.destroy();

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -2687,11 +2687,23 @@ export class WYSIWYG {
                             keepCursor: true,
                         });
                     } else if (!protyle.disabled) {
+                        // 🔑 计算点击位置信息
+                        const targetRect = embedItemElement.getBoundingClientRect();
+                        const relativeX = event.clientX - targetRect.left;
+                        const relativeY = event.clientY - targetRect.top;
+                        
                         window.siyuan.blockPanels.push(new BlockPanel({
                             app: protyle.app,
                             targetElement: embedItemElement,
                             isBacklink: false,
-                            refDefs: [{refID: embedId}]
+                            refDefs: [{refID: embedId}],
+                            clickInfo: {
+                                clientX: event.clientX,
+                                clientY: event.clientY,
+                                targetRect: targetRect,
+                                relativeX: relativeX,
+                                relativeY: relativeY
+                            }
                         }));
                     }
                     /// #endif


### PR DESCRIPTION
在用户尽可能无感的情况下用浮窗做了一个假的可编辑嵌入块，D大看看这个方案可不可行

### 实现了以下功能

1. 外观样式、宽高、定位几乎一致
2. 滚动跟随，嵌入块浮窗看起来与真的嵌入块一样，超出视口的部分会被文档“裁剪”
3. 嵌入块浮窗会在鼠标点击处插入光标
4. 拖拽嵌入块浮窗的顶部可以还原为普通浮窗
5. 根据嵌入块的设置显隐面包屑

https://github.com/user-attachments/assets/0d4871f4-c8e9-4985-888e-ceef4c74db1a

### 已知问题

1. 快速滚动文档时，已激活的嵌入块浮窗的跟随滚动会稍微滞后
2. 不能在已激活的嵌入块浮窗范围内滚动嵌入块所在文档