### PR TITLE
Improve the style of exporting PDF

### DIFF
--- a/app/src/protyle/export/index.ts
+++ b/app/src/protyle/export/index.ts
@@ -85,7 +85,7 @@ const getSnippetCSS = () => {
     let snippetCSS = "";
     document.querySelectorAll("style").forEach((item) => {
         if (item.id.startsWith("snippet")) {
-            snippetCSS += item.innerHTML;
+            snippetCSS += item.outerHTML;
         }
     });
     return snippetCSS;
@@ -182,8 +182,8 @@ const renderPDF = async (id: string) => {
         }
         ${await setInlineStyle(false)}
         ${await getPluginStyle()}
-        ${getSnippetCSS()}
     </style>
+    ${getSnippetCSS()}
 </head>
 <body style="-webkit-print-color-adjust: exact;">
 <div id="action">
@@ -676,8 +676,8 @@ const onExport = async (data: IWebSocketData, filePath: string, exportOption: IE
         body {font-family: var(--b3-font-family);background-color: var(--b3-theme-background);color: var(--b3-theme-on-background)}
         ${await setInlineStyle(false)}
         ${await getPluginStyle()}
-        ${getSnippetCSS()}
     </style>
+    ${getSnippetCSS()}
 </head>
 <body>
 <div class="${["htmlmd", "word"].includes(exportOption.type) ? "b3-typography" : "protyle-wysiwyg" + (window.siyuan.config.editor.displayBookmarkIcon ? " protyle-wysiwyg--attr" : "")}" 


### PR DESCRIPTION
导出 PDF 时，如果其中一个 CSS 代码片段有语法错误，则该 CSS 之后的所有 CSS 都无法生效，导致了这个问题：https://github.com/siyuan-note/siyuan/issues/15016#issuecomment-2965557301

因此改成每个 CSS 片段使用一个 style 元素