### PR TITLE
copyTextByType change bullet point from '*' to '-'

### DIFF
--- a/app/src/protyle/toolbar/util.ts
+++ b/app/src/protyle/toolbar/util.ts
@@ -221,7 +221,7 @@ export const copyTextByType = async (ids: string[],
     for (let i = 0; i < ids.length; i++) {
         const id = ids[i];
         if (ids.length > 1) {
-            text += "* ";
+            text += "- ";
         }
         if (type === "ref") {
             const response = await fetchSyncPost("/api/block/getRefText", {id});


### PR DESCRIPTION
与目前复制markdown的列表格式保持一致
并且部分软件比如滴答清单不支持`* `列表，只支持`- `列表
