### PR TITLE
Improve font appearance menu

### DIFF
--- a/app/src/assets/scss/business/_color.scss
+++ b/app/src/assets/scss/business/_color.scss
@@ -15,7 +15,7 @@
   border-radius: var(--b3-border-radius);
   font-size: 16px;
   font-weight: 500;
-  color: var(--b3-theme-on-background);
+  color: var(--b3-color-text, --b3-theme-on-background);
 
   &--list {
     margin: 0 8px 0 0;

--- a/app/src/mobile/util/keyboardToolbar.ts
+++ b/app/src/mobile/util/keyboardToolbar.ts
@@ -64,7 +64,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     let lastColorHTML = "";
     const lastFonts = window.siyuan.storage[Constants.LOCAL_FONTSTYLES];
     if (lastFonts.length > 0) {
-        lastColorHTML = `<div class="keyboard__slash-title">
+        lastColorHTML = `<div data-id="lastUsed" class="keyboard__slash-title">
     ${window.siyuan.languages.lastUsed}
 </div>
 <div class="keyboard__slash-block">`;
@@ -137,7 +137,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     }
     const utilElement = toolbarElement.querySelector(".keyboard__util") as HTMLElement;
     utilElement.innerHTML = `${lastColorHTML}
-<div class="keyboard__slash-title">${window.siyuan.languages.color}</div>
+<div data-id="color" class="keyboard__slash-title">${window.siyuan.languages.color}</div>
 <div class="keyboard__slash-block">
     <button class="keyboard__slash-item" data-type="style1">
         <span class="keyboard__slash-icon">A</span>
@@ -160,15 +160,15 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
         <span class="keyboard__slash-text">${window.siyuan.languages.successStyle}</span>
     </button>
 </div>
-<div class="keyboard__slash-title">${window.siyuan.languages.colorFont}</div>
+<div data-id="colorFont" class="keyboard__slash-title">${window.siyuan.languages.colorFont}</div>
 <div class="keyboard__slash-block">
     ${colorHTML}
 </div>
-<div class="keyboard__slash-title">${window.siyuan.languages.colorPrimary}</div>
+<div data-id="colorPrimary" class="keyboard__slash-title">${window.siyuan.languages.colorPrimary}</div>
 <div class="keyboard__slash-block">
     ${bgHTML}
 </div>
-<div class="keyboard__slash-title">${window.siyuan.languages.fontStyle}</div>
+<div data-id="fontStyle" class="keyboard__slash-title">${window.siyuan.languages.fontStyle}</div>
 <div class="keyboard__slash-block">
     <button class="keyboard__slash-item" data-type="style2">
         <span class="keyboard__slash-text" style="-webkit-text-stroke: 0.2px var(--b3-theme-on-background);-webkit-text-fill-color : transparent;">${window.siyuan.languages.hollow}</span>
@@ -181,7 +181,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
         <span class="keyboard__slash-text">${window.siyuan.languages.clearFontStyle}</span>
     </button>
 </div>
-<div class="keyboard__slash-title${disableFont ? " fn__none" : ""}">${window.siyuan.languages.fontSize}</div>
+<div data-id="fontSize" class="keyboard__slash-title${disableFont ? " fn__none" : ""}">${window.siyuan.languages.fontSize}</div>
 <div class="keyboard__slash-block${disableFont ? " fn__none" : ""}">
     <select class="b3-select fn__block" style="width: calc(50% - 8px);margin: 4px 0 8px 0;">
         <option ${fontSize === "12px" ? "selected" : ""} value="12px">12px</option>

--- a/app/src/mobile/util/keyboardToolbar.ts
+++ b/app/src/mobile/util/keyboardToolbar.ts
@@ -124,6 +124,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     }
     let textElement: HTMLElement;
     let fontSize = "16px";
+    let textColor: string;
     if (nodeElements && nodeElements.length > 0) {
         textElement = nodeElements[0] as HTMLElement;
     } else {
@@ -134,6 +135,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     }
     if (textElement) {
         fontSize = textElement.style.fontSize || "16px";
+        textColor = textElement.style.color;
     }
     const utilElement = toolbarElement.querySelector(".keyboard__util") as HTMLElement;
     utilElement.innerHTML = `${lastColorHTML}
@@ -165,7 +167,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     ${colorHTML}
 </div>
 <div data-id="colorPrimary" class="keyboard__slash-title">${window.siyuan.languages.colorPrimary}</div>
-<div data-id="colorPrimaryWrap" class="keyboard__slash-block">
+<div data-id="colorPrimaryWrap" class="keyboard__slash-block"${textColor ? ` style="--b3-color-text: ${textColor};"` : ""}>
     ${bgHTML}
 </div>
 <div data-id="fontStyle" class="keyboard__slash-title">${window.siyuan.languages.fontStyle}</div>
@@ -561,14 +563,17 @@ export const initKeyboardToolbar = () => {
         if (["clear", "style2", "style4", "color", "backgroundColor", "fontSize", "style1"].includes(type)) {
             const nodeElements = getFontNodeElements(protyle);
             const itemElement = buttonElement.firstElementChild as HTMLElement;
+            const colorPrimaryWrap = toolbarElement.querySelector("[data-id='colorPrimaryWrap']") as HTMLElement;
             if (type === "style1") {
                 fontEvent(protyle, nodeElements, type, itemElement.style.backgroundColor + Constants.ZWSP + itemElement.style.color);
+                colorPrimaryWrap.style.setProperty("--b3-color-text", itemElement.style.color);
             } else if (type === "fontSize") {
                 fontEvent(protyle, nodeElements, type, itemElement.textContent.trim());
             } else if (type === "backgroundColor") {
                 fontEvent(protyle, nodeElements, type, itemElement.style.backgroundColor);
             } else if (type === "color") {
                 fontEvent(protyle, nodeElements, type, itemElement.style.color);
+                colorPrimaryWrap.style.setProperty("--b3-color-text", itemElement.style.color);
             } else {
                 fontEvent(protyle, nodeElements, type);
             }

--- a/app/src/mobile/util/keyboardToolbar.ts
+++ b/app/src/mobile/util/keyboardToolbar.ts
@@ -67,7 +67,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
         lastColorHTML = `<div data-id="lastUsed" class="keyboard__slash-title">
     ${window.siyuan.languages.lastUsed}
 </div>
-<div class="keyboard__slash-block">`;
+<div data-id="lastUsedWrap" class="keyboard__slash-block">`;
         lastFonts.forEach((item: string) => {
             const lastFontStatus = item.split(Constants.ZWSP);
             switch (lastFontStatus[0]) {
@@ -138,7 +138,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     const utilElement = toolbarElement.querySelector(".keyboard__util") as HTMLElement;
     utilElement.innerHTML = `${lastColorHTML}
 <div data-id="color" class="keyboard__slash-title">${window.siyuan.languages.color}</div>
-<div class="keyboard__slash-block">
+<div data-id="colorWrap" class="keyboard__slash-block">
     <button class="keyboard__slash-item" data-type="style1">
         <span class="keyboard__slash-icon">A</span>
         <span class="keyboard__slash-text">${window.siyuan.languages.color} ${window.siyuan.languages.default}</span>
@@ -161,15 +161,15 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     </button>
 </div>
 <div data-id="colorFont" class="keyboard__slash-title">${window.siyuan.languages.colorFont}</div>
-<div class="keyboard__slash-block">
+<div data-id="colorFontWrap" class="keyboard__slash-block">
     ${colorHTML}
 </div>
 <div data-id="colorPrimary" class="keyboard__slash-title">${window.siyuan.languages.colorPrimary}</div>
-<div class="keyboard__slash-block">
+<div data-id="colorPrimaryWrap" class="keyboard__slash-block">
     ${bgHTML}
 </div>
 <div data-id="fontStyle" class="keyboard__slash-title">${window.siyuan.languages.fontStyle}</div>
-<div class="keyboard__slash-block">
+<div data-id="fontStyleWrap" class="keyboard__slash-block">
     <button class="keyboard__slash-item" data-type="style2">
         <span class="keyboard__slash-text" style="-webkit-text-stroke: 0.2px var(--b3-theme-on-background);-webkit-text-fill-color : transparent;">${window.siyuan.languages.hollow}</span>
     </button>
@@ -182,7 +182,7 @@ export const renderTextMenu = (protyle: IProtyle, toolbarElement: Element) => {
     </button>
 </div>
 <div data-id="fontSize" class="keyboard__slash-title${disableFont ? " fn__none" : ""}">${window.siyuan.languages.fontSize}</div>
-<div class="keyboard__slash-block${disableFont ? " fn__none" : ""}">
+<div data-id="fontSizeWrap" class="keyboard__slash-block${disableFont ? " fn__none" : ""}">
     <select class="b3-select fn__block" style="width: calc(50% - 8px);margin: 4px 0 8px 0;">
         <option ${fontSize === "12px" ? "selected" : ""} value="12px">12px</option>
         <option ${fontSize === "13px" ? "selected" : ""} value="13px">13px</option>

--- a/app/src/protyle/toolbar/Font.ts
+++ b/app/src/protyle/toolbar/Font.ts
@@ -43,7 +43,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
         "var(--b3-font-background5)", "var(--b3-font-background6)", "var(--b3-font-background7)", "var(--b3-font-background8)",
         "var(--b3-font-background9)", "var(--b3-font-background10)", "var(--b3-font-background11)", "var(--b3-font-background12)",
         "var(--b3-font-background13)"].forEach((item) => {
-        bgHTML += `<button ${item ? `class="color__square" style="background-color:${item}"` : `class="color__square ariaLabel" data-position="3south" aria-label="${window.siyuan.languages.default}"`} data-type="backgroundColor"></button>`;
+        bgHTML += `<button ${item ? `class="color__square" style="background-color:${item}"` : `class="color__square ariaLabel" data-position="3south" aria-label="${window.siyuan.languages.default}"`} data-type="backgroundColor">A</button>`;
     });
 
     const element = document.createElement("div");

--- a/app/src/protyle/toolbar/Font.ts
+++ b/app/src/protyle/toolbar/Font.ts
@@ -97,6 +97,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     }
     let textElement: HTMLElement;
     let fontSize = window.siyuan.config.editor.fontSize + "px";
+    let textColor: string;
     if (nodeElements && nodeElements.length > 0) {
         textElement = nodeElements[0] as HTMLElement;
     } else {
@@ -107,6 +108,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     }
     if (textElement) {
         fontSize = textElement.style.fontSize || window.siyuan.config.editor.fontSize + "px";
+        textColor = textElement.style.color;
     }
     element.innerHTML = `${lastColorHTML}
 <div class="fn__hr"></div>
@@ -128,7 +130,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
 <div class="fn__hr"></div>
 <div data-id="colorPrimary">${window.siyuan.languages.colorPrimary}</div>
 <div class="fn__hr--small"></div>
-<div data-id="colorPrimaryWrap" class="fn__flex fn__flex-wrap">
+<div data-id="colorPrimaryWrap" class="fn__flex fn__flex-wrap"${textColor ? ` style="--b3-color-text: ${textColor};"` : ""}>
     ${bgHTML}
 </div>
 <div class="fn__hr"></div>
@@ -166,6 +168,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     </button>
     <div class="fn__space--small"></div>
 </div>`;
+    const colorPrimaryWrap = element.querySelector("[data-id='colorPrimaryWrap']") as HTMLElement;
     element.addEventListener("click", function (event: Event) {
         let target = event.target as HTMLElement;
         while (target && !target.isEqualNode(element)) {
@@ -173,12 +176,14 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
             if (target.tagName === "BUTTON") {
                 if (dataType === "style1") {
                     fontEvent(protyle, nodeElements, dataType, target.style.backgroundColor + Constants.ZWSP + target.style.color);
+                    colorPrimaryWrap.style.setProperty("--b3-color-text", target.style.color);
                 } else if (dataType === "fontSize") {
                     fontEvent(protyle, nodeElements, dataType, target.textContent.trim());
                 } else if (dataType === "backgroundColor") {
                     fontEvent(protyle, nodeElements, dataType, target.style.backgroundColor);
                 } else if (dataType === "color") {
                     fontEvent(protyle, nodeElements, dataType, target.style.color);
+                    colorPrimaryWrap.style.setProperty("--b3-color-text", target.style.color);
                 } else {
                     fontEvent(protyle, nodeElements, dataType);
                 }

--- a/app/src/protyle/toolbar/Font.ts
+++ b/app/src/protyle/toolbar/Font.ts
@@ -64,7 +64,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     <kbd class="fn__kbd fn__flex-center${window.siyuan.config.keymap.editor.insert.lastUsed.custom ? "" : " fn__none"}">${updateHotkeyTip(window.siyuan.config.keymap.editor.insert.lastUsed.custom)}</kbd>
 </div>
 <div class="fn__hr--small"></div>
-<div class="fn__flex fn__flex-wrap" style="align-items: center">`;
+<div data-id="lastUsedWrap" class="fn__flex fn__flex-wrap" style="align-items: center">`;
         lastFonts.forEach((item: string) => {
             const lastFontStatus = item.split(Constants.ZWSP);
             switch (lastFontStatus[0]) {
@@ -112,7 +112,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
 <div class="fn__hr"></div>
 <div data-id="color">${window.siyuan.languages.color}</div>
 <div class="fn__hr--small"></div>
-<div class="fn__flex fn__flex-wrap">
+<div data-id="colorWrap" class="fn__flex fn__flex-wrap">
     <button class="color__square ariaLabel" data-position="3south" data-type="style1" aria-label="${window.siyuan.languages.default}">A</button>
     <button class="color__square" data-type="style1" style="color: var(--b3-card-error-color);background-color: var(--b3-card-error-background);">A</button>
     <button class="color__square" data-type="style1" style="color: var(--b3-card-warning-color);background-color: var(--b3-card-warning-background);">A</button>
@@ -122,19 +122,19 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
 <div class="fn__hr"></div>
 <div data-id="colorFont">${window.siyuan.languages.colorFont}</div>
 <div class="fn__hr--small"></div>
-<div class="fn__flex fn__flex-wrap">
+<div data-id="colorFontWrap" class="fn__flex fn__flex-wrap">
     ${colorHTML}
 </div>
 <div class="fn__hr"></div>
 <div data-id="colorPrimary">${window.siyuan.languages.colorPrimary}</div>
 <div class="fn__hr--small"></div>
-<div class="fn__flex fn__flex-wrap">
+<div data-id="colorPrimaryWrap" class="fn__flex fn__flex-wrap">
     ${bgHTML}
 </div>
 <div class="fn__hr"></div>
 <div data-id="fontStyle">${window.siyuan.languages.fontStyle}</div>
 <div class="fn__hr--small"></div>
-<div class="fn__flex">
+<div data-id="fontStyleWrap" class="fn__flex">
     <button data-type="style2" class="protyle-font__style" style="-webkit-text-stroke: 0.2px var(--b3-theme-on-background);-webkit-text-fill-color : transparent;">${window.siyuan.languages.hollow}</button>
     <button data-type="style4" class="protyle-font__style" style="text-shadow: 1px 1px var(--b3-theme-surface-lighter), 2px 2px var(--b3-theme-surface-lighter), 3px 3px var(--b3-theme-surface-lighter), 4px 4px var(--b3-theme-surface-lighter)">${window.siyuan.languages.shadow}</button>
 </div>
@@ -149,7 +149,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
         <span class="fn__space--small"></span>
     </label>
 </div>
-<div class="${disableFont ? " fn__none" : ""}">
+<div data-id="fontSizeWrap" class="${disableFont ? " fn__none" : ""}">
     <div class="fn__hr"></div>
     <div class="b3-tooltips b3-tooltips__n fn__flex${fontSize.endsWith("em") ? " fn__none" : ""}" aria-label="${fontSize}">   
         <input class="b3-slider fn__block" id="fontSizePX" max="72" min="9" step="1" type="range" value="${parseInt(fontSize)}">

--- a/app/src/protyle/toolbar/Font.ts
+++ b/app/src/protyle/toolbar/Font.ts
@@ -58,7 +58,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     let lastColorHTML = "";
     const lastFonts = window.siyuan.storage[Constants.LOCAL_FONTSTYLES];
     if (lastFonts.length > 0) {
-        lastColorHTML = `<div class="fn__flex">
+        lastColorHTML = `<div data-id="lastUsed" class="fn__flex">
     ${window.siyuan.languages.lastUsed}
     <span class="fn__space"></span>
     <kbd class="fn__kbd fn__flex-center${window.siyuan.config.keymap.editor.insert.lastUsed.custom ? "" : " fn__none"}">${updateHotkeyTip(window.siyuan.config.keymap.editor.insert.lastUsed.custom)}</kbd>
@@ -110,7 +110,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     }
     element.innerHTML = `${lastColorHTML}
 <div class="fn__hr"></div>
-<div>${window.siyuan.languages.color}</div>
+<div data-id="color">${window.siyuan.languages.color}</div>
 <div class="fn__hr--small"></div>
 <div class="fn__flex fn__flex-wrap">
     <button class="color__square ariaLabel" data-position="3south" data-type="style1" aria-label="${window.siyuan.languages.default}">A</button>
@@ -120,26 +120,26 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     <button class="color__square" data-type="style1" style="color: var(--b3-card-success-color);background-color: var(--b3-card-success-background);">A</button>
 </div>
 <div class="fn__hr"></div>
-<div>${window.siyuan.languages.colorFont}</div>
+<div data-id="colorFont">${window.siyuan.languages.colorFont}</div>
 <div class="fn__hr--small"></div>
 <div class="fn__flex fn__flex-wrap">
     ${colorHTML}
 </div>
 <div class="fn__hr"></div>
-<div>${window.siyuan.languages.colorPrimary}</div>
+<div data-id="colorPrimary">${window.siyuan.languages.colorPrimary}</div>
 <div class="fn__hr--small"></div>
 <div class="fn__flex fn__flex-wrap">
     ${bgHTML}
 </div>
 <div class="fn__hr"></div>
-<div>${window.siyuan.languages.fontStyle}</div>
+<div data-id="fontStyle">${window.siyuan.languages.fontStyle}</div>
 <div class="fn__hr--small"></div>
 <div class="fn__flex">
     <button data-type="style2" class="protyle-font__style" style="-webkit-text-stroke: 0.2px var(--b3-theme-on-background);-webkit-text-fill-color : transparent;">${window.siyuan.languages.hollow}</button>
     <button data-type="style4" class="protyle-font__style" style="text-shadow: 1px 1px var(--b3-theme-surface-lighter), 2px 2px var(--b3-theme-surface-lighter), 3px 3px var(--b3-theme-surface-lighter), 4px 4px var(--b3-theme-surface-lighter)">${window.siyuan.languages.shadow}</button>
 </div>
 <div class="fn__hr${disableFont ? " fn__none" : ""}"></div>
-<div class="fn__flex${disableFont ? " fn__none" : ""}">
+<div data-id="fontSize" class="fn__flex${disableFont ? " fn__none" : ""}">
     ${window.siyuan.languages.fontSize}
     <span class="fn__flex-1"></span>
     <label class="fn__flex">
@@ -159,7 +159,7 @@ export const appearanceMenu = (protyle: IProtyle, nodeElements?: Element[]) => {
     </div>
 </div>
 <div class="fn__hr--b"></div>
-<div class="fn__flex">
+<div data-id="clearFontStyle" class="fn__flex">
     <div class="fn__space--small"></div>
     <button class="b3-button b3-button--remove fn__block" data-type="clear">
         <svg><use xlink:href="#iconTrashcan"></use></svg>${window.siyuan.languages.clearFontStyle}


### PR DESCRIPTION
### 01

Close https://github.com/siyuan-note/siyuan/issues/15604

例如使用以下 CSS 片段，在明亮主题给选中文本设置特定背景色时，同时应用特定的文本颜色：

```css
.protyle-wysiwyg [data-node-id] span[style*="background-color: var(--b3-font-background13)"],
.color__square[style*="--b3-font-background13"] {
  background-color: rgb(0 0 0);
  color: var(--b3-color-text, rgb(249 255 0));
}
```

原本只能知道会设置成什么背景颜色：

<img width="506" height="268" alt="image" src="https://github.com/user-attachments/assets/20da09cb-f705-4565-b62b-e097854c3c3c" />

现在能同时知道背景颜色和文本颜色：

<img width="528" height="270" alt="image" src="https://github.com/user-attachments/assets/aa92b471-0b82-49e1-b01e-cf913d27ca15" />

同时也与移动端保持一致：

https://github.com/siyuan-note/siyuan/blob/a37e23bf5f9870f6ad0e3f5e2a0583052270931f/app/src/mobile/util/keyboardToolbar.ts#L50

![f83e4654475089411c0f3dd89cbc7a75](https://github.com/user-attachments/assets/82ae4808-8e81-4f2a-a342-5ccdc379aab6)

### 02

给一些元素添加 data-id 属性，便于主题样式定位元素

### 03

有时候要设置了背景色之后才发现跟文本的颜色对比度不太够，然后重新设置。

实现了动态显示选中文本的颜色，方便判断设置背景色之后的真实效果：

[video.webm](https://github.com/user-attachments/assets/9af86394-ea6b-403e-830c-973be530bd6c)

p.s. 设置文本颜色的那部分按钮需不需要也实现动态的背景色？