### PR TITLE
Improve the style of the snackbar

### DIFF
--- a/app/src/assets/scss/component/_snackbar.scss
+++ b/app/src/assets/scss/component/_snackbar.scss
@@ -24,6 +24,11 @@
     flex-direction: column;
     transform: translate3d(calc(20vw + 48px), 0, 0);
     transition: transform .15s cubic-bezier(.4, 0, 1, 1) 0ms;
+    pointer-events: none;
+
+    * {
+      pointer-events: auto;
+    }
 
     &--show {
       transform: translate3d(0, 0, 0) !important;

--- a/app/src/assets/scss/component/_snackbar.scss
+++ b/app/src/assets/scss/component/_snackbar.scss
@@ -1,10 +1,13 @@
 .b3-snackbar {
-  margin-bottom: 16px;
   position: relative;
   transition: transform 256ms cubic-bezier(.45, .05, .55, .95) 0ms;
   text-align: right;
   justify-self: end;
   font-size: var(--b3-font-size);
+
+  &:not(:first-child) {
+    margin-top: 16px;
+  }
 
   &--hide {
     transform: translate3d(calc(20vw + 48px), 0, 0);
@@ -16,6 +19,7 @@
     top: 22px;
     // 不能设置死，否则右键菜单会被遮盖 z-index: 999999;
     max-height: calc(100vh - 32px);
+    margin: 0 18px;
     display: flex;
     flex-direction: column;
     transform: translate3d(calc(20vw + 48px), 0, 0);
@@ -27,15 +31,11 @@
 
     & > .b3-button {
       align-self: flex-end;
-      margin-right: 18px;
+      margin-top: 16px;
     }
 
-    & > .fn__flex-1 {
-      padding: 0 18px 0 18px;
-
-      &::-webkit-scrollbar {
-        display: none;
-      }
+    & > .fn__flex-1::-webkit-scrollbar {
+      display: none;
     }
   }
 


### PR DESCRIPTION
有时候弹出消息之后，虽然下方的按钮还露出来一点点，但就是无法点击：

<img width="718" height="272" alt="image" src="https://github.com/user-attachments/assets/26f94348-e554-400e-a14c-74e0ed0f7980" />

然后我发现目前的样式会使消息的下方出现一块看不见的无法点击的区域：

<img width="442" height="239" alt="image" src="https://github.com/user-attachments/assets/4dc82ab2-00bc-4624-b4f0-1d62916c7f5d" />

修改之后：

<img width="449" height="207" alt="image" src="https://github.com/user-attachments/assets/5364c4f9-c930-4396-beff-22afa1a49e7e" />

<img width="515" height="274" alt="image" src="https://github.com/user-attachments/assets/7245c0d2-3712-4554-81f1-440cae77784b" />

