### PR TITLE
If the block ref is pointing to a doc block, the doc title will be displayed in the block ref floating window

### DIFF
--- a/app/src/block/Panel.ts
+++ b/app/src/block/Panel.ts
@@ -182,6 +182,7 @@ export class BlockPanel {
                     scroll: true,
                     gutter: true,
                     breadcrumbDocName: true,
+                    title: response.data.rootID === this.refDefs[index].refID, // 如果块是文档，显示文档标题
                 },
                 typewriterMode: false,
                 after: (editor) => {


### PR DESCRIPTION
块引浮窗如果块引指向的是文档块，显示文档标题

https://github.com/siyuan-note/siyuan/issues/11392

为什么要显示
- 方便复制、修改文档标题
- 方便查看文档属性，比如命名、别名、数据库属性等，悬浮窗看不到每次都要点开文档查看很难受，特别是数据库，其他块块引能看到数据库属性，文档块看不到数据库属性非常难受

效果

<img width="1627" height="1209" alt="PixPin_2025-09-24_22-58-02" src="https://github.com/user-attachments/assets/2024fa40-48a0-4851-b69b-4894a024f504" />
