### PR TITLE
Improve template syntax highlight

### DIFF
--- a/app/stage/protyle/js/highlight.js/third-languages.js
+++ b/app/stage/protyle/js/highlight.js/third-languages.js
@@ -161,7 +161,7 @@ hljs.registerLanguage('template', function (hljs) {
     // 内置函数规则
     const BUILT_IN_FUNCTIONS = {
         className: 'built_in',
-        begin: /\b(queryBlocks|querySpans|querySQL|getHPathByID|getBlock|statBlock|runeCount|wordCount|toPrettyJson|parseTime|Weekday|WeekdayCN|WeekdayCN2|ISOWeek|ISOYear|ISOMonth|pow|powf|log|logf|FormatFloat|now|date|toDate|duration|AddDate|Sub|sub|add|mul|mod|div|min|max|Compare|Year|Month|Day|Hour|Minute|Second|Hours|Minutes|Seconds|String|trim|repeat|substr|trunc|abbrev|contains|cat|replace|join|splitList|list|first|last|append|prepend|concat|reverse|has|index|slice|len|atoi|float64|int|int64|toDecimal|toString|toStrings|dict|get)\b/,
+        begin: /\b(queryBlocks|querySpans|querySQL|getHPathByID|getBlock|statBlock|runeCount|wordCount|toPrettyJson|parseTime|Weekday|WeekdayCN|WeekdayCN2|ISOWeek|ISOYear|ISOMonth|ISOWeekDate|pow|powf|log|logf|FormatFloat|now|date|toDate|duration|AddDate|Sub|sub|add|mul|mod|div|min|max|Compare|Year|Month|Day|Hour|Minute|Second|Hours|Minutes|Seconds|String|trim|repeat|substr|trunc|abbrev|contains|cat|replace|join|splitList|list|first|last|append|prepend|concat|reverse|has|index|slice|len|atoi|float64|int|int64|toDecimal|toString|toStrings|dict|get)\b/,
         relevance: 10
     };
 

--- a/app/stage/protyle/js/highlight.js/third-languages.js
+++ b/app/stage/protyle/js/highlight.js/third-languages.js
@@ -140,12 +140,28 @@ hljs.registerLanguage("gdscript",function(){"use strict";var e=e||{};function r(
 hljs.registerLanguage('template', function (hljs) {
 
     const markdownRules = hljs.getLanguage('markdown') || { contains: [] };
+
+    // Filter out the indented code block rule from Markdown's code block definitions
+    const filteredMarkdownContains = (markdownRules.contains || []).map(rule => {
+        // The rule for code blocks in Markdown has className: 'code'
+        if (rule.className === 'code' && Array.isArray(rule.variants)) {
+            // Create a new rule object to avoid modifying the original Markdown language definition
+            const newRule = { ...rule };
+            // Filter out the variant that matches indented code blocks
+            newRule.variants = rule.variants.filter(variant => {
+                return variant.begin !== '(?=^( {4}|\\t))';
+            });
+            return newRule;
+        }
+        return rule;
+    });
+
     const goRules = hljs.getLanguage('go') || { contains: [] };
 
     // 内置函数规则
     const BUILT_IN_FUNCTIONS = {
         className: 'built_in',
-        begin: /\b(queryBlocks|querySpans|querySQL|getHPathByID|getBlock|statBlock|runeCount|wordCount|toPrettyJson|parseTime|Weekday|WeekdayCN|WeekdayCN2|ISOWeek|pow|powf|log|logf|FormatFloat|now|date|toDate|duration|AddDate|Sub|sub|add|mul|mod|div|min|max|Compare|Year|Month|Day|Hour|Minute|Second|Hours|Minutes|Seconds|String|trim|repeat|substr|trunc|abbrev|contains|cat|replace|join|splitList|list|first|last|append|prepend|concat|reverse|has|index|slice|len|atoi|float64|int|int64|toDecimal|toString|toStrings|dict|get)\b/,
+        begin: /\b(queryBlocks|querySpans|querySQL|getHPathByID|getBlock|statBlock|runeCount|wordCount|toPrettyJson|parseTime|Weekday|WeekdayCN|WeekdayCN2|ISOWeek|ISOYear|ISOMonth|pow|powf|log|logf|FormatFloat|now|date|toDate|duration|AddDate|Sub|sub|add|mul|mod|div|min|max|Compare|Year|Month|Day|Hour|Minute|Second|Hours|Minutes|Seconds|String|trim|repeat|substr|trunc|abbrev|contains|cat|replace|join|splitList|list|first|last|append|prepend|concat|reverse|has|index|slice|len|atoi|float64|int|int64|toDecimal|toString|toStrings|dict|get)\b/,
         relevance: 10
     };
 
@@ -361,7 +377,7 @@ hljs.registerLanguage('template', function (hljs) {
             ACTION_BLOCK,
             CURLY_BLOCK,
             BLOCK_ATTR_RULE,
-            ...markdownRules.contains,
+            ...filteredMarkdownContains,
         ]
     };
 });


### PR DESCRIPTION
- 去除缩进识别为代码块高亮规则：https://github.com/siyuan-note/siyuan/issues/15686
- 内置函数新增ISOYear、ISOMonth、ISOWeekDate：https://github.com/siyuan-note/siyuan/issues/15679


改进前
<img width="1864" height="673" alt="PixPin_2025-08-27_11-44-02" src="https://github.com/user-attachments/assets/8d7efd83-e170-4d02-87fa-2cf2cd7406dd" />

改进后
<img width="1864" height="673" alt="PixPin_2025-08-27_11-44-13" src="https://github.com/user-attachments/assets/00af2817-b7f5-4e2b-bba9-fca635cbb7f6" />

