### PR TITLE
Replace the deprecated `isSameNode` method in DOM Level 4

### DIFF
--- a/app/src/ai/actions.ts
+++ b/app/src/ai/actions.ts
@@ -255,7 +255,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
             });
             element.addEventListener("click", (event) => {
                 let target = event.target as HTMLElement;
-                while (target && !target.isSameNode(element)) {
+                while (target && (target !== element)) {
                     if (target.classList.contains("b3-list-item__action")) {
                         const subItem = window.siyuan.storage[Constants.LOCAL_AI][target.parentElement.dataset.index];
                         editDialog(subItem.name, subItem.memo);

--- a/app/src/block/popover.ts
+++ b/app/src/block/popover.ts
@@ -117,7 +117,7 @@ export const initBlockPopover = (app: App) => {
                     const boxData = response.data.boxInfo;
                     const tip = `${boxData.name} <small class='ft__on-surface'>${boxData.hSize}</small>${boxData.docCount !== 0 ? window.siyuan.languages.includeSubFile.replace("x", boxData.docCount) : ""}<br>${window.siyuan.languages.modifiedAt} ${boxData.hMtime}<br>${window.siyuan.languages.createdAt} ${boxData.hCtime}`;
                     const scopeNotebookItemElement = hasClosestByClassName(event.target, "b3-list-item__text");
-                    if (notebookItemElement && scopeNotebookItemElement && notebookItemElement.isSameNode(scopeNotebookItemElement)) {
+                    if (notebookItemElement && scopeNotebookItemElement && (notebookItemElement === scopeNotebookItemElement)) {
                         showTooltip(tip, notebookItemElement);
                     }
                     if (scopeNotebookItemElement &&
@@ -242,7 +242,7 @@ const hidePopover = (event: MouseEvent & { path: HTMLElement[] }) => {
     if (!popoverTargetElement && linkElement && linkElement.getAttribute("data-href")?.startsWith("siyuan://blocks")) {
         popoverTargetElement = linkElement;
     }
-    if (!popoverTargetElement || (popoverTargetElement && window.siyuan.menus.menu.data?.isSameNode(popoverTargetElement))) {
+    if (!popoverTargetElement || (popoverTargetElement && window.siyuan.menus.menu.data && (window.siyuan.menus.menu.data === popoverTargetElement))) {
         // 移动到弹窗的 loading 元素上，但经过 settimeout 后 loading 已经被移除了
         // https://ld246.com/article/1673596577519/comment/1673767749885#comments
         let targetElement = target;
@@ -356,7 +356,7 @@ const getTarget = (event: MouseEvent & { target: HTMLElement }, aElement: false 
 };
 
 export const showPopover = async (app: App, showRef = false) => {
-    if (!popoverTargetElement || window.siyuan.menus.menu.data?.isSameNode(popoverTargetElement)) {
+    if (!popoverTargetElement || (window.siyuan.menus.menu.data && (window.siyuan.menus.menu.data === popoverTargetElement))) {
         return;
     }
     let refDefs: IRefDefs[] = [];

--- a/app/src/boot/globalEvent/keydown.ts
+++ b/app/src/boot/globalEvent/keydown.ts
@@ -80,7 +80,7 @@ import {bindAVPanelKeydown} from "../../protyle/render/av/keydown";
 const switchDialogEvent = (app: App, event: MouseEvent) => {
     event.preventDefault();
     let target = event.target as HTMLElement;
-    while (!target.isSameNode(switchDialog.element)) {
+    while (target !== switchDialog.element) {
         if (target.classList.contains("b3-list-item")) {
             const currentType = target.getAttribute("data-type");
             if (currentType) {

--- a/app/src/boot/globalEvent/mousemove.ts
+++ b/app/src/boot/globalEvent/mousemove.ts
@@ -111,7 +111,7 @@ export const windowMouseMove = (event: MouseEvent, mouseIsEnter: boolean) => {
             const allModels = getAllModels();
             let findNode = false;
             allModels.editor.find(item => {
-                if (item.editor.protyle.wysiwyg.element.isSameNode(eventPath0)) {
+                if (item.editor.protyle.wysiwyg.element === eventPath0) {
                     item.editor.protyle.gutter.render(item.editor.protyle, targetBlockElement, item.editor.protyle.wysiwyg.element, rowElement);
                     findNode = true;
                     return true;
@@ -134,7 +134,7 @@ export const windowMouseMove = (event: MouseEvent, mouseIsEnter: boolean) => {
             if (!findNode) {
                 allModels.backlink.find(item => {
                     item.editors.find(eItem => {
-                        if (eItem.protyle.wysiwyg.element.isSameNode(eventPath0)) {
+                        if (eItem.protyle.wysiwyg.element === eventPath0) {
                             eItem.protyle.gutter.render(eItem.protyle, targetBlockElement, eItem.protyle.wysiwyg.element, rowElement);
                             findNode = true;
                             return true;

--- a/app/src/card/makeCard.ts
+++ b/app/src/card/makeCard.ts
@@ -71,7 +71,7 @@ export const makeCard = (app: App, ids: string[]) => {
         dialog.element.setAttribute("data-key", Constants.DIALOG_MAKECARD);
         dialog.element.addEventListener("click", (event) => {
             let target = event.target as HTMLElement;
-            while (target && !target.isSameNode(dialog.element)) {
+            while (target && (target !== dialog.element)) {
                 const type = target.getAttribute("data-type");
                 if (type === "create") {
                     let msgId = "";

--- a/app/src/card/viewCards.ts
+++ b/app/src/card/viewCards.ts
@@ -115,7 +115,7 @@ export const viewCards = (app: App, deckID: string, title: string, deckType: "Tr
                 return;
             }
             let target = event.target as HTMLElement;
-            while (target && !dialog.element.isSameNode(target)) {
+            while (target && (dialog.element !== target)) {
                 const type = target.getAttribute("data-type");
                 if (type === "close") {
                     dialog.destroy();

--- a/app/src/config/keymap.ts
+++ b/app/src/config/keymap.ts
@@ -475,7 +475,7 @@ export const keymap = {
                         hasConflict = true;
                     }
                     Array.from(keymap.element.querySelectorAll("label.b3-list-item input")).find((inputItem: HTMLElement) => {
-                        if (!inputItem.isSameNode(this) && inputItem.getAttribute("data-value") === keymapStr) {
+                        if ((inputItem !== this) && inputItem.getAttribute("data-value") === keymapStr) {
                             const inputValueList = inputItem.getAttribute("data-key").split(Constants.ZWSP);
                             if (inputValueList[1] === "list") {
                                 inputValueList[1] = "list1";

--- a/app/src/config/util/snippets.ts
+++ b/app/src/config/util/snippets.ts
@@ -114,7 +114,7 @@ export const openSnippets = () => {
         dialog.element.setAttribute("data-key", Constants.DIALOG_SNIPPETS);
         dialog.element.addEventListener("click", (event) => {
             let target = event.target as HTMLElement;
-            while (target && !target.isSameNode(dialog.element)) {
+            while (target && (target !== dialog.element)) {
                 if (target.id === "addCodeSnippetCSS" || target.id === "addCodeSnippetJS") {
                     target.parentElement.insertAdjacentHTML("afterend", genSnippet({
                         type: target.id === "addCodeSnippetCSS" ? "css" : "js",

--- a/app/src/dialog/confirmDialog.ts
+++ b/app/src/dialog/confirmDialog.ts
@@ -25,7 +25,7 @@ export const confirmDialog = (title: string, text: string,
     dialog.element.addEventListener("click", (event) => {
         let target = event.target as HTMLElement;
         const isDispatch = typeof event.detail === "string";
-        while (target && !target.isSameNode(dialog.element) || isDispatch) {
+        while (target && (target !== dialog.element) || isDispatch) {
             if (target.id === "cancelDialogConfirmBtn" || (isDispatch && event.detail=== "Escape")) {
                 if (cancel) {
                     cancel(dialog);

--- a/app/src/dialog/message.ts
+++ b/app/src/dialog/message.ts
@@ -12,7 +12,7 @@ export const initMessage = () => {
                 hideMessage(target.parentElement.getAttribute("data-id"));
                 event.preventDefault();
                 break;
-            } else if (target.isSameNode(messageElement.lastElementChild)) {
+            } else if (target === messageElement.lastElementChild) {
                 target.parentElement.classList.remove("b3-snackbars--show");
                 setTimeout(() => {
                     target.parentElement.firstElementChild.innerHTML = "";

--- a/app/src/history/keydown.ts
+++ b/app/src/history/keydown.ts
@@ -16,7 +16,7 @@ export const historyKeydown = (event: KeyboardEvent, dialog: Dialog) => {
             currentItem = items[items.length - 1];
         } else {
             items.find((item, index) => {
-                if (item.isSameNode(currentItem)) {
+                if (item === currentItem) {
                     if (event.key === "ArrowUp") {
                         if (index === 0) {
                             currentItem = items[items.length - 1];

--- a/app/src/layout/Tab.ts
+++ b/app/src/layout/Tab.ts
@@ -128,7 +128,7 @@ export class Tab {
                     // 按 esc 取消的时候应该还原在 dragover 时交换的 tab
                     this.parent.children.forEach((item, index) => {
                         const currentElement = this.headElement.parentElement.children[index];
-                        if (!item.headElement.isSameNode(currentElement)) {
+                        if (item.headElement !== currentElement) {
                             if (index === 0) {
                                 this.headElement.parentElement.firstElementChild.before(item.headElement);
                             } else {

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -170,7 +170,7 @@ export class Wnd {
             if (!window.siyuan.currentDragOverTabHeadersElement) {
                 window.siyuan.currentDragOverTabHeadersElement = it;
             } else {
-                if (!window.siyuan.currentDragOverTabHeadersElement.isSameNode(it)) {
+                if (window.siyuan.currentDragOverTabHeadersElement !== it) {
                     window.siyuan.currentDragOverTabHeadersElement.classList.remove("layout-tab-bars--drag");
                     window.siyuan.currentDragOverTabHeadersElement.querySelectorAll(".layout-tab-bar li[data-clone='true']").forEach(item => {
                         item.remove();
@@ -220,7 +220,7 @@ export class Wnd {
                 return;
             }
             it.classList.remove("layout-tab-bars--drag");
-            if (!newTabHeaderElement.isSameNode(oldTabHeaderElement) &&
+            if ((newTabHeaderElement !== oldTabHeaderElement) &&
                 ((oldTabHeaderElement.classList.contains("item--pin") && newTabHeaderElement.classList.contains("item--pin")) ||
                     (!oldTabHeaderElement.classList.contains("item--pin") && !newTabHeaderElement.classList.contains("item--pin")))) {
                 const rect = newTabHeaderElement.getClientRects()[0];
@@ -816,7 +816,7 @@ export class Wnd {
                     if (item.headElement.classList.contains("item--focus")) {
                         let latestHeadElement: HTMLElement;
                         Array.from(item.headElement.parentElement.children).forEach((headItem: HTMLElement) => {
-                            if (!headItem.isSameNode(item.headElement) &&
+                            if ((headItem !== item.headElement) &&
                                 headItem.style.maxWidth !== "0px"   // 不对比已移除但还在动画效果中的元素 https://github.com/siyuan-note/siyuan/issues/7878
                             ) {
                                 if (!latestHeadElement) {

--- a/app/src/layout/dock/Backlink.ts
+++ b/app/src/layout/dock/Backlink.ts
@@ -278,7 +278,7 @@ export class Backlink extends Model {
             this.setFocus();
             let target = event.target as HTMLElement;
             while (target && !target.isEqualNode(this.element)) {
-                if (target.classList.contains("block__icon") && target.parentElement.parentElement.isSameNode(this.element)) {
+                if (target.classList.contains("block__icon") && (target.parentElement.parentElement === this.element)) {
                     const type = target.getAttribute("data-type");
                     switch (type) {
                         case "refresh":
@@ -433,7 +433,7 @@ export class Backlink extends Model {
         if (svgElement.classList.contains("b3-list-item__arrow--open")) {
             svgElement.classList.remove("b3-list-item__arrow--open");
             this.editors.find((item, index) => {
-                if (item.protyle.block.rootID === docId && liElement.nextElementSibling && item.protyle.element.isSameNode(liElement.nextElementSibling)) {
+                if (item.protyle.block.rootID === docId && liElement.nextElementSibling && (item.protyle.element === liElement.nextElementSibling)) {
                     item.destroy();
                     this.editors.splice(index, 1);
                     liElement.nextElementSibling.remove();

--- a/app/src/layout/dock/Outline.ts
+++ b/app/src/layout/dock/Outline.ts
@@ -178,7 +178,7 @@ export class Outline extends Model {
                             break;
                     }
                     break;
-                } else if (this.blockId && (target.isSameNode(this.headerElement.nextElementSibling) || target.classList.contains("block__icons"))) {
+                } else if (this.blockId && ((target === this.headerElement.nextElementSibling) || target.classList.contains("block__icons"))) {
                     openFileById({
                         app: options.app,
                         id: this.blockId,
@@ -269,7 +269,7 @@ export class Outline extends Model {
                 this.element.querySelectorAll(".dragover__top, .dragover__bottom, .dragover, .dragover__current").forEach(item => {
                     item.classList.remove("dragover__top", "dragover__bottom", "dragover", "dragover__current");
                 });
-                if (selectItem.isSameNode(item)) {
+                if (selectItem === item) {
                     selectItem.classList.add("dragover__current");
                     return;
                 }

--- a/app/src/layout/dock/index.ts
+++ b/app/src/layout/dock/index.ts
@@ -186,13 +186,13 @@ export class Dock {
                 const targetItem = hasClosestByClassName(moveEvent.target as HTMLElement, "dock__item") ||
                     hasClosestByClassName(moveEvent.target as HTMLElement, "dock__items") as HTMLElement ||
                     hasClosestByClassName(moveEvent.target as HTMLElement, "dock__item--space") as HTMLElement;
-                if (targetItem && selectItem && targetItem.isSameNode(selectItem)) {
+                if (targetItem && selectItem && (targetItem === selectItem)) {
                     if (selectItem.classList.contains("dock__item--space")) {
                         const selectRect = selectItem.getBoundingClientRect();
                         if (selectItem.parentElement.id === "dockBottom") {
                             if (moveEvent.clientX < selectRect.right && moveEvent.clientX > selectRect.right - 40) {
                                 const lastFirstElement = selectItem.nextElementSibling.firstElementChild;
-                                if (lastFirstElement && lastFirstElement.isSameNode(item)) {
+                                if (lastFirstElement && (lastFirstElement === item)) {
                                     moveItem.classList.add("fn__none");
                                 } else {
                                     moveItem.classList.remove("fn__none");
@@ -202,7 +202,7 @@ export class Dock {
                         } else {
                             if (moveEvent.clientY < selectRect.bottom && moveEvent.clientY > selectRect.bottom - 40) {
                                 const lastFirstElement = selectItem.nextElementSibling.firstElementChild;
-                                if (lastFirstElement && lastFirstElement.isSameNode(item)) {
+                                if (lastFirstElement && (lastFirstElement === item)) {
                                     moveItem.classList.add("fn__none");
                                 } else {
                                     moveItem.classList.remove("fn__none");
@@ -211,7 +211,7 @@ export class Dock {
                             }
                         }
                     } else if (selectItem.classList.contains("dock__item--pin")) {
-                        if (item.nextElementSibling?.isSameNode(selectItem)) {
+                        if (item.nextElementSibling && (item.nextElementSibling === selectItem)) {
                             moveItem.classList.add("fn__none");
                         } else {
                             moveItem.classList.remove("fn__none");
@@ -221,14 +221,14 @@ export class Dock {
                         const selectRect = selectItem.getBoundingClientRect();
                         if (selectItem.parentElement.parentElement.id === "dockBottom") {
                             if (selectRect.left + selectRect.width / 2 > moveEvent.clientX) {
-                                if (item.nextElementSibling?.isSameNode(selectItem)) {
+                                if (item.nextElementSibling && (item.nextElementSibling === selectItem)) {
                                     moveItem.classList.add("fn__none");
                                 } else {
                                     moveItem.classList.remove("fn__none");
                                     selectItem.before(moveItem);
                                 }
                             } else {
-                                if (item.previousElementSibling?.isSameNode(selectItem)) {
+                                if (item.previousElementSibling && (item.previousElementSibling === selectItem)) {
                                     moveItem.classList.add("fn__none");
                                 } else {
                                     moveItem.classList.remove("fn__none");
@@ -237,14 +237,14 @@ export class Dock {
                             }
                         } else {
                             if (selectRect.top + selectRect.height / 2 > moveEvent.clientY) {
-                                if (item.nextElementSibling?.isSameNode(selectItem)) {
+                                if (item.nextElementSibling && (item.nextElementSibling === selectItem)) {
                                     moveItem.classList.add("fn__none");
                                 } else {
                                     moveItem.classList.remove("fn__none");
                                     selectItem.before(moveItem);
                                 }
                             } else {
-                                if (item.previousElementSibling?.isSameNode(selectItem)) {
+                                if (item.previousElementSibling && (item.previousElementSibling === selectItem)) {
                                     moveItem.classList.add("fn__none");
                                 } else {
                                     moveItem.classList.remove("fn__none");
@@ -266,8 +266,8 @@ export class Dock {
                     }
                     return;
                 }
-                if (!targetItem || targetItem.style.position === "fixed" || targetItem.isSameNode(item) || targetItem.id === "dockMoveItem") {
-                    if (targetItem && targetItem.isSameNode(item)) {
+                if (!targetItem || targetItem.style.position === "fixed" || (targetItem === item) || targetItem.id === "dockMoveItem") {
+                    if (targetItem && (targetItem === item)) {
                         moveItem.classList.add("fn__none");
                     }
                     return;
@@ -295,7 +295,7 @@ export class Dock {
                     } else if (moveItem.parentElement.parentElement.id === "dockRight") {
                         dock = window.siyuan.layout.rightDock;
                     }
-                    dock.add(moveItem.parentElement.isSameNode(dock.element.firstElementChild) ? 0 : 1, item, moveItem.previousElementSibling?.getAttribute("data-type"));
+                    dock.add(moveItem.parentElement === dock.element.firstElementChild ? 0 : 1, item, moveItem.previousElementSibling?.getAttribute("data-type"));
                 }
                 moveItem.remove();
             };

--- a/app/src/layout/util.ts
+++ b/app/src/layout/util.ts
@@ -857,17 +857,17 @@ export const addResize = (obj: Layout | Wnd) => {
                 if (previousNowSize < 8 || nextNowSize < 8) {
                     return;
                 }
-                if (window.siyuan.layout.leftDock?.layout.element.isSameNode(previousElement) &&
+                if (window.siyuan.layout.leftDock && (window.siyuan.layout.leftDock.layout.element === previousElement) &&
                     previousNowSize < getMinSize(previousElement) &&
                     // https://github.com/siyuan-note/siyuan/issues/10506
                     previousNowSize < previousSize) {
                     return;
                 }
-                if (window.siyuan.layout.rightDock?.layout.element.isSameNode(nextElement) &&
+                if (window.siyuan.layout.rightDock && (window.siyuan.layout.rightDock.layout.element === nextElement) &&
                     nextNowSize < getMinSize(nextElement) && nextNowSize < nextSize) {
                     return;
                 }
-                if (window.siyuan.layout.bottomDock?.layout.element.isSameNode(nextElement) &&
+                if (window.siyuan.layout.bottomDock && (window.siyuan.layout.bottomDock.layout.element === nextElement) &&
                     nextNowSize < 64 && nextNowSize < nextSize) {
                     return;
                 }

--- a/app/src/menus/Menu.ts
+++ b/app/src/menus/Menu.ts
@@ -42,7 +42,7 @@ export class Menu {
             }
             const subMenuElement = itemElement.querySelector(".b3-menu__submenu") as HTMLElement;
             this.element.querySelectorAll(".b3-menu__item--show").forEach((item) => {
-                if (!item.contains(itemElement) && !item.isSameNode(itemElement) && !itemElement.contains(item)) {
+                if (!item.contains(itemElement) && (item !== itemElement) && !itemElement.contains(item)) {
                     item.classList.remove("b3-menu__item--show");
                 }
             });

--- a/app/src/menus/commonMenuItem.ts
+++ b/app/src/menus/commonMenuItem.ts
@@ -259,7 +259,7 @@ export const openFileAttr = (attrs: IObject, focusName = "bookmark", protyle?: I
         if (typeof event.detail === "string") {
             target = dialog.element.querySelector(`.item--full[data-type="${event.detail}"]`);
         }
-        while (!target.isSameNode(dialog.element)) {
+        while (target !== dialog.element) {
             const type = target.dataset.action;
             if (target.classList.contains("item--full")) {
                 target.parentElement.querySelector(".item--focus").classList.remove("item--focus");

--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -447,7 +447,7 @@ export const initFileMenu = (app: App, notebookId: string, pathString: string, l
                     const paths: string[] = [];
                     Array.from(liElement.parentElement.children).forEach((item) => {
                         if (item.tagName === "LI") {
-                            if (item.isSameNode(liElement)) {
+                            if (item === liElement) {
                                 paths.push(undefined);
                             }
                             paths.push(item.getAttribute("data-path"));
@@ -472,7 +472,7 @@ export const initFileMenu = (app: App, notebookId: string, pathString: string, l
                     Array.from(liElement.parentElement.children).forEach((item) => {
                         if (item.tagName === "LI") {
                             paths.push(item.getAttribute("data-path"));
-                            if (item.isSameNode(liElement)) {
+                            if (item === liElement) {
                                 paths.push(undefined);
                             }
                         }

--- a/app/src/menus/protyle.ts
+++ b/app/src/menus/protyle.ts
@@ -2142,7 +2142,7 @@ export const tableMenu = (protyle: IProtyle, nodeElement: Element, cellElement: 
                     if (prueTrElement) {
                         const tbodyElement = nodeElement.querySelector("tbody");
                         const theadElement = nodeElement.querySelector("thead");
-                        while (!prueTrElement.isSameNode(theadElement.lastElementChild)) {
+                        while (prueTrElement !== theadElement.lastElementChild) {
                             tbodyElement.insertAdjacentElement("afterbegin", theadElement.lastElementChild);
                         }
                     }

--- a/app/src/mobile/menu/search.ts
+++ b/app/src/mobile/menu/search.ts
@@ -352,7 +352,7 @@ const initSearchEvent = (app: App, element: Element, config: Config.IUILayoutTab
     const localSearch = window.siyuan.storage[Constants.LOCAL_SEARCHASSET] as ISearchAssetOption;
     element.addEventListener("click", (event: MouseEvent) => {
         let target = event.target as HTMLElement;
-        while (target && !target.isSameNode(element)) {
+        while (target && (target !== element)) {
             const type = target.getAttribute("data-type");
             if (type === "replaceHistory") {
                 toggleReplaceHistory(target.nextElementSibling as HTMLInputElement);

--- a/app/src/mobile/settings/about.ts
+++ b/app/src/mobile/settings/about.ts
@@ -182,7 +182,7 @@ export const initAbout = () => {
             const importKeyElement = modelMainElement.querySelector("#importKey");
             modelMainElement.firstElementChild.addEventListener("click", (event) => {
                 let target = event.target as HTMLElement;
-                while (target && !target.isSameNode(modelMainElement)) {
+                while (target && (target !== modelMainElement)) {
                     if (target.id === "authCode") {
                         setAccessAuthCode();
                         event.preventDefault();

--- a/app/src/mobile/settings/account.ts
+++ b/app/src/mobile/settings/account.ts
@@ -135,7 +135,7 @@ ${renewHTML}<div class="fn__hr--b"></div>`;
                 if (typeof event.detail !== "number") {
                     target = event.detail;
                 }
-                while (target && !target.isSameNode(modelMainElement)) {
+                while (target && (target !== modelMainElement)) {
                     if (target.getAttribute("data-action") === "iOSPay") {
                         iOSPurchase(target.getAttribute("data-type"));
                         event.preventDefault();

--- a/app/src/protyle/breadcrumb/action.ts
+++ b/app/src/protyle/breadcrumb/action.ts
@@ -26,7 +26,7 @@ export const net2LocalAssets = (protyle: IProtyle, type: "Assets" | "Img") => {
         /// #else
         getAllEditor().forEach(item => {
             if (item.protyle.block.rootID === protyle.block.rootID) {
-                reloadProtyle(item.protyle, item.protyle.element.isSameNode(protyle.element));
+                reloadProtyle(item.protyle, item.protyle.element === protyle.element);
             }
         });
         /// #endif
@@ -95,7 +95,7 @@ export const fullscreen = (element: Element, btnElement?: Element) => {
         window.siyuan.editorIsFullscreen = !isFullscreen;
     }
     getAllModels().editor.forEach(item => {
-        if (!element.isSameNode(item.element)) {
+        if (element !== item.element) {
             if (window.siyuan.editorIsFullscreen) {
                 if (item.element.classList.contains("fullscreen")) {
                     item.element.classList.remove("fullscreen");

--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -563,7 +563,7 @@ export class Gutter {
                 hasEmbedBlock = true;
             }
             if (item.nextElementSibling && selectsElement[index + 1] &&
-                item.nextElementSibling.isSameNode(selectsElement[index + 1])) {
+                (item.nextElementSibling === selectsElement[index + 1])) {
                 isContinue = true;
             } else if (index !== selectsElement.length - 1) {
                 isContinue = false;
@@ -2329,7 +2329,7 @@ export class Gutter {
                         listItem = undefined;
                     }
                     // 标题必须显示
-                    if (!topElement.isSameNode(nodeElement) && type !== "NodeHeading") {
+                    if ((topElement !== nodeElement) && type !== "NodeHeading") {
                         nodeElement = topElement;
                         parentElement = hasClosestBlock(nodeElement.parentElement);
                         type = nodeElement.getAttribute("data-type");

--- a/app/src/protyle/hint/extend.ts
+++ b/app/src/protyle/hint/extend.ts
@@ -564,7 +564,7 @@ export const hintMoveBlock = (pathString: string, sourceElements: Element[], pro
             item.parentElement) {
             topSourceElement = getTopAloneElement(item);
             sideElement = topSourceElement.nextElementSibling || topSourceElement.previousElementSibling;
-            if (topSourceElement.isSameNode(item)) {
+            if (topSourceElement === item) {
                 topSourceElement = undefined;
             }
         }

--- a/app/src/protyle/render/av/action.ts
+++ b/app/src/protyle/render/av/action.ts
@@ -580,7 +580,7 @@ ${window.siyuan.languages[avType === "table" ? "insertRowBefore" : "insertItemBe
                 bind(element) {
                     const inputElement = element.querySelector("input");
                     element.addEventListener("click", () => {
-                        if (document.activeElement.isSameNode(inputElement)) {
+                        if (document.activeElement === inputElement) {
                             return;
                         }
                         insertRows(blockElement, protyle, parseInt(inputElement.value), rowElements[0].previousElementSibling.getAttribute("data-id"));
@@ -603,7 +603,7 @@ ${window.siyuan.languages[avType === "table" ? "insertRowAfter" : "insertItemAft
                 bind(element) {
                     const inputElement = element.querySelector("input");
                     element.addEventListener("click", () => {
-                        if (document.activeElement.isSameNode(inputElement)) {
+                        if (document.activeElement === inputElement) {
                             return;
                         }
                         insertRows(blockElement, protyle, parseInt(inputElement.value), rowElements[0].getAttribute("data-id"));
@@ -735,7 +735,7 @@ export const updateAVName = (protyle: IProtyle, blockElement: Element) => {
 
     // 当前页面不能进行推送，否则光标会乱跳
     Array.from(protyle.wysiwyg.element.querySelectorAll(`[data-av-id="${avId}"]`)).forEach((item: HTMLElement) => {
-        if (blockElement.isSameNode(item)) {
+        if (blockElement === item) {
             return;
         }
         const titleElement = item.querySelector(".av__title") as HTMLElement;

--- a/app/src/protyle/render/av/blockAttr.ts
+++ b/app/src/protyle/render/av/blockAttr.ts
@@ -298,11 +298,11 @@ class="fn__flex-1 fn__flex${["url", "text", "number", "email", "phone", "block"]
                 if (!targetElement) {
                     targetElement = hasClosestByClassName(document.elementFromPoint(event.clientX, event.clientY - 1), "av__row");
                 }
-                if (!targetElement || targetElement.isSameNode(window.siyuan.dragElement) || !dragBlockElement) {
+                if (!targetElement || (targetElement === window.siyuan.dragElement) || !dragBlockElement) {
                     return;
                 }
                 const targetBlockElement = hasClosestBlock(targetElement);
-                if (!targetBlockElement || !targetBlockElement.isSameNode(dragBlockElement)) {
+                if (!targetBlockElement || (targetBlockElement !== dragBlockElement)) {
                     return;
                 }
                 event.preventDefault();
@@ -455,13 +455,13 @@ const openEdit = (protyle: IProtyle, element: HTMLElement, event: MouseEvent) =>
     if (!blockElement) {
         return;
     }
-    while (target && !element.isSameNode(target)) {
+    while (target && (element !== target)) {
         const type = target.getAttribute("data-type");
         if (target.classList.contains("av__celltext--url") || target.classList.contains("av__cellassetimg")) {
             if (event.type === "contextmenu" || (!target.dataset.url && target.tagName !== "IMG")) {
                 let index = 0;
                 Array.from(target.parentElement.children).find((item, i) => {
-                    if (item.isSameNode(target)) {
+                    if (item === target) {
                         index = i;
                         return true;
                     }

--- a/app/src/protyle/render/av/cell.ts
+++ b/app/src/protyle/render/av/cell.ts
@@ -743,9 +743,9 @@ export const updateCellsValue = (protyle: IProtyle, nodeElement: HTMLElement, va
         const cellId = item.dataset.id;   // 刚创建时无 id，更新需和 oldValue 保持一致
         const colId = getColId(item, viewType);
 
-        text += getCellText(item) + ((cellElements[elementIndex + 1] && item.nextElementSibling && item.nextElementSibling.isSameNode(cellElements[elementIndex + 1])) ? "\t" : "\n\n");
+        text += getCellText(item) + ((cellElements[elementIndex + 1] && item.nextElementSibling && (item.nextElementSibling === cellElements[elementIndex + 1])) ? "\t" : "\n\n");
         const oldValue = genCellValueByElement(type, item);
-        if (elementIndex === 0 || !cellElements[elementIndex - 1].isSameNode(item.previousElementSibling)) {
+        if (elementIndex === 0 || (cellElements[elementIndex - 1] !== item.previousElementSibling)) {
             json.push([]);
         }
         json[json.length - 1].push(oldValue);

--- a/app/src/protyle/render/av/col.ts
+++ b/app/src/protyle/render/av/col.ts
@@ -1015,7 +1015,7 @@ export const showColMenu = (protyle: IProtyle, blockElement: Element, cellElemen
                         dialog.element.addEventListener("click", (event) => {
                             let target = event.target as HTMLElement;
                             const isDispatch = typeof event.detail === "string";
-                            while (target && !target.isSameNode(dialog.element) || isDispatch) {
+                            while (target && (target !== dialog.element) || isDispatch) {
                                 const action = target.getAttribute("data-action");
                                 if (action === "delete" || (isDispatch && event.detail === "Enter")) {
                                     removeColByMenu({

--- a/app/src/protyle/render/av/gallery/render.ts
+++ b/app/src/protyle/render/av/gallery/render.ts
@@ -45,7 +45,7 @@ export const renderGallery = (options: {
     const created = options.protyle.options.history?.created;
     const snapshot = options.protyle.options.history?.snapshot;
     let searchInputElement = options.blockElement.querySelector('[data-type="av-search"]') as HTMLInputElement;
-    const isSearching = searchInputElement && document.activeElement.isSameNode(searchInputElement);
+    const isSearching = searchInputElement && (document.activeElement === searchInputElement);
     const query = searchInputElement?.value || "";
     fetchPost(created ? "/api/av/renderHistoryAttributeView" : (snapshot ? "/api/av/renderSnapshotAttributeView" : "/api/av/renderAttributeView"), {
         id: options.blockElement.getAttribute("data-av-id"),
@@ -213,7 +213,7 @@ ${view.hideAttrViewName ? " av__gallery--top" : ""}">
             const range = getSelection().getRangeAt(0);
             if (!hasClosestByClassName(range.startContainer, "av__title")) {
                 const blockElement = hasClosestBlock(range.startContainer);
-                if (blockElement && options.blockElement.isSameNode(blockElement) && !isSearching) {
+                if (blockElement && (options.blockElement === blockElement) && !isSearching) {
                     focusBlock(options.blockElement);
                 }
             }
@@ -245,7 +245,7 @@ ${view.hideAttrViewName ? " av__gallery--top" : ""}">
             if (event.isComposing) {
                 return;
             }
-            if (searchInputElement.value || document.activeElement.isSameNode(searchInputElement)) {
+            if (searchInputElement.value || (document.activeElement === searchInputElement)) {
                 viewsElement.classList.add("av__views--show");
             } else {
                 viewsElement.classList.remove("av__views--show");

--- a/app/src/protyle/render/av/openMenuPanel.ts
+++ b/app/src/protyle/render/av/openMenuPanel.ts
@@ -475,11 +475,11 @@ export const openMenuPanel = (options: {
             if (!targetElement) {
                 targetElement = hasClosestByAttribute(document.elementFromPoint(event.clientX, event.clientY - 1), "draggable", "true");
             }
-            if (!targetElement || targetElement.isSameNode(window.siyuan.dragElement)) {
+            if (!targetElement || (targetElement === window.siyuan.dragElement)) {
                 return;
             }
             event.preventDefault();
-            if (dragoverElement && targetElement.isSameNode(dragoverElement)) {
+            if (dragoverElement && (targetElement === dragoverElement)) {
                 const nodeRect = targetElement.getBoundingClientRect();
                 avPanelElement.querySelectorAll(".dragover__bottom, .dragover__top").forEach((item: HTMLElement) => {
                     item.classList.remove("dragover__bottom", "dragover__top");
@@ -526,7 +526,7 @@ export const openMenuPanel = (options: {
                 type = (event.detail as { type: string }).type;
                 target = (event.detail as { target: HTMLElement }).target;
             }
-            while (target && !target.isSameNode(avPanelElement) || type) {
+            while (target && (target !== avPanelElement) || type) {
                 type = target?.dataset.type || type;
                 if (type === "close") {
                     if (!options.protyle.toolbar.subElement.classList.contains("fn__none")) {
@@ -1181,7 +1181,7 @@ export const openMenuPanel = (options: {
                         dialog.element.addEventListener("click", (dialogEvent) => {
                             let target = dialogEvent.target as HTMLElement;
                             const isDispatch = typeof dialogEvent.detail === "string";
-                            while (target && !target.isSameNode(dialog.element) || isDispatch) {
+                            while (target && (target !== dialog.element) || isDispatch) {
                                 const action = target.getAttribute("data-action");
                                 if (action === "delete" || (isDispatch && dialogEvent.detail === "Enter")) {
                                     removeCol({

--- a/app/src/protyle/render/av/render.ts
+++ b/app/src/protyle/render/av/render.ts
@@ -85,7 +85,7 @@ export const avRender = (element: Element, protyle: IProtyle, cb?: (data: IAV) =
             const created = protyle.options.history?.created;
             const snapshot = protyle.options.history?.snapshot;
             let searchInputElement = e.querySelector('[data-type="av-search"]') as HTMLInputElement;
-            const isSearching = searchInputElement && document.activeElement.isSameNode(searchInputElement);
+            const isSearching = searchInputElement && (document.activeElement === searchInputElement);
             const query = searchInputElement?.value || "";
             fetchPost(created ? "/api/av/renderHistoryAttributeView" : (snapshot ? "/api/av/renderSnapshotAttributeView" : "/api/av/renderAttributeView"), {
                 id: e.getAttribute("data-av-id"),
@@ -336,7 +336,7 @@ ${cell.color ? `color:${cell.color};` : ""}">${renderCell(cell.value, rowIndex, 
                     } else if (!avPanelElement && !isSearching && getSelection().rangeCount > 0) {
                         const range = getSelection().getRangeAt(0);
                         const blockElement = hasClosestBlock(range.startContainer);
-                        if (blockElement && e.isSameNode(blockElement)) {
+                        if (blockElement && (e === blockElement)) {
                             focusBlock(e);
                         }
                     } else if (avPanelElement && !newCellElement) {
@@ -366,7 +366,7 @@ ${cell.color ? `color:${cell.color};` : ""}">${renderCell(cell.value, rowIndex, 
                     const range = getSelection().getRangeAt(0);
                     if (!hasClosestByClassName(range.startContainer, "av__title")) {
                         const blockElement = hasClosestBlock(range.startContainer);
-                        if (blockElement && e.isSameNode(blockElement) && !isSearching) {
+                        if (blockElement && (e === blockElement) && !isSearching) {
                             focusBlock(e);
                         }
                     }
@@ -398,7 +398,7 @@ ${cell.color ? `color:${cell.color};` : ""}">${renderCell(cell.value, rowIndex, 
                     if (event.isComposing) {
                         return;
                     }
-                    if (searchInputElement.value || document.activeElement.isSameNode(searchInputElement)) {
+                    if (searchInputElement.value || (document.activeElement === searchInputElement)) {
                         viewsElement.classList.add("av__views--show");
                     } else {
                         viewsElement.classList.remove("av__views--show");

--- a/app/src/protyle/render/av/view.ts
+++ b/app/src/protyle/render/av/view.ts
@@ -408,17 +408,17 @@ export const dragoverTab = (event: DragEvent) => {
     if (!target) {
         return;
     }
-    if (!viewTabElement.isSameNode(window.siyuan.dragElement.parentElement) || target.isSameNode(window.siyuan.dragElement)) {
+    if ((viewTabElement !== window.siyuan.dragElement.parentElement) || (target === window.siyuan.dragElement)) {
         return;
     }
     const targetRect = target.getBoundingClientRect();
     if (targetRect.left + targetRect.width / 2 < event.clientX) {
-        if (target.nextElementSibling?.isSameNode(window.siyuan.dragElement)) {
+        if (target.nextElementSibling && (target.nextElementSibling === window.siyuan.dragElement)) {
             return;
         }
         target.after(window.siyuan.dragElement);
     } else {
-        if (target.previousElementSibling?.isSameNode(window.siyuan.dragElement)) {
+        if (target.previousElementSibling && (target.previousElementSibling === window.siyuan.dragElement)) {
             return;
         }
         target.before(window.siyuan.dragElement);

--- a/app/src/protyle/toolbar/index.ts
+++ b/app/src/protyle/toolbar/index.ts
@@ -134,7 +134,7 @@ export class Toolbar {
         // shift+方向键或三击选中，不同的块 https://github.com/siyuan-note/siyuan/issues/3891
         const startElement = hasClosestBlock(range.startContainer);
         const endElement = hasClosestBlock(range.endContainer);
-        if (startElement && endElement && !startElement.isSameNode(endElement)) {
+        if (startElement && endElement && (startElement !== endElement)) {
             if (event) { // 在 keyup 中使用 shift+方向键选中
                 if (event.key === "ArrowLeft") {
                     this.range = setLastNodeRange(getContenteditableElement(startElement), range, false);
@@ -212,7 +212,7 @@ export class Toolbar {
         if (types.length === 0 && (!endElement || endElement.nodeType === 3)) {
             return [];
         }
-        if (endElement && !["DIV", "TD", "TH", "TR"].includes(endElement.tagName) && !startElement.isSameNode(endElement)) {
+        if (endElement && !["DIV", "TD", "TH", "TR"].includes(endElement.tagName) && (startElement !== endElement)) {
             types = types.concat((endElement.getAttribute("data-type") || "").split(" "));
         }
         range.cloneContents().childNodes.forEach((item: HTMLElement) => {
@@ -240,7 +240,7 @@ export class Toolbar {
             return;
         }
         // 三击后还没有重新纠正 range 时使用快捷键标记会导致异常 https://github.com/siyuan-note/siyuan/issues/7068
-        if (!nodeElement.isSameNode(endElement)) {
+        if (nodeElement !== endElement) {
             this.range = setLastNodeRange(getContenteditableElement(nodeElement), this.range, false);
         }
 
@@ -251,9 +251,9 @@ export class Toolbar {
             }
         });
         const rangeStartNextSibling = hasNextSibling(this.range.startContainer);
-        const isSameNode = this.range.startContainer.isSameNode(this.range.endContainer) ||
-            (rangeStartNextSibling && rangeStartNextSibling.isSameNode(this.range.endContainer) &&
-                this.range.startContainer.parentElement.isSameNode(this.range.endContainer.parentElement));
+        const isSameNode = (this.range.startContainer === this.range.endContainer) ||
+            (rangeStartNextSibling && (rangeStartNextSibling === this.range.endContainer) &&
+                (this.range.startContainer.parentElement === this.range.endContainer.parentElement));
         if (this.range.startContainer.nodeType === 3 && this.range.startContainer.parentElement.tagName === "SPAN" &&
             isSameNode &&
             this.range.startOffset > -1 && this.range.endOffset <= this.range.endContainer.textContent.length) {
@@ -284,7 +284,7 @@ export class Toolbar {
             }
         }
         // https://github.com/siyuan-note/siyuan/issues/14534
-        if (rangeTypes.includes("text") && type === "text" && textObj && this.range.startContainer.nodeType === 3 && this.range.startContainer.isSameNode(this.range.endContainer)) {
+        if (rangeTypes.includes("text") && type === "text" && textObj && this.range.startContainer.nodeType === 3 && (this.range.startContainer === this.range.endContainer)) {
             const selectParentElement = this.range.startContainer.parentElement;
             if (selectParentElement && hasSameTextStyle(null, selectParentElement, textObj)) {
                 return;
@@ -304,14 +304,14 @@ export class Toolbar {
                     this.range.startOffset !== 0 ||
                     // https://github.com/siyuan-note/siyuan/issues/14869
                     (this.range.startOffset === 0 && this.range.startContainer.previousSibling?.nodeType === 3 &&
-                        this.range.startContainer.previousSibling.parentElement.isSameNode(this.range.startContainer.parentElement))
+                        (this.range.startContainer.previousSibling.parentElement === this.range.startContainer.parentElement))
                 ) && (
                     this.range.endOffset !== this.range.endContainer.textContent.length ||
                     // https://github.com/siyuan-note/siyuan/issues/14869#issuecomment-2911553387
                     (
                         this.range.endOffset === this.range.endContainer.textContent.length &&
                         this.range.endContainer.nextSibling?.nodeType === 3 &&
-                        this.range.endContainer.nextSibling.parentElement.isSameNode(this.range.endContainer.parentElement)
+                        (this.range.endContainer.nextSibling.parentElement === this.range.endContainer.parentElement)
                     )
                 ) &&
                 !(this.range.startOffset === 1 && this.range.startContainer.textContent.startsWith(Constants.ZWSP))) {
@@ -722,7 +722,7 @@ export class Toolbar {
                                 endOffset = previousElement.textContent.length;
                                 if (!startContainer) {
                                     startContainer = currentNode;
-                                } else if (startContainer.isSameNode(previousElement)) {
+                                } else if (startContainer === previousElement) {
                                     startContainer = currentNode;
                                 }
                             }

--- a/app/src/protyle/ui/initUI.ts
+++ b/app/src/protyle/ui/initUI.ts
@@ -226,10 +226,10 @@ export const initUI = (protyle: IProtyle) => {
                 if (!isInEmbedBlock(item) && protyle.gutter.isMatchNode(item)) {
                     const rowItem = item.querySelector(`.av__row[data-id="${buttonElement.dataset.rowId}"]`);
                     Array.from(protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--hl, .av__row--hl")).forEach(hlItem => {
-                        if (!item.isSameNode(hlItem)) {
+                        if (item !== hlItem) {
                             hlItem.classList.remove("protyle-wysiwyg--hl");
                         }
-                        if (rowItem && !rowItem.isSameNode(hlItem)) {
+                        if (rowItem && (rowItem !== hlItem)) {
                             rowItem.classList.remove("av__row--hl");
                         }
                     });

--- a/app/src/protyle/util/editorCommonEvent.ts
+++ b/app/src/protyle/util/editorCommonEvent.ts
@@ -64,7 +64,7 @@ const moveToNew = (protyle: IProtyle, sourceElements: Element[], targetElement: 
         const itemId = item.getAttribute("data-node-id");
         if (index === sourceElements.length - 1) {
             topSourceElement = getTopAloneElement(item);
-            if (topSourceElement.isSameNode(item)) {
+            if (topSourceElement === item) {
                 topSourceElement = undefined;
                 // 单个缩放或反链面板中的列表项拖拽到包含该列表的编辑器中会导致残留的 list
                 Array.from(protyle.wysiwyg.element.querySelectorAll(`[data-node-id="${item.getAttribute("data-node-id")}"]`)).find((targetItem: HTMLElement) => {
@@ -158,7 +158,7 @@ const moveTo = async (protyle: IProtyle, sourceElements: Element[], targetElemen
         const parentID = item.parentElement.getAttribute("data-node-id") || protyle.block.rootID;
         if (index === sourceElements.length - 1) {
             topSourceElement = getTopAloneElement(item);
-            if (topSourceElement.isSameNode(item)) {
+            if (topSourceElement === item) {
                 topSourceElement = undefined;
             } else if (topSourceElement.contains(item) && topSourceElement.contains(targetElement)) {
                 // * * 1 列表项拖拽到父级列表项下 https://ld246.com/article/1665448570858
@@ -312,7 +312,7 @@ const dragSb = async (protyle: IProtyle, sourceElements: Element[], targetElemen
         sourceElements.reverse().forEach((item, index) => {
             if (index === sourceElements.length - 1) {
                 topSourceElement = getTopAloneElement(item);
-                if (topSourceElement.isSameNode(item)) {
+                if (topSourceElement === item) {
                     topSourceElement = undefined;
                 }
             }
@@ -374,7 +374,7 @@ const dragSb = async (protyle: IProtyle, sourceElements: Element[], targetElemen
             const parentID = item.parentElement.getAttribute("data-node-id") || protyle.block.rootID;
             if (index === sourceElements.length - 1) {
                 topSourceElement = getTopAloneElement(item);
-                if (topSourceElement.isSameNode(item)) {
+                if (topSourceElement === item) {
                     topSourceElement = undefined;
                 }
             }
@@ -481,7 +481,7 @@ const dragSb = async (protyle: IProtyle, sourceElements: Element[], targetElemen
     // https://github.com/siyuan-note/insider/issues/536
     if (!isCopy && oldSourceParentElement && oldSourceParentElement.classList.contains("list") &&
         oldSourceParentElement.getAttribute("data-subtype") === "o" &&
-        !oldSourceParentElement.isSameNode(sourceElements[0].parentElement) && oldSourceParentElement.childElementCount > 1) {
+        (oldSourceParentElement !== sourceElements[0].parentElement) && oldSourceParentElement.childElementCount > 1) {
         Array.from(oldSourceParentElement.children).forEach((item) => {
             if (item.classList.contains("protyle-attr")) {
                 return;
@@ -540,7 +540,7 @@ const dragSb = async (protyle: IProtyle, sourceElements: Element[], targetElemen
             if (otherProtyleElement) {
                 const allEditor = getAllEditor();
                 for (let i = 0; i < allEditor.length; i++) {
-                    if (allEditor[i].protyle.element.isSameNode(otherProtyleElement)) {
+                    if (allEditor[i].protyle.element === otherProtyleElement) {
                         const otherSbData = await cancelSB(allEditor[i].protyle, oldSourceParentElement);
                         doOperations.push(otherSbData.doOperations[0], otherSbData.doOperations[1]);
                         undoOperations.splice(0, 0, otherSbData.undoOperations[0], otherSbData.undoOperations[1]);
@@ -558,7 +558,7 @@ const dragSb = async (protyle: IProtyle, sourceElements: Element[], targetElemen
         const protyleElement = hasClosestByClassName(oldSourceParentElement, "protyle", true);
         if (protyleElement) {
             getAllEditor().find(item => {
-                if (item.protyle.element.isSameNode(protyleElement)) {
+                if (item.protyle.element === protyleElement) {
                     if (item.protyle.block.id === item.protyle.block.rootID) {
                         const newId = Lute.NewNodeID();
                         doOperations.splice(0, 0, {
@@ -676,7 +676,7 @@ const dragSame = async (protyle: IProtyle, sourceElements: Element[], targetElem
         isSameDoc &&    // 同一文档分屏后，oldSourceParentElement 已经被移走，不可再 update https://github.com/siyuan-note/siyuan/issues/8863
         oldSourceParentElement && oldSourceParentElement.classList.contains("list") &&
         oldSourceParentElement.getAttribute("data-subtype") === "o" &&
-        !oldSourceParentElement.isSameNode(sourceElements[0].parentElement) && oldSourceParentElement.childElementCount > 1) {
+        (oldSourceParentElement !== sourceElements[0].parentElement) && oldSourceParentElement.childElementCount > 1) {
         Array.from(oldSourceParentElement.children).forEach((item) => {
             if (item.classList.contains("protyle-attr")) {
                 return;
@@ -743,7 +743,7 @@ const dragSame = async (protyle: IProtyle, sourceElements: Element[], targetElem
             if (otherProtyleElement) {
                 const allEditor = getAllEditor();
                 for (let i = 0; i < allEditor.length; i++) {
-                    if (allEditor[i].protyle.element.isSameNode(otherProtyleElement)) {
+                    if (allEditor[i].protyle.element === otherProtyleElement) {
                         const otherSbData = await cancelSB(allEditor[i].protyle, oldSourceParentElement);
                         doOperations.push(otherSbData.doOperations[0], otherSbData.doOperations[1]);
                         undoOperations.splice(0, 0, otherSbData.undoOperations[0], otherSbData.undoOperations[1]);
@@ -760,7 +760,7 @@ const dragSame = async (protyle: IProtyle, sourceElements: Element[], targetElem
         const protyleElement = hasClosestByClassName(oldSourceParentElement, "protyle", true);
         if (protyleElement) {
             getAllEditor().find(item => {
-                if (item.protyle.element.isSameNode(protyleElement)) {
+                if (item.protyle.element === protyleElement) {
                     if (item.protyle.block.id === item.protyle.block.rootID) {
                         const newId = Lute.NewNodeID();
                         doOperations.splice(0, 0, {
@@ -1423,7 +1423,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             if (targetElement && targetElement.getAttribute("data-dtype") === "mAsset" &&
                 !targetElement.classList.contains("av__cell--header")) {
                 event.preventDefault(); // 不使用导致无法触发 drop
-                if (dragoverElement && targetElement.isSameNode(dragoverElement)) {
+                if (dragoverElement && (targetElement === dragoverElement)) {
                     return;
                 }
                 const blockElement = hasClosestBlock(targetElement);
@@ -1528,8 +1528,8 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             if (targetElement) {
                 const targetRowElement = hasClosestByClassName(targetElement, "av__row--header");
                 const dragRowElement = hasClosestByClassName(window.siyuan.dragElement, "av__row--header");
-                if (targetElement.isSameNode(window.siyuan.dragElement) || !targetRowElement || !dragRowElement ||
-                    (targetRowElement && dragRowElement && !targetRowElement.isSameNode(dragRowElement))
+                if ((targetElement === window.siyuan.dragElement) || !targetRowElement || !dragRowElement ||
+                    (targetRowElement && dragRowElement && (targetRowElement !== dragRowElement))
                 ) {
                     targetElement = false;
                 }
@@ -1544,7 +1544,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             // gallery item 只能拖拽当前 av 中
             const galleryElement = hasClosestByClassName(event.target, "av__gallery");
             if (targetElement.classList.contains("av") || !galleryElement ||
-                !galleryElement.contains(window.siyuan.dragElement) || targetElement.isSameNode(window.siyuan.dragElement)) {
+                !galleryElement.contains(window.siyuan.dragElement) || (targetElement === window.siyuan.dragElement)) {
                 targetElement = false;
                 editorElement.querySelectorAll(".dragover__left, .dragover__right").forEach((item: HTMLElement) => {
                     item.classList.remove("dragover__left", "dragover__right");
@@ -1559,7 +1559,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             !targetElement.classList.contains("av__row--util") &&
             !targetElement.classList.contains("av__gallery-item") &&
             !targetElement.classList.contains("av__gallery-add");
-        if (targetElement && dragoverElement && targetElement.isSameNode(dragoverElement)) {
+        if (targetElement && dragoverElement && (targetElement === dragoverElement)) {
             // 性能优化，目标为同一个元素不再进行校验
             const nodeRect = targetElement.getBoundingClientRect();
             editorElement.querySelectorAll(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top, .dragover").forEach((item: HTMLElement) => {
@@ -1597,11 +1597,11 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
 
             if (targetElement.classList.contains("av__cell")) {
                 if (event.clientX < nodeRect.left + nodeRect.width / 2 && event.clientX > nodeRect.left &&
-                    !targetElement.classList.contains("av__row") && !targetElement.previousElementSibling.isSameNode(window.siyuan.dragElement)) {
+                    !targetElement.classList.contains("av__row") && (targetElement.previousElementSibling !== window.siyuan.dragElement)) {
                     targetElement.classList.add("dragover__left");
                 } else if (event.clientX > nodeRect.right - nodeRect.width / 2 && event.clientX <= nodeRect.right + 1 &&
-                    !targetElement.classList.contains("av__row") && !targetElement.isSameNode(window.siyuan.dragElement.previousElementSibling)) {
-                    if (window.siyuan.dragElement.previousElementSibling.classList.contains("av__colsticky") && targetElement.isSameNode(window.siyuan.dragElement.previousElementSibling.lastElementChild)) {
+                    !targetElement.classList.contains("av__row") && (targetElement !== window.siyuan.dragElement.previousElementSibling)) {
+                    if (window.siyuan.dragElement.previousElementSibling.classList.contains("av__colsticky") && (targetElement === window.siyuan.dragElement.previousElementSibling.lastElementChild)) {
                         // 拖拽到固定列的最后一个元素
                     } else {
                         targetElement.classList.add("dragover__right");

--- a/app/src/protyle/util/hasClosest.ts
+++ b/app/src/protyle/util/hasClosest.ts
@@ -113,7 +113,7 @@ export const hasClosestBlock = (element: Node) => {
 export const isInEmbedBlock = (element: Element) => {
     const embedElement = hasTopClosestByAttribute(element, "data-type", "NodeBlockQueryEmbed");
     if (embedElement) {
-        if (embedElement.isSameNode(element)) {
+        if (embedElement === element) {
             return false;
         } else {
             return embedElement;

--- a/app/src/protyle/util/insertHTML.ts
+++ b/app/src/protyle/util/insertHTML.ts
@@ -403,7 +403,7 @@ export const insertHTML = (html: string, protyle: IProtyle, isBlock = false,
             }
             // 粘贴带样式的行内元素到另一个行内元素中需进行切割
             const spanElement = range.startContainer.nodeType === 3 ? range.startContainer.parentElement : range.startContainer as HTMLElement;
-            if (spanElement.tagName === "SPAN" && spanElement.isSameNode(range.endContainer.nodeType === 3 ? range.endContainer.parentElement : range.endContainer) &&
+            if (spanElement.tagName === "SPAN" && (spanElement === (range.endContainer.nodeType === 3 ? range.endContainer.parentElement : range.endContainer)) &&
                 // 粘贴纯文本不需切割 https://ld246.com/article/1665556907936
                 // emoji 图片需要切割 https://github.com/siyuan-note/siyuan/issues/9370
                 tempElement.content.querySelector("span, img")

--- a/app/src/protyle/util/onGet.ts
+++ b/app/src/protyle/util/onGet.ts
@@ -153,7 +153,7 @@ const setHTML = (options: {
         if (!protyle.wysiwyg.element.querySelector(".protyle-wysiwyg--select") && !protyle.scroll.keepLazyLoad && protyle.contentElement.scrollHeight > REMOVED_OVER_HEIGHT) {
             let removeElement = protyle.wysiwyg.element.firstElementChild as HTMLElement;
             const removeElements = [];
-            while (protyle.wysiwyg.element.childElementCount > 2 && removeElements && !protyle.wysiwyg.element.lastElementChild.isSameNode(removeElement)) {
+            while (protyle.wysiwyg.element.childElementCount > 2 && removeElements && (protyle.wysiwyg.element.lastElementChild !== removeElement)) {
                 if (protyle.contentElement.scrollHeight - removeElement.offsetTop > REMOVED_OVER_HEIGHT) {
                     removeElements.push(removeElement);
                 } else {
@@ -508,7 +508,7 @@ const focusElementById = (protyle: IProtyle, action: string[], scrollAttr?: IScr
         protyle.observer.observe(protyle.wysiwyg.element);
     }, 1000 * 3);
 
-    if (focusElement.isSameNode(protyle.wysiwyg.element.firstElementChild) && !hasScrollTop) {
+    if ((focusElement === protyle.wysiwyg.element.firstElementChild) && !hasScrollTop) {
         protyle.observerLoad.disconnect();
     }
 };

--- a/app/src/protyle/util/selection.ts
+++ b/app/src/protyle/util/selection.ts
@@ -109,7 +109,7 @@ export const selectAll = (protyle: IProtyle, nodeElement: Element, range: Range)
     }
     range.collapse(true);
     const selectElements = protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select");
-    if (protyle.wysiwyg.element.childElementCount === selectElements.length && selectElements[0].parentElement.isSameNode(protyle.wysiwyg.element)) {
+    if (protyle.wysiwyg.element.childElementCount === selectElements.length && (selectElements[0].parentElement === protyle.wysiwyg.element)) {
         return true;
     }
     hideElements(["select"], protyle);
@@ -139,7 +139,7 @@ export const getEditorRange = (element: Element): Range => {
     let range: Range;
     if (getSelection().rangeCount > 0) {
         range = getSelection().getRangeAt(0);
-        if (element.isSameNode(range.startContainer) || element.contains(range.startContainer)) {
+        if ((element === range.startContainer) || element.contains(range.startContainer)) {
             // 有时候点击编辑器头部需要矫正到第一个块中
             if (range.toString() === "" && range.startContainer.nodeType === 1 && range.startOffset === 0 &&
                 (range.startContainer as HTMLElement).classList.contains("protyle-wysiwyg")) {
@@ -528,7 +528,7 @@ export const focusByWbr = (element: Element, range: Range) => {
         }
     } else {
         const wbrPreviousSibling = hasPreviousSibling(wbrElement);
-        if (wbrPreviousSibling && wbrElement.previousElementSibling.isSameNode(wbrPreviousSibling)) {
+        if (wbrPreviousSibling && (wbrElement.previousElementSibling === wbrPreviousSibling)) {
             if (wbrElement.previousElementSibling.lastChild?.nodeType === 3) {
                 // <em>text</em><wbr> 需把光标放在里面，因为 chrome 点击后也是默认在里面
                 range.setStart(wbrElement.previousElementSibling.lastChild, wbrElement.previousElementSibling.lastChild.textContent.length);

--- a/app/src/protyle/util/table.ts
+++ b/app/src/protyle/util/table.ts
@@ -67,7 +67,7 @@ export const setTableAlign = (protyle: IProtyle, cellElements: HTMLElement[], no
 
     for (let i = 0; i < rowCnt; i++) {
         for (let j = 0; j < columnCnt; j++) {
-            if (tableElement.rows[i].cells[j].isSameNode(cellElements[currentColumns.length])) {
+            if (tableElement.rows[i].cells[j] === cellElements[currentColumns.length]) {
                 currentColumns.push(j);
             }
         }
@@ -178,7 +178,7 @@ export const insertColumn = (protyle: IProtyle, nodeElement: Element, cellElemen
         const colCellElement = tableElement.rows[i].cells[index];
         const newCellElement = document.createElement(colCellElement.tagName);
         colCellElement.insertAdjacentElement(type, newCellElement);
-        if (colCellElement.isSameNode(cellElement)) {
+        if (colCellElement === cellElement) {
             newCellElement.innerHTML = "<wbr> ";
             // 滚动条横向定位
             if (newCellElement.offsetLeft + newCellElement.clientWidth > nodeElement.firstElementChild.scrollLeft + nodeElement.firstElementChild.clientWidth) {
@@ -319,7 +319,7 @@ export const moveColumnToLeft = (protyle: IProtyle, range: Range, cellElement: H
     const html = nodeElement.outerHTML;
     let cellIndex = 0;
     Array.from(cellElement.parentElement.children).find((item, index) => {
-        if (cellElement.isSameNode(item)) {
+        if (cellElement === item) {
             cellIndex = index;
             return true;
         }
@@ -346,7 +346,7 @@ export const moveColumnToRight = (protyle: IProtyle, range: Range, cellElement: 
     const html = nodeElement.outerHTML;
     let cellIndex = 0;
     Array.from(cellElement.parentElement.children).find((item, index) => {
-        if (cellElement.isSameNode(item)) {
+        if (cellElement === item) {
             cellIndex = index;
             return true;
         }
@@ -422,7 +422,7 @@ export const fixTable = (protyle: IProtyle, event: KeyboardEvent, range: Range) 
         // 表格后无内容时，按右键需新建空块
         if (event.key === "ArrowRight" && range.toString() === "" &&
             !nodeElement.nextElementSibling &&
-            cellElement.isSameNode(nodeElement.querySelector("table").lastElementChild.lastElementChild.lastElementChild) &&
+            (cellElement === nodeElement.querySelector("table").lastElementChild.lastElementChild.lastElementChild) &&
             getSelectionOffset(cellElement, protyle.wysiwyg.element, range).start === cellElement.textContent.length) {
             event.preventDefault();
             insertEmptyBlock(protyle, "afterend", nodeElement.getAttribute("data-node-id"));

--- a/app/src/protyle/wysiwyg/enter.ts
+++ b/app/src/protyle/wysiwyg/enter.ts
@@ -384,7 +384,7 @@ const listEnter = (protyle: IProtyle, blockElement: HTMLElement, range: Range) =
     let newElement;
     if (subListElement && listItemElement.getAttribute("fold") !== "1" &&
         // 子列表下的段落块回车 https://ld246.com/article/1623919354587
-        blockElement.nextElementSibling.isSameNode(subListElement)) {
+        (blockElement.nextElementSibling === subListElement)) {
         // 含有子列表的换行
         if (position.end >= editableElement.textContent.length -
             // 数学公式结尾会有 zwsp https://github.com/siyuan-note/siyuan/issues/6679

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -319,15 +319,15 @@ export class WYSIWYG {
                     cellElements.forEach((item: HTMLElement, index) => {
                         const cellText = getCellText(item);
                         if (index === 0 || (
-                            !cellElements[index - 1].isSameNode(item.previousElementSibling) &&
-                            !(item.previousElementSibling?.classList.contains("av__colsticky") && !cellElements[index - 1].nextElementSibling && cellElements[index - 1].parentElement.isSameNode(item.previousElementSibling))
+                            (cellElements[index - 1] !== item.previousElementSibling) &&
+                            !(item.previousElementSibling?.classList.contains("av__colsticky") && !cellElements[index - 1].nextElementSibling && (cellElements[index - 1].parentElement === item.previousElementSibling))
                         )) {
                             html += "[";
                         }
                         html += JSON.stringify(genCellValueByElement(getTypeByCellElement(item), item)) + ",";
                         if (index === cellElements.length - 1 || (
-                            !cellElements[index + 1].isSameNode(item.nextElementSibling) &&
-                            !(!item.nextElementSibling && item.parentElement.nextElementSibling.isSameNode(cellElements[index + 1]))
+                            (cellElements[index + 1] !== item.nextElementSibling) &&
+                            !(!item.nextElementSibling && (item.parentElement.nextElementSibling === cellElements[index + 1]))
                         )) {
                             html = html.substring(0, html.length - 1) + "],";
                             textPlain += cellText + "\n";
@@ -356,12 +356,12 @@ export class WYSIWYG {
                 });
                 selectCellElements.forEach((item, index) => {
                     if (index === 0 || !item.previousElementSibling ||
-                        !item.previousElementSibling.isSameNode(selectCellElements[index - 1])) {
+                        (item.previousElementSibling !== selectCellElements[index - 1])) {
                         html += "<tr>";
                     }
                     html += item.outerHTML;
                     if (!item.nextElementSibling || !selectCellElements[index + 1] ||
-                        !item.nextElementSibling.isSameNode(selectCellElements[index + 1])) {
+                        (item.nextElementSibling !== selectCellElements[index + 1])) {
                         html += "</tr>";
                     }
                 });
@@ -395,7 +395,7 @@ export class WYSIWYG {
                     textPlain = selectImgElement.querySelector("img").getAttribute("data-src");
                 } else if (selectTypes.length > 0 && range.startContainer.nodeType === 3 &&
                     range.startContainer.parentElement.tagName === "SPAN" &&
-                    range.startContainer.parentElement.isSameNode(range.endContainer.parentElement)) {
+                    (range.startContainer.parentElement === range.endContainer.parentElement)) {
                     // 复制粗体等字体中的一部分
                     const attributes = range.startContainer.parentElement.attributes;
                     const spanElement = document.createElement("span");
@@ -507,7 +507,7 @@ export class WYSIWYG {
                         item.classList.add("av__gallery-item--select");
                     });
                     event.preventDefault();
-                } else if (startElement && endElement && !startElement.isSameNode(endElement)) {
+                } else if (startElement && endElement && (startElement !== endElement)) {
                     let toDown = true;
                     const startRect = startElement.getBoundingClientRect();
                     const endRect = endElement.getBoundingClientRect();
@@ -746,7 +746,7 @@ export class WYSIWYG {
                 let lastCellElement: HTMLElement;
                 documentSelf.onmousemove = (moveEvent: MouseEvent) => {
                     const tempCellElement = hasClosestByClassName(moveEvent.target as HTMLElement, "av__cell") as HTMLElement;
-                    if (moveAVCellElement && tempCellElement && tempCellElement.isSameNode(moveAVCellElement)) {
+                    if (moveAVCellElement && tempCellElement && (tempCellElement === moveAVCellElement)) {
                         return;
                     }
                     moveAVCellElement = tempCellElement;
@@ -823,7 +823,7 @@ export class WYSIWYG {
                             protyle.contentElement.scrollTop += 5;
                         }
                     }
-                    if (moveSelectCellElement && tempCellElement && tempCellElement.isSameNode(moveSelectCellElement)) {
+                    if (moveSelectCellElement && tempCellElement && (tempCellElement === moveSelectCellElement)) {
                         return;
                     }
                     if (tempCellElement && tempCellElement.dataset.id && (event.clientX !== moveEvent.clientX || event.clientY !== moveEvent.clientY)) {
@@ -1021,14 +1021,14 @@ export class WYSIWYG {
                         moveTarget.classList.remove("fn__none");
                         moveTarget = hasClosestByTag(pointElement, "TH") || hasClosestByTag(pointElement, "TD");
                     }
-                    if (moveTarget && moveTarget.isSameNode(target)) {
+                    if (moveTarget && (moveTarget === target)) {
                         tableBlockElement.querySelector(".table__select").removeAttribute("style");
                         protyle.wysiwyg.element.classList.remove("protyle-wysiwyg--hiderange");
                         moveCellElement = moveTarget;
                         return false;
                     }
                     if (moveTarget && (moveTarget.tagName === "TH" || moveTarget.tagName === "TD") &&
-                        (!moveCellElement || !moveCellElement.isSameNode(moveTarget))) {
+                        (!moveCellElement || (moveCellElement !== moveTarget))) {
                         // @ts-ignore
                         tableBlockElement.firstElementChild.style.webkitUserModify = "read-only";
                         let width = target.offsetLeft + target.clientWidth - moveTarget.offsetLeft;
@@ -1150,7 +1150,7 @@ export class WYSIWYG {
                 }
                 protyle.selectElement.setAttribute("style", `background-color: ${protyle.selectElement.style.backgroundColor};top:${newTop}px;height:${newHeight}px;left:${newLeft + 2}px;width:${newWidth - 2}px;`);
                 const newMouseElement = document.elementFromPoint(moveEvent.clientX, moveEvent.clientY);
-                if (mouseElement && mouseElement.isSameNode(newMouseElement) && !mouseElement.classList.contains("protyle-wysiwyg") &&
+                if (mouseElement && (mouseElement === newMouseElement) && !mouseElement.classList.contains("protyle-wysiwyg") &&
                     !mouseElement.classList.contains("list") && !mouseElement.classList.contains("bq") && !mouseElement.classList.contains("sb")) {
                     // 性能优化，同一个p元素不进行选中计算
                     return;
@@ -1318,7 +1318,7 @@ export class WYSIWYG {
                                         tableBlockElement.querySelectorAll("th, td").forEach((item: HTMLTableCellElement, index: number) => {
                                             if (item.classList.contains("fn__none")) {
                                                 // 合并的元素中间有 fn__none 的元素
-                                                if (item.previousElementSibling && item.previousElementSibling.isSameNode(selectCellElements[selectCellElements.length - 1])) {
+                                                if (item.previousElementSibling && (item.previousElementSibling === selectCellElements[selectCellElements.length - 1])) {
                                                     selectCellElements.push(item);
                                                     if (!isTHead && item.parentElement.parentElement.tagName === "THEAD") {
                                                         isTHead = true;
@@ -1359,7 +1359,7 @@ export class WYSIWYG {
                                         let cellElement = selectCellElements[0];
                                         let colSpan = cellElement.colSpan;
                                         let index = 1;
-                                        while (cellElement.nextElementSibling && cellElement.nextElementSibling.isSameNode(selectCellElements[index])) {
+                                        while (cellElement.nextElementSibling && (cellElement.nextElementSibling === selectCellElements[index])) {
                                             cellElement = cellElement.nextElementSibling as HTMLTableCellElement;
                                             if (!cellElement.classList.contains("fn__none")) { // https://github.com/siyuan-note/insider/issues/1007#issuecomment-1046195608
                                                 colSpan += cellElement.colSpan;
@@ -1376,7 +1376,7 @@ export class WYSIWYG {
                                             }
                                             html += cellHTML + ((!cellHTML || index === selectCellElements.length - 1) ? "" : "<br>");
                                             if (index !== 0) {
-                                                if (!rowElement.isSameNode(item.parentElement)) {
+                                                if (rowElement !== item.parentElement) {
                                                     if (!item.classList.contains("fn__none")) { // https://github.com/siyuan-note/insider/issues/1011
                                                         rowSpan += item.rowSpan;
                                                     }
@@ -1558,7 +1558,7 @@ export class WYSIWYG {
                                     selectCellElements.forEach((item, index) => {
                                         textPlain += item.textContent.trim() + "\t";
                                         if (!item.nextElementSibling || !selectCellElements[index + 1] ||
-                                            !item.nextElementSibling.isSameNode(selectCellElements[index + 1])) {
+                                            (item.nextElementSibling !== selectCellElements[index + 1])) {
                                             textPlain = textPlain.slice(0, -1) + "\n";
                                         }
                                     });
@@ -1680,7 +1680,7 @@ export class WYSIWYG {
                     } else {
                         endBlockElement = hasClosestBlock(range.endContainer);
                     }
-                    if (startBlockElement && endBlockElement && !endBlockElement.isSameNode(startBlockElement)) {
+                    if (startBlockElement && endBlockElement && (endBlockElement !== startBlockElement)) {
                         if ((range.startContainer.nodeType === 1 && (range.startContainer as HTMLElement).tagName === "DIV" && (range.startContainer as HTMLElement).classList.contains("protyle-attr")) ||
                             event.clientY > mouseUpEvent.clientY) {
                             setFirstNodeRange(getContenteditableElement(endBlockElement), range);
@@ -1711,7 +1711,7 @@ export class WYSIWYG {
                 return;
             }
             const range = getSelection().getRangeAt(0);
-            if (this.element.isSameNode(range.startContainer) || this.element.contains(range.startContainer)) {
+            if ((this.element === range.startContainer) || this.element.contains(range.startContainer)) {
                 protyle.toolbar.range = range;
             }
         });
@@ -1810,12 +1810,12 @@ export class WYSIWYG {
                 nodeElement.setAttribute("updated", dayjs().format("YYYYMMDDHHmmss"));
                 selectCellElements.forEach((item, index) => {
                     if (index === 0 || !item.previousElementSibling ||
-                        !item.previousElementSibling.isSameNode(selectCellElements[index - 1])) {
+                        (item.previousElementSibling !== selectCellElements[index - 1])) {
                         html += "<tr>";
                     }
                     html += item.outerHTML;
                     if (!item.nextElementSibling || !selectCellElements[index + 1] ||
-                        !item.nextElementSibling.isSameNode(selectCellElements[index + 1])) {
+                        (item.nextElementSibling !== selectCellElements[index + 1])) {
                         html += "</tr>";
                     }
                     item.innerHTML = "";
@@ -1840,7 +1840,7 @@ export class WYSIWYG {
                 if (headElement && range.toString() === headElement.firstElementChild.textContent) {
                     tempElement.insertAdjacentHTML("afterbegin", headElement.firstElementChild.innerHTML);
                     headElement.firstElementChild.innerHTML = "";
-                } else if (range.toString() !== "" && startContainer.isSameNode(range.endContainer) &&
+                } else if (range.toString() !== "" && (startContainer === range.endContainer) &&
                     range.startContainer.nodeType === 3 &&
                     // 需使用 wholeText https://github.com/siyuan-note/siyuan/issues/14339
                     range.endOffset === (range.endContainer as Text).wholeText.length &&
@@ -1852,7 +1852,7 @@ export class WYSIWYG {
                     tempElement.append(selectImgElement);
                 } else if (range.startContainer.nodeType === 3 && range.startContainer.parentElement.tagName === "SPAN" &&
                     range.startContainer.parentElement.getAttribute("data-type") &&
-                    range.startContainer.parentElement.isSameNode(range.endContainer.parentElement)) {
+                    (range.startContainer.parentElement === range.endContainer.parentElement)) {
                     // 剪切粗体等字体中的一部分
                     const spanElement = range.startContainer.parentElement;
                     const attributes = spanElement.attributes;
@@ -2486,10 +2486,10 @@ export class WYSIWYG {
                 if (item.tagName !== "DIV") {
                     return;
                 }
-                if (!tableElement || !item.isSameNode(tableElement)) {
+                if (!tableElement || (item !== tableElement)) {
                     item.querySelector(".table__select").removeAttribute("style");
                 }
-                if (tableElement && tableElement.isSameNode(item) && item.querySelector(".table__select").getAttribute("style")) {
+                if (tableElement && (tableElement === item) && item.querySelector(".table__select").getAttribute("style")) {
                     // 防止合并单元格的菜单消失
                     event.stopPropagation();
                 }

--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -115,7 +115,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
 
         // https://ld246.com/article/1694506408293
         const endElement = hasClosestBlock(range.endContainer);
-        if (!matchHotKey("⌘C", event) && endElement && !nodeElement.isSameNode(endElement)) {
+        if (!matchHotKey("⌘C", event) && endElement && (nodeElement !== endElement)) {
             event.stopPropagation();
             event.preventDefault();
             return;
@@ -540,7 +540,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                 centerElement = document.elementFromPoint(contentRect.x + contentRect.width / 2, contentRect.y + contentRect.height / 2 + Constants.SIZE_TOOLBAR_HEIGHT);
             }
             const centerBlockElement = hasClosestBlock(centerElement);
-            if (centerBlockElement && !centerBlockElement.isSameNode(nodeElement)) {
+            if (centerBlockElement && (centerBlockElement !== nodeElement)) {
                 focusBlock(centerBlockElement, undefined, false);
             }
             event.stopPropagation();
@@ -594,7 +594,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                         return;
                     } else if (!previousSibling &&
                         range.startContainer.parentElement.previousSibling &&
-                        range.startContainer.parentElement.previousSibling.isSameNode(range.startContainer.parentElement.previousElementSibling) &&
+                        (range.startContainer.parentElement.previousSibling === range.startContainer.parentElement.previousElementSibling) &&
                         range.startContainer.parentElement.previousElementSibling.getAttribute("data-type")?.indexOf("inline-math") > -1
                     ) {
                         inlineMathMenu(protyle, range.startContainer.parentElement.previousElementSibling);
@@ -649,7 +649,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                         !getPreviousBlock(nodeElement) &&  // 列表第一个块为嵌入块，第二个块为段落块，上键应选中第一个块 https://ld246.com/article/1652667912155
                         nodeElement.contains(firstEditElement)
                     ) ||
-                    (!firstEditElement && nodeElement.isSameNode(protyle.wysiwyg.element.firstElementChild))) {
+                    (!firstEditElement && (nodeElement === protyle.wysiwyg.element.firstElementChild))) {
                     // 不能用\n判断，否则文字过长折行将错误 https://github.com/siyuan-note/siyuan/issues/6156
                     if (getSelectionPosition(nodeEditableElement, range).top - nodeEditableElement.getBoundingClientRect().top < 20 || nodeElement.classList.contains("av")) {
                         if (protyle.title && protyle.title.editElement &&
@@ -704,7 +704,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                         }
                     }
                 }
-            } else if (selectText === "" && (event.key === "ArrowDown" || event.key === "ArrowRight") && nodeElement.isSameNode(getLastBlock(protyle.wysiwyg.element.lastElementChild)) &&
+            } else if (selectText === "" && (event.key === "ArrowDown" || event.key === "ArrowRight") && (nodeElement === getLastBlock(protyle.wysiwyg.element.lastElementChild)) &&
                 // 表格无法右移动 https://ld246.com/article/1631434502215
                 !hasClosestByTag(range.startContainer, "TD") && !hasClosestByTag(range.startContainer, "TH")) {
                 // 页面按向下/右箭头丢失焦点 https://ld246.com/article/1629954026096
@@ -715,7 +715,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                     event.preventDefault();
                     focusByRange(range);
                 }
-            } else if (selectText === "" && event.key === "ArrowLeft" && nodeElement.isSameNode(getFirstBlock(protyle.wysiwyg.element.firstElementChild))) {
+            } else if (selectText === "" && event.key === "ArrowLeft" && (nodeElement === getFirstBlock(protyle.wysiwyg.element.firstElementChild))) {
                 // 页面向左箭头丢失焦点 https://github.com/siyuan-note/siyuan/issues/2768
                 const firstEditElement = getContenteditableElement(nodeElement);
                 if (firstEditElement && getSelectionOffset(firstEditElement, undefined, range).start === 0) {
@@ -726,7 +726,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
             }
             if (event.key === "ArrowDown") {
                 if (nodeEditableElement?.innerText.trimRight().substr(position.start).indexOf("\n") === -1 &&
-                    nodeElement.isSameNode(protyle.wysiwyg.element.lastElementChild)) {
+                    (nodeElement === protyle.wysiwyg.element.lastElementChild)) {
                     setLastNodeRange(getContenteditableElement(nodeEditableElement), range, false);
                     range.collapse(false);
                     event.stopPropagation();
@@ -1465,7 +1465,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                 let isContinuous = true;
                 selectElements.forEach((item, index) => {
                     if (item.nextElementSibling && selectElements[index + 1]) {
-                        if (!selectElements[index + 1].isSameNode(item.nextElementSibling)) {
+                        if (selectElements[index + 1] !== item.nextElementSibling) {
                             isContinuous = false;
                         }
                     }
@@ -1491,7 +1491,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                 let isContinuous = true;
                 selectElements.forEach((item, index) => {
                     if (item.nextElementSibling && selectElements[index + 1]) {
-                        if (!selectElements[index + 1].isSameNode(item.nextElementSibling)) {
+                        if (selectElements[index + 1] !== item.nextElementSibling) {
                             isContinuous = false;
                         }
                     }
@@ -1580,7 +1580,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                         return true;
                     }
                     if (item.nextElementSibling && selectsElement[index + 1] &&
-                        item.nextElementSibling.isSameNode(selectsElement[index + 1])) {
+                        (item.nextElementSibling === selectsElement[index + 1])) {
                         isContinue = true;
                     } else if (index !== selectsElement.length - 1) {
                         isContinue = false;
@@ -1807,7 +1807,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                     if (snippetClassName.startsWith("language-")) {
                         language = snippetClassName.replace("language-", "");
                         // https://github.com/siyuan-note/siyuan/issues/14767
-                        if (!wbrElement.parentElement.isSameNode(range.commonAncestorContainer)) {
+                        if (wbrElement.parentElement !== range.commonAncestorContainer) {
                             wbrElement.parentElement.after(wbrElement);
                             wbrElement.previousElementSibling.remove();
                         }

--- a/app/src/protyle/wysiwyg/list.ts
+++ b/app/src/protyle/wysiwyg/list.ts
@@ -228,7 +228,7 @@ export const breakList = (protyle: IProtyle, blockElement: Element, range: Range
     let newListHTML = "";
     let hasFind = 0;
     Array.from(listItemElement.parentElement.children).forEach(item => {
-        if (!hasFind && item.isSameNode(listItemElement)) {
+        if (!hasFind && (item === listItemElement)) {
             hasFind = 1;
         } else if (hasFind && !item.classList.contains("protyle-attr")) {
             undoOperations.push({

--- a/app/src/protyle/wysiwyg/remove.ts
+++ b/app/src/protyle/wysiwyg/remove.ts
@@ -202,7 +202,7 @@ export const removeBlock = async (protyle: IProtyle, blockElement: Element, rang
                 if (backLinkTab instanceof Tab && backLinkTab.model instanceof Backlink) {
                     const editors = backLinkTab.model.editors;
                     editors.find((item, index) => {
-                        if (item.protyle.element.isSameNode(protyle.element)) {
+                        if (item.protyle.element === protyle.element) {
                             item.destroy();
                             editors.splice(index, 1);
                             item.protyle.element.previousElementSibling.remove();

--- a/app/src/protyle/wysiwyg/transaction.ts
+++ b/app/src/protyle/wysiwyg/transaction.ts
@@ -26,7 +26,7 @@ const removeTopElement = (updateElement: Element, protyle: IProtyle) => {
     // TODO 文档没有打开时，需要通过后台获取 getTopAloneElement
     const topAloneElement = getTopAloneElement(updateElement);
     const doOperations: IOperation[] = [];
-    if (!topAloneElement.isSameNode(updateElement)) {
+    if (topAloneElement !== updateElement) {
         updateElement.remove();
         doOperations.push({
             action: "delete",
@@ -104,7 +104,7 @@ const promiseTransaction = () => {
                     // 反链中有多个相同块的情况
                     Array.from(protyle.wysiwyg.element.querySelectorAll(`[data-node-id="${operation.id}"]`)).forEach(item => {
                         if (!isInEmbedBlock(item)) {
-                            if (range && (item.isSameNode(range.startContainer) || item.contains(range.startContainer))) {
+                            if (range && ((item === range.startContainer) || item.contains(range.startContainer))) {
                                 // 正在编辑的块不能进行更新
                             } else {
                                 item.outerHTML = operation.data.replace("<wbr>", "");
@@ -1026,7 +1026,7 @@ export const turnsIntoTransaction = (options: {
                 hasEmbedBlock = true;
             }
             if (item.nextElementSibling && selectsElement[index + 1] &&
-                item.nextElementSibling.isSameNode(selectsElement[index + 1])) {
+                (item.nextElementSibling === selectsElement[index + 1])) {
                 isContinue = true;
             } else if (index !== selectsElement.length - 1) {
                 isContinue = false;
@@ -1092,7 +1092,7 @@ export const turnsIntoTransaction = (options: {
                     action: "delete",
                     id,
                 });
-                if (item.isSameNode(selectsElement[index + 1]?.previousElementSibling)) {
+                if (item === selectsElement[index + 1]?.previousElementSibling) {
                     previousId = id;
                 } else {
                     previousId = undefined;

--- a/app/src/search/util.ts
+++ b/app/src/search/util.ts
@@ -337,7 +337,7 @@ export const genSearch = (app: App, config: Config.IUILayoutTabSearchConfig, ele
     element.addEventListener("click", (event: MouseEvent) => {
         let target = event.target as HTMLElement;
         const searchPathInputElement = element.querySelector("#searchPathInput");
-        while (target && !target.isSameNode(element)) {
+        while (target && (target !== element)) {
             const type = target.getAttribute("data-type");
             if (type === "removeCriterion") {
                 updateConfig(element, {

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -563,7 +563,7 @@ export const movePathTo = (cb: (toPath: string[], toNotebook: string[]) => void,
                     return;
                 }
                 if (title === window.siyuan.languages.specifyPath && isOnlyMeta(event)) {
-                    if (currentItemElements.length === 1 && currentItemElements[0].isSameNode(target)) {
+                    if (currentItemElements.length === 1 && (currentItemElements[0] === target)) {
                         // 至少需选中一个
                     } else {
                         target.classList.toggle("b3-list-item--focus");


### PR DESCRIPTION
Replace the deprecated `isSameNode` method in DOM Level 4 with the `===` operator

https://developer.mozilla.org/zh-CN/docs/Web/API/Node/isSameNode