### PR TITLE
The height of the dividing line adjusts with font size

### DIFF
--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -86,16 +86,16 @@
       & > div {
         padding-left: 100%;
         position: relative;
-        height: 26px;
+        min-height: 1.625em;
 
         &::after {
           position: absolute;
           content: " ";
-          height: 1px;
+          height: calc(1em / 16);
           background-color: var(--b3-theme-background-light);
           width: calc(100% - 1px);
           left: 0;
-          top: 13px;
+          top: calc(1.625em / 2);
         }
       }
     }


### PR DESCRIPTION
目前分隔线的大小是固定的，比较奇怪：

[video.webm](https://github.com/user-attachments/assets/a2120a7e-5c15-4c2c-aa77-5a0cbc20869a)

改进为跟随字号变化：

[video.webm](https://github.com/user-attachments/assets/a5176d08-abce-4707-8f78-3e2562d3be65)

p.s. 那个 calc 会在编译的时候自动计算，不用手动算