### PR TITLE
Hide header image button in read-only mode of the editor

### DIFF
--- a/app/src/assets/scss/protyle/_protyle.scss
+++ b/app/src/assets/scss/protyle/_protyle.scss
@@ -265,9 +265,12 @@
 }
 
 .protyle-top:hover .protyle-background--enable {
-  .protyle-background__action,
-  .protyle-background__img .protyle-icons {
+  .protyle-background__action  {
     opacity: .86;
+  }
+
+  .protyle-background__img .protyle-icons {
+    display: flex;
   }
 }
 
@@ -332,6 +335,7 @@
     }
 
     .protyle-icons {
+      display: none;
       position: absolute;
       top: 8px;
       right: 8px;


### PR DESCRIPTION
需要使用 `display:none` 来隐藏按钮，否则还是有 tooltip：

[video.webm](https://github.com/user-attachments/assets/3e0116ef-ba13-416a-89ad-3c3f9ba839df)
