### PR TITLE
The year is changed to ISOYear when the dynamic icon displays the week number

### DIFF
--- a/kernel/api/icon.go
+++ b/kernel/api/icon.go
@@ -18,13 +18,14 @@ package api
 
 import (
 	"fmt"
-	"github.com/siyuan-note/siyuan/kernel/util"
 	"math"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/siyuan-note/siyuan/kernel/util"
 
 	"github.com/gin-gonic/gin"
 	"github.com/siyuan-note/siyuan/kernel/model"
@@ -238,8 +239,8 @@ func getDateInfo(dateStr string, lang string, weekdayType string) map[string]int
 			weekdayStr = date.Format("Mon")
 		}
 	}
-	// Calculate week number
-	_, weekNum := date.ISOWeek()
+	// Calculate week number and ISO year
+	isoYear, weekNum := date.ISOWeek()
 	weekNumStr := fmt.Sprintf("%dW", weekNum)
 
 	switch lang {
@@ -259,6 +260,7 @@ func getDateInfo(dateStr string, lang string, weekdayType string) map[string]int
 
 	return map[string]interface{}{
 		"year":      year,
+		"isoYear":   isoYear,
 		"month":     month,
 		"day":       day,
 		"date":      fmt.Sprintf("%02d-%02d", date.Month(), date.Day()),
@@ -399,7 +401,7 @@ func generateTypeFiveSVG(color string, lang string, dateInfo map[string]interfac
         <text transform="translate(22 146.5)" style="fill: #fff;font-size: 120px; font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%d</text>
         <text x="50%%" y="410.5" style="fill: #66757f;font-size: 200px;text-anchor: middle;font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Noto Sans CJK SC', 'Microsoft YaHei'; ">%s</text>
     </svg>
-    `, colorScheme.Primary, colorScheme.Secondary, dateInfo["year"], dateInfo["week"])
+    `, colorScheme.Primary, colorScheme.Secondary, dateInfo["isoYear"], dateInfo["week"])
 }
 
 // Type 6: 仅显示星期


### PR DESCRIPTION
动态图标展示周数时年份改为ISOYear

type5，展示年和月的时候，年需要改为ISOYear，在2025年12月29日会变为2025第一周，应该是2026年第1周
<img width="677" height="934" alt="PixPin_2025-08-26_12-20-07" src="https://github.com/user-attachments/assets/9fc484e3-3deb-4a89-96e0-b9ccaf2b2528" />


