### PR TITLE
Improve `showMessage()` function

### DIFF
--- a/app/src/assets/scss/component/_snackbar.scss
+++ b/app/src/assets/scss/component/_snackbar.scss
@@ -3,6 +3,7 @@
   position: relative;
   transition: transform 256ms cubic-bezier(.45, .05, .55, .95) 0ms;
   text-align: right;
+  justify-self: end;
   font-size: var(--b3-font-size);
 
   &--hide {

--- a/app/src/dialog/message.ts
+++ b/app/src/dialog/message.ts
@@ -32,10 +32,21 @@ export const initMessage = () => {
             target = target.parentElement;
         }
     });
-    const tempMessageElement = document.getElementById("tempMessage");
-    if (tempMessageElement) {
-        showMessage(tempMessageElement.innerHTML);
-        tempMessageElement.remove();
+    
+    const tempMessages = document.getElementById("tempMessages");
+    if (tempMessages) {
+        const items = tempMessages.querySelectorAll("[temp-message]");
+        items.forEach((item) => {
+            const timeoutString = item.getAttribute("data-timeout");
+            let timeout;
+            if (timeoutString) {
+                timeout = parseInt(timeoutString);
+            }
+            const type = item.getAttribute("data-type");
+            const messageId = item.getAttribute("data-message-id");
+            showMessage(item.innerHTML, timeout, type, messageId);
+        });
+        tempMessages.remove();
     }
 };
 
@@ -43,14 +54,25 @@ export const initMessage = () => {
 export const showMessage = (message: string, timeout = 6000, type = "info", messageId?: string) => {
     const messagesElement = document.getElementById("message").firstElementChild;
     if (!messagesElement) {
-        document.body.insertAdjacentHTML("beforeend", `<div style="top: 10px;
-    position: fixed;
-    z-index: 100;
-    background: white;
-    padding: 10px;
-    border-radius: 5px;
-    right: 10px;
-    border: 1px solid #e0e0e0;" id='tempMessage'>${message}</div>`);
+        let tempMessages = document.getElementById("tempMessages");
+        if (!tempMessages) {
+            document.body.insertAdjacentHTML("beforeend", "<div id='tempMessages'></div>");
+            tempMessages = document.getElementById("tempMessages");
+        }
+        
+        tempMessages.insertAdjacentHTML("beforeend", `<div style="
+            top: 10px;
+            position: fixed;
+            z-index: 100;
+            background: white;
+            padding: 10px;
+            border-radius: 5px;
+            right: 10px;
+            border: 1px solid #e0e0e0;"
+            data-timeout='${timeout}'
+            data-type="${type}"
+            data-message-id='${messageId || ""}'
+            temp-message>${message}</div>`);
         return;
     }
     const id = messageId || genUUID();


### PR DESCRIPTION
插件在 onload 时如果思源的界面还未加载，调用 showMessage() 会出现异常：

- 多次调用 showMessage()，界面加载之后只保留了最后一个
- 传入 showMessage() 的参数 timeout、type、messageId 无效
- tempMessageElement（白色的消息元素）会留在界面右上角，无法通过点击移除

<img width="1765" height="702" alt="image" src="https://github.com/user-attachments/assets/acc52525-baaa-4172-982d-84a8bf0284ae" />

另外，感叹号的位置有点问题，用 `justify-self: end;` 调整消息元素的宽度修复了：

<img width="694" height="340" alt="image" src="https://github.com/user-attachments/assets/fcde5f14-ccd7-449f-b0d6-118a50aefa00" />
