### PR TITLE
Disable drag in read-only mode of the editor

### DIFF
--- a/app/src/protyle/util/editorCommonEvent.ts
+++ b/app/src/protyle/util/editorCommonEvent.ts
@@ -809,6 +809,11 @@ const dragSame = async (protyle: IProtyle, sourceElements: Element[], targetElem
 
 export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
     editorElement.addEventListener("dragstart", (event) => {
+        if (protyle.disabled) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
         let target = event.target as HTMLElement;
         if (target.classList.contains("av__gallery-img")) {
             target = hasClosestByClassName(target, "av__gallery-item") as HTMLElement;


### PR DESCRIPTION
只读模式下拖拽操作没有作用，应完全禁用拖拽：

[video.webm](https://github.com/user-attachments/assets/5399eb32-5544-42ef-b161-ff75a0fb081c)
