### PR TITLE
Filter hidden columns when browsing the current view image of a database table

### DIFF
--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -1826,9 +1826,14 @@ func GetCurrentAttributeViewImages(avID, viewID, query string) (ret []string, er
 	av.Filter(table, attrView)
 	av.Sort(table, attrView)
 
+	ids:= map[string]bool{}
+	for _, column := range table.Columns { 
+		ids[column.ID] = column.Hidden
+	}
+
 	for _, row := range table.Rows {
 		for _, cell := range row.Cells {
-			if nil != cell.Value && av.KeyTypeMAsset == cell.Value.Type && nil != cell.Value.MAsset {
+			if nil != cell.Value && av.KeyTypeMAsset == cell.Value.Type && nil != cell.Value.MAsset && !ids[cell.Value.KeyID]{
 				for _, a := range cell.Value.MAsset {
 					if av.AssetTypeImage == a.Type {
 						ret = append(ret, a.Content)


### PR DESCRIPTION
浏览数据库表格当前视图图片时过滤隐藏列

希望支持，因为既然把列过滤了，肯定是不想看到这列的内容
