### PR TITLE
Doc tree supports `Shift+Click` to select multiple documents

### DIFF
--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -34,6 +34,7 @@ export class Files extends Model {
     public parent: Tab;
     private actionsElement: HTMLElement;
     public closeElement: HTMLElement;
+    private lastClickedFileItem: HTMLElement = null;
 
     constructor(options: { tab: Tab, app: App }) {
         super({
@@ -333,9 +334,47 @@ export class Files extends Model {
                     } else if (target.tagName === "LI") {
                         if (isOnlyMeta(event) && !event.altKey && !event.shiftKey) {
                             target.classList.toggle("b3-list-item--focus");
+                        } else if (event.shiftKey && !event.altKey && !isOnlyMeta(event) && target.getAttribute("data-type") === "navigation-file") {
+                            // Shift+click 多选文档
+                            event.preventDefault();
+                            event.stopPropagation();
+                            
+                            if (!this.lastClickedFileItem) {
+                                this.lastClickedFileItem = target;
+                                this.setCurrent(target, false);
+                                return;
+                            }
+                            
+                            // 获取所有文档项
+                            const allFiles = Array.from(this.element.querySelectorAll('li[data-type="navigation-file"]'));
+                            
+                            // 获取起始和结束索引
+                            const startIndex = allFiles.indexOf(this.lastClickedFileItem);
+                            const endIndex = allFiles.indexOf(target);
+                            
+                            if (startIndex === -1 || endIndex === -1) return;
+                            
+                            // 确定选择范围
+                            const start = Math.min(startIndex, endIndex);
+                            const end = Math.max(startIndex, endIndex);
+                            
+                            // 清除现有选择
+                            allFiles.forEach(file => {
+                                (file as HTMLElement).classList.remove("b3-list-item--focus");
+                            });
+                            
+                            // 添加新选择
+                            for (let i = start; i <= end; i++) {
+                                (allFiles[i] as HTMLElement).classList.add("b3-list-item--focus");
+                            }
+                            
+                            needFocus = false;
+                            return;
                         } else {
                             this.setCurrent(target, false);
                             if (target.getAttribute("data-type") === "navigation-file") {
+                                // 更新最后点击的文档项
+                                this.lastClickedFileItem = target;
                                 needFocus = false;
                                 if (target.getAttribute("data-opening")) {
                                     return;
@@ -351,7 +390,7 @@ export class Files extends Model {
                                             target.removeAttribute("data-opening");
                                         }
                                     });
-                                } else if (!event.altKey && isNotCtrl(event) && event.shiftKey) {
+                                } else if (event.altKey && !isNotCtrl(event) && !event.shiftKey) {
                                     openFileById({
                                         app: options.app,
                                         id: target.getAttribute("data-node-id"),

--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -390,7 +390,7 @@ export class Files extends Model {
                                             target.removeAttribute("data-opening");
                                         }
                                     });
-                                } else if (event.altKey && !isNotCtrl(event) && !event.shiftKey) {
+                                } else if (!event.altKey && isNotCtrl(event) && event.shiftKey) {
                                     openFileById({
                                         app: options.app,
                                         id: target.getAttribute("data-node-id"),

--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -390,7 +390,7 @@ export class Files extends Model {
                                             target.removeAttribute("data-opening");
                                         }
                                     });
-                                } else if (!event.altKey && isNotCtrl(event) && event.shiftKey) {
+                                } else if (!event.altKey && !isNotCtrl(event) && event.shiftKey) {
                                     openFileById({
                                         app: options.app,
                                         id: target.getAttribute("data-node-id"),

--- a/app/src/menus/util.ts
+++ b/app/src/menus/util.ts
@@ -67,7 +67,7 @@ export const openEditorTab = (app: App, ids: string[], notebookId?: string, path
         id: "insertBottom",
         icon: "iconLayoutBottom",
         label: window.siyuan.languages.insertBottom,
-        accelerator: ids.length === 1 ? "⌥⌘" + window.siyuan.languages.click : "",
+        accelerator: ids.length === 1 ? "⇧⌘" + window.siyuan.languages.click : "",
         click: () => {
             if (notebookId) {
                 openFileById({

--- a/app/src/menus/util.ts
+++ b/app/src/menus/util.ts
@@ -67,7 +67,7 @@ export const openEditorTab = (app: App, ids: string[], notebookId?: string, path
         id: "insertBottom",
         icon: "iconLayoutBottom",
         label: window.siyuan.languages.insertBottom,
-        accelerator: ids.length === 1 ? "⇧" + window.siyuan.languages.click : "",
+        accelerator: ids.length === 1 ? "⌥⌘" + window.siyuan.languages.click : "",
         click: () => {
             if (notebookId) {
                 openFileById({


### PR DESCRIPTION
文档树支持 Shift+点击多选文档

关联：https://github.com/siyuan-note/siyuan/issues/12185

## 为什么要修改

- 用户需要多选文档进行批量复制块引、添加到数据库、移动、删除等操作
- 思源文档树的shift+click却是「在页签下侧打开」，老实说这个功能应该只有少数人用，却占用了非常常用的shift+click快捷键，并不合理
- shift+click是绝大多数软件多选文档的快捷键，包括思源的多选块也是shift+click

## 修改内容

- 文档树的「在页签下侧打开」快捷键改为ctrl+shift+click
- 文档树支持shift+click多选文档，符合绝大多数软件的交互