### PR TITLE
Add plugin event bus `code-language-update` and `code-language-change`

### DIFF
--- a/app/src/protyle/toolbar/index.ts
+++ b/app/src/protyle/toolbar/index.ts
@@ -1226,15 +1226,24 @@ export class Toolbar {
         hideElements(["hint"], protyle);
         window.siyuan.menus.menu.remove();
         this.range = getEditorRange(nodeElement);
-        let html = `<div class="b3-list-item">${window.siyuan.languages.clear}</div>`;
-        const hljsLanguages = Constants.ALIAS_CODE_LANGUAGES.concat(window.hljs?.listLanguages() ?? []).sort();
+        let html = `<div data-id="clear" class="b3-list-item">${window.siyuan.languages.clear}</div>`;
+        let hljsLanguages = Constants.ALIAS_CODE_LANGUAGES.concat(window.hljs?.listLanguages() ?? []).sort();
+        
+        const eventDetail = { languages: hljsLanguages };
+        if (protyle.app && protyle.app.plugins) {
+            protyle.app.plugins.forEach((plugin: any) => {
+                plugin.eventBus.emit("code-languages-prepare", eventDetail);
+            });
+        }
+        
+        hljsLanguages = eventDetail.languages;
         hljsLanguages.forEach((item, index) => {
-            html += `<div class="b3-list-item${index === 0 ? " b3-list-item--focus" : ""}">${item}</div>`;
+            html += `<div data-id="${item}" class="b3-list-item">${item}</div>`;
         });
 
         this.subElement.style.width = "";
         this.subElement.style.padding = "";
-        this.subElement.innerHTML = `<div class="fn__flex-column" style="max-height:50vh">
+        this.subElement.innerHTML = `<div data-id="codeLanguage" class="fn__flex-column" style="max-height:50vh">
     <input placeholder="${window.siyuan.languages.search}" style="margin: 0 8px 4px 8px" class="b3-text-field"/>
     <div class="b3-list fn__flex-1 b3-list--background" style="position: relative">${html}</div>
 </div>`;
@@ -1260,41 +1269,47 @@ export class Toolbar {
         });
         inputElement.addEventListener("input", (event) => {
             const lowerCaseValue = inputElement.value.toLowerCase();
-            const matchLanguages = hljsLanguages.filter(item => item.includes(lowerCaseValue));
-            let html = "";
-            // sort
+            let html = `<div data-id="clear" class="b3-list-item">${window.siyuan.languages.clear}</div>`;
             let matchInput = false;
-            matchLanguages.sort((a, b) => {
-                if (a.startsWith(lowerCaseValue) && b.startsWith(lowerCaseValue)) {
-                    if (a.length < b.length) {
+            if (inputElement.value.trim()) {
+                const matchLanguages = hljsLanguages.filter(item => item.includes(lowerCaseValue));
+                // sort
+                matchLanguages.sort((a, b) => {
+                    if (a.startsWith(lowerCaseValue) && b.startsWith(lowerCaseValue)) {
+                        if (a.length < b.length) {
+                            return -1;
+                        } else if (a.length === b.length) {
+                            return 0;
+                        } else {
+                            return 1;
+                        }
+                    } else if (a.startsWith(lowerCaseValue)) {
                         return -1;
-                    } else if (a.length === b.length) {
-                        return 0;
-                    } else {
+                    } else if (b.startsWith(lowerCaseValue)) {
                         return 1;
+                    } else {
+                        return 0;
                     }
-                } else if (a.startsWith(lowerCaseValue)) {
-                    return -1;
-                } else if (b.startsWith(lowerCaseValue)) {
-                    return 1;
-                } else {
-                    return 0;
+                }).forEach((item) => {
+                    if (inputElement.value === item) {
+                        matchInput = true;
+                    }
+                    html += `<div data-id="${item}" data-type="match" class="b3-list-item">${item.replace(lowerCaseValue, "<b>" + lowerCaseValue + "</b>")}</div>`;
+                });
+                if (!matchInput) {
+                    html += `<div data-id="custom" data-type="match" class="b3-list-item"><b>${escapeHtml(inputElement.value.replace(/`| /g, "_"))}</b></div>`;
                 }
-            }).forEach((item) => {
-                if (inputElement.value === item) {
-                    matchInput = true;
-                }
-                html += `<div class="b3-list-item">${item.replace(lowerCaseValue, "<b>" + lowerCaseValue + "</b>")}</div>`;
-            });
-            if (inputElement.value.trim() && !matchInput) {
-                html = `<div class="b3-list-item"><b>${escapeHtml(inputElement.value.replace(/`| /g, "_"))}</b></div>${html}`;
-            }
-            html = `<div class="b3-list-item">${window.siyuan.languages.clear}</div>` + html;
-            listElement.innerHTML = html;
-            if (listElement.childElementCount > 2 && !matchInput && inputElement.value.trim()) {
-                listElement.firstElementChild.nextElementSibling.nextElementSibling.classList.add("b3-list-item--focus");
             } else {
-                listElement.firstElementChild.nextElementSibling.classList.add("b3-list-item--focus");
+                hljsLanguages.forEach((item, index) => {
+                    html += `<div data-id="${item}" class="b3-list-item">${item}</div>`;
+                });
+            }
+            listElement.innerHTML = html;
+            for (const item of listElement.children) {
+                if (item.getAttribute("data-id") !== "clear" && item.getBoundingClientRect().height !== 0) {
+                    item.classList.add("b3-list-item--focus");
+                    break;
+                }
             }
             event.stopPropagation();
         });
@@ -1315,6 +1330,12 @@ export class Toolbar {
         /// #else
         setPosition(this.subElement, 0, 0);
         /// #endif
+        for (const item of listElement.children) {
+            if (item.getBoundingClientRect().height !== 0) {
+                item.classList.add("b3-list-item--focus");
+                break;
+            }
+        }
         this.element.classList.add("fn__none");
         inputElement.select();
     }
@@ -1744,15 +1765,33 @@ ${item.name}
         }
     }
 
-    private updateLanguage(languageElement: HTMLElement[], protyle: IProtyle, selectedLang: string) {
+    private updateLanguage(languageElements: HTMLElement[], protyle: IProtyle, selectedLang: string) {
         const currentLang = selectedLang === window.siyuan.languages.clear ? "" : selectedLang;
+        
+        if (protyle.app && protyle.app.plugins) {
+            const languageChanges = languageElements.map(element => {
+                return {
+                    oldLanguage: element.textContent || "",
+                    languageElement: element
+                };
+            });
+            const eventDetail = {
+                language: currentLang,
+                languageChanges: languageChanges,
+                protyle: protyle
+            };
+            protyle.app.plugins.forEach((plugin: any) => {
+                plugin.eventBus.emit("code-languages-change", eventDetail);
+            });
+        }
+        
         if (!Constants.SIYUAN_RENDER_CODE_LANGUAGES.includes(currentLang)) {
             window.siyuan.storage[Constants.LOCAL_CODELANG] = currentLang;
             setStorageVal(Constants.LOCAL_CODELANG, window.siyuan.storage[Constants.LOCAL_CODELANG]);
         }
         const doOperations: IOperation[] = [];
         const undoOperations: IOperation[] = [];
-        languageElement.forEach(item => {
+        languageElements.forEach(item => {
             const nodeElement = hasClosestBlock(item);
             if (nodeElement) {
                 const id = nodeElement.getAttribute("data-node-id");

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -84,7 +84,8 @@ type TEventBus = "ws-main" | "sync-start" | "sync-end" | "sync-fail" |
     "switch-protyle" | "switch-protyle-mode" |
     "destroy-protyle" |
     "lock-screen" |
-    "mobile-keyboard-show" | "mobile-keyboard-hide"
+    "mobile-keyboard-show" | "mobile-keyboard-hide" |
+    "code-languages-prepare" | "code-languages-change"
 type TAVView = "table" | "gallery"
 type TAVCol =
     "text"


### PR DESCRIPTION
Add plugin event bus `code-languages-prepare` and `code-languages-change`

本 PR 有几个改进：

1. 给选项添加 data-id 属性（ https://github.com/siyuan-note/siyuan/issues/12518 ）
2. 给选项添加 b3-list-item--focus 类名之前先检查元素是否被隐藏，兼容用户使用 CSS 隐藏了选项的情况
3. 把搜索时的[自定义语言](https://github.com/siyuan-note/siyuan/issues/7754)移动到列表末尾，因为使用自定义语言是更低频的
4. 增加事件 `code-languages-prepare` 和 `code-languages-change`，能够通过插件实现这几个需求：https://github.com/siyuan-note/siyuan/issues/6479 https://github.com/siyuan-note/siyuan/issues/9964 https://github.com/siyuan-note/siyuan/issues/11507

    p.s. 还需要修改 https://github.com/siyuan-note/petal

    我简单试了一下可以实现这样的效果：

	```ts
	import {Plugin} from "siyuan";
	export default class PluginSample extends Plugin {
	    onload() {
	        // 监听代码语言列表准备事件
	        this.eventBus.on("code-languages-prepare", (event) => {
	            console.log("code-languages-prepare", event);
	            const { languages } = event.detail;
	
	            // 定义自定义语言列表（排序在最前面）
	            const customLanguages = ['abcdefg'];
	            
	            // 定义优先级语言列表
	            const priorityLanguages = ['css', 'js'];
	            
	            // 重新排序语言列表：优先级语言在前，其他语言在后
	            const sortedLanguages = [
	                ...customLanguages,
	                ...priorityLanguages.filter(lang => languages.includes(lang)),
	                ...languages.filter(lang => !priorityLanguages.includes(lang) && !customLanguages.includes(lang))
	            ];
	            
	            // 将排序后的语言列表赋值回 event.detail.languages
	            event.detail.languages = sortedLanguages;
	            
	            console.log("重新排序后的语言列表:", sortedLanguages);
	        });
	        
	        // 监听代码语言变更事件
	        this.eventBus.on("code-languages-change", (event) => {
	            console.log("code-languages-change", event);
	            const { language, languageChanges } = event.detail;
	            
	            // 执行相应的操作
	            console.log(`代码语言从 ${languageChanges[0].oldLanguage} 更改为: ${language}`);
	        });
	    }
	}
	```

    [video.webm](https://github.com/user-attachments/assets/de25a7ec-4b06-4fd1-b968-071c1a92a15a)


另外，对于第 4 点，还有一份 AI 的总结：

# 代码语言钩子 API

## 概述

思源笔记提供了两个代码语言相关的钩子：

1. **`code-languages-prepare`**: 在显示代码语言列表前触发，允许插件修改可用的代码语言列表
6. **`code-languages-change`**: 在用户更改代码语言后触发，允许插件执行相应的操作

## 事件详情

### code-languages-prepare 钩子
- **事件类型**: `code-languages-prepare`
- **事件详情**: `{ languages: string[] }`
  - `languages`: 包含所有可用代码语言的数组

### code-languages-change 钩子
- **事件类型**: `code-languages-change`
- **事件详情**: `{ language: string, languageChanges: Array<{oldLanguage: string, languageElement: HTMLElement}>, protyle: IProtyle }`
  - `language`: 新的语言名称（空字符串表示清除语言）
  - `languageChanges`: 语言变更信息数组，每个元素包含 oldLanguage 和 languageElement
  - `protyle`: 编辑器实例

## 使用方法

### 1. 基本用法

```typescript
export default class MyPlugin extends Plugin {
    onload() {
        // 监听代码语言列表准备事件
        this.eventBus.on("code-languages-prepare", (event) => {
            const { languages } = event.detail;
            
            // 修改语言列表
            // 注意：直接修改 languages 数组即可
        });
        
        // 监听代码语言变更事件
        this.eventBus.on("code-languages-change", (event) => {
            const { language, languageChanges, protyle } = event.detail;
            
            // 执行相应的操作
            languageChanges.forEach(change => {
                console.log(`代码语言从 ${change.oldLanguage} 更改为: ${language}`);
            });
        });
    }
}
```

### 2. 添加自定义语言

```typescript
this.eventBus.on("code-languages-prepare", (event) => {
    const { languages } = event.detail;
    
    // 添加自定义的代码语言
    if (!languages.includes("my-custom-lang")) {
        languages.push("my-custom-lang");
    }
});
```

### 3. 移除特定语言

```typescript
this.eventBus.on("code-languages-prepare", (event) => {
    const { languages } = event.detail;
    
    // 移除不需要的语言
    const index = languages.indexOf("unwanted-language");
    if (index > -1) {
        languages.splice(index, 1);
    }
});
```

### 4. 重新排序语言

```typescript
this.eventBus.on("code-languages-prepare", (event) => {
    const { languages } = event.detail;
    
    // 按字母顺序排序
    languages.sort();
    
    // 或者自定义排序逻辑
    languages.sort((a, b) => {
        // 将常用语言排在前面
        const commonLanguages = ["javascript", "typescript", "html", "css"];
        const aIndex = commonLanguages.indexOf(a);
        const bIndex = commonLanguages.indexOf(b);
        
        if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
        if (aIndex === -1) return 1;
        if (bIndex === -1) return -1;
        return aIndex - bIndex;
    });
});
```

### 5. 过滤语言

```typescript
this.eventBus.on("code-languages-prepare", (event) => {
    const { languages } = event.detail;
    
    // 过滤掉以特定前缀开头的语言
    const filteredLanguages = languages.filter(lang => 
        !lang.startsWith("deprecated-") && 
        !lang.startsWith("legacy-")
    );
    
    // 将过滤后的结果赋值回事件详情
    event.detail.languages = filteredLanguages;
});
```

### 6. 使用 code-languages-change 钩子

```typescript
this.eventBus.on("code-languages-change", (event) => {
    const { language, languageChanges, protyle } = event.detail;
    
    // 示例：当设置特定语言时执行操作
    if (language === "javascript") {
        // 为 JavaScript 代码块添加特殊样式
        languageChanges.forEach(change => {
            change.languageElement.classList.add("js-code-block");
        });
    }
    
    // 示例：记录语言使用统计
    if (language && language !== "") {
        const stats = window.siyuan.storage["code-languages-stats"] || {};
        stats[language] = (stats[language] || 0) + 1;
        window.siyuan.storage["code-languages-stats"] = stats;
    }
    
    // 示例：根据语言变更执行不同的处理逻辑
    languageChanges.forEach(change => {
        const { oldLanguage, languageElement } = change;
        
        if (oldLanguage === "python" && language === "javascript") {
            console.log("从 Python 切换到 JavaScript");
        } else if (oldLanguage === "" && language !== "") {
            console.log(`新设置了 ${language} 语言`);
        } else if (oldLanguage !== "" && language === "") {
            console.log(`清除了 ${oldLanguage} 语言`);
        }
        
        // 示例：根据语言执行不同的处理逻辑
        switch (language) {
            case "python":
                // Python 代码的特殊处理
                console.log("Python 代码块已设置");
                break;
            case "html":
                // HTML 代码的特殊处理
                console.log("HTML 代码块已设置");
                break;
            case "":
                // 清除语言时的处理
                console.log("代码语言已清除");
                break;
        }
    });
});
```

## 注意事项

1. **直接修改**: 插件应该直接修改 `languages` 数组，而不是创建新的数组
2. **性能考虑**: 避免在钩子中执行耗时的操作，因为这会影响用户体验
7. **错误处理**: 在修改语言列表时添加适当的错误处理

## 完整示例

```typescript
import { Plugin } from "./index";

export default class CodeLanguageEnhancerPlugin extends Plugin {
    onload() {
        // 监听代码语言列表准备事件
        this.eventBus.on("code-languages-prepare", (event) => {
            try {
                const { languages } = event.detail;
                
                // 添加自定义语言
                const customLanguages = ["my-special-lang", "internal-format"];
                customLanguages.forEach(lang => {
                    if (!languages.includes(lang)) {
                        languages.push(lang);
                    }
                });
                
                // 移除过时的语言
                const deprecatedLanguages = ["old-format", "legacy-syntax"];
                deprecatedLanguages.forEach(lang => {
                    const index = languages.indexOf(lang);
                    if (index > -1) {
                        languages.splice(index, 1);
                    }
                });
                
                // 重新排序，将常用语言排在前面
                const commonLanguages = ["javascript", "typescript", "html", "css", "python"];
                languages.sort((a, b) => {
                    const aIndex = commonLanguages.indexOf(a);
                    const bIndex = commonLanguages.indexOf(b);
                    
                    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
                    if (aIndex === -1) return 1;
                    if (bIndex === -1) return -1;
                    return aIndex - bIndex;
                });
                
            } catch (error) {
                console.error("修改代码语言列表时出错:", error);
            }
        });
        
        // 监听代码语言变更事件
        this.eventBus.on("code-languages-change", (event) => {
            try {
                const { language, languageChanges, protyle } = event.detail;
                
                // 记录语言使用统计
                if (language && language !== "") {
                    const stats = window.siyuan.storage["code-languages-stats"] || {};
                    stats[language] = (stats[language] || 0) + 1;
                    window.siyuan.storage["code-languages-stats"] = stats;
                }
                
                // 遍历每个语言变更
                languageChanges.forEach(change => {
                    const { oldLanguage, languageElement } = change;
                    
                    // 根据语言变更执行特定操作
                    if (oldLanguage === "python" && language === "javascript") {
                        console.log("从 Python 切换到 JavaScript");
                    } else if (oldLanguage === "" && language !== "") {
                        console.log(`新设置了 ${language} 语言`);
                    } else if (oldLanguage !== "" && language === "") {
                        console.log(`清除了 ${oldLanguage} 语言`);
                    }
                    
                    // 根据语言执行特定操作
                    if (language === "javascript") {
                        languageElement.classList.add("js-code-block");
                    } else if (language === "python") {
                        languageElement.classList.add("python-code-block");
                    }
                });
                
            } catch (error) {
                console.error("处理代码语言变更时出错:", error);
            }
        });
    }
}
```

## 相关文件

- `app/src/protyle/toolbar/index.ts` - 钩子触发位置
- `app/src/types/index.d.ts` - 事件类型定义
- `app/src/plugin/EventBus.ts` - 事件总线实现
