### PR TITLE
Improve the style of buttons on database cells

### DIFF
--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -384,14 +384,6 @@
       min-height: 23px;
       padding: 5px 4px;
 
-      &:hover {
-        .b3-chip[data-type="block-more"] {
-          top: 4px;
-          display: block;
-          z-index: 1;
-        }
-      }
-
       .av__cell {
         padding: 2px 4px;
         border-right: 0;
@@ -405,11 +397,20 @@
         &:hover {
           background-color: var(--b3-list-hover);
           border-radius: var(--b3-border-radius);
+
+          [data-type="block-more"] {
+            top: 4px;
+            display: block;
+            z-index: 1;
+          }
         }
 
         .block__icon {
-          display: none;
-          top: 1px;
+          top: .3em;
+
+          &:hover {
+            background-color: var(--b3-theme-background) !important;
+          }
         }
 
         &[data-dtype="created"],
@@ -689,7 +690,14 @@
     .block__icon {
       position: absolute;
       right: 5px;
-      top: 5px;
+      top: .5em;
+      line-height: 0;
+      transition: none;
+
+      svg {
+        width: .7em;
+        height: .7em;
+      }
     }
 
     &:hover .block__icon {

--- a/app/src/protyle/render/av/cell.ts
+++ b/app/src/protyle/render/av/cell.ts
@@ -1006,10 +1006,13 @@ export const renderCell = (cellValue: IAVCellValue, rowIndex = 0, showIcon = tru
         }
     }
 
-    if ((["text", "template", "url", "email", "phone", "number", "date", "created", "updated"].includes(cellValue.type) && cellValue[cellValue.type as "url"]?.content) ||
-        cellValue.type === "lineNumber" ||
-        (cellValue.type === "block" && cellValue.block?.content)) {
-        text += `<span ${cellValue.type !== "number" ? "" : 'style="right:auto;left:5px"'} data-type="copy" class="block__icon"><svg><use xlink:href="#iconCopy"></use></svg></span>`;
+    if (
+        (["text", "template", "url", "email", "phone", "date", "created", "updated"].includes(cellValue.type) && cellValue[cellValue.type as "url"]?.content) ||
+        (cellValue.type === "number" && cellValue.number?.isNotEmpty) ||
+        (cellValue.type === "block" && cellValue.block?.content) ||
+        cellValue.type === "lineNumber"
+    ) {
+        text += `<span ${cellValue.type !== "number" || type !== "table"? "" : 'style="right:auto;left:5px"'} data-type="copy" class="block__icon"><svg><use xlink:href="#iconCopy"></use></svg></span>`;
     }
     return text;
 };


### PR DESCRIPTION
1. 只读模式下主键不需要显示“更多”按钮
2. 画廊视图需要显示字段的“复制”按钮
3. 画廊视图中数字字段的“复制”按钮不需要居左
4. “复制”按钮的大小和位置需要适应不同的编辑器字号
5. 数字字段单元格填 0 时也需要显示“复制”按钮