### PR TITLE
Improve right-click menu paste

### DIFF
--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -450,7 +450,7 @@ export class WYSIWYG {
             restoreLuteMarkdownSyntax(protyle);
 
             // 在 text/html 中插入注释节点，用于右键菜单粘贴时获取 text/siyuan 数据
-            event.clipboardData.setData("text/html", `<!--siyuan-data:${encodeBase64(siyuanHTML)}-->` + (selectTableElement ? html : protyle.lute.BlockDOM2HTML(selectAVElement ? textPlain : html)));
+            event.clipboardData.setData("text/html", `<!--data-siyuan='${encodeBase64(siyuanHTML)}'-->` + (selectTableElement ? html : protyle.lute.BlockDOM2HTML(selectAVElement ? textPlain : html)));
         });
 
         this.element.addEventListener("mousedown", (event: MouseEvent) => {
@@ -1953,7 +1953,7 @@ export class WYSIWYG {
             restoreLuteMarkdownSyntax(protyle);
 
             // 在 text/html 中插入注释节点，用于右键菜单粘贴时获取 text/siyuan 数据
-            event.clipboardData.setData("text/html", `<!--siyuan-data:${encodeBase64(siyuanHTML)}-->` + (selectTableElement ? html : protyle.lute.BlockDOM2HTML(selectAVElement ? textPlain : html)));
+            event.clipboardData.setData("text/html", `<!--data-siyuan='${encodeBase64(siyuanHTML)}'-->` + (selectTableElement ? html : protyle.lute.BlockDOM2HTML(selectAVElement ? textPlain : html)));
         });
 
         let beforeContextmenuRange: Range;


### PR DESCRIPTION
继续改进 https://github.com/siyuan-note/siyuan/pull/15286

1. Node.js 环境使用 Buffer 提高字符处理性能
2. 浏览器环境添加分块处理以避免栈溢出（解决报错 "Uncaught RangeError: Maximum call stack size exceeded"）
3. 参考 AFFiNE 写入剪贴板的方式（`<div data-blocksuite-snapshot="[^"]+">`），将 `<!--siyuan-data:[^>]+-->` 改为 `<!--data-siyuan='[^']+'-->`

---

20251113：复制块和复制行级元素都需要这样处理，因为行级元素也可以有自定义属性。不然右键菜单粘贴出来的没有自定义属性