### PR TITLE
Improve icons size

### DIFF
--- a/app/src/assets/scss/business/_config.scss
+++ b/app/src/assets/scss/business/_config.scss
@@ -74,8 +74,8 @@
       &__graphic {
         margin-right: 0;
         padding: 0 10px 0 5px;
-        height: 16px;
-        width: 16px;
+        height: 14px;
+        width: 14px;
       }
     }
   }

--- a/app/src/assets/scss/business/_layout.scss
+++ b/app/src/assets/scss/business/_layout.scss
@@ -373,11 +373,10 @@
 
   svg {
     height: 14px;
-    width: 14px;
   }
 
   &--vertical {
-    width: 42px;
+    width: 40px;
     flex-direction: column;
     height: 100%;
     padding: 0;

--- a/app/src/assets/scss/component/_button.scss
+++ b/app/src/assets/scss/component/_button.scss
@@ -15,8 +15,8 @@
   text-align: center;
 
   svg {
-    height: 16px;
-    width: 16px;
+    height: 14px;
+    width: 14px;
     margin-right: 4px;
     flex-shrink: 0;
   }


### PR DESCRIPTION
1. 设置窗口的图标看起来比文字还大，小点更好看

	![image](https://github.com/user-attachments/assets/3e3e790f-caad-43b6-9c4a-dac96755fd4a)

2. 侧栏的图标看起来偏左，是因为按钮的宽度多余 2px

	![image](https://github.com/user-attachments/assets/31225e33-f2f5-4921-9e16-69587c3343b6)
