### PR TITLE
Improve toolbar position calculation

### DIFF
--- a/app/src/assets/scss/protyle/_toolbar.scss
+++ b/app/src/assets/scss/protyle/_toolbar.scss
@@ -6,7 +6,10 @@
     box-shadow: var(--b3-point-shadow);
     border-radius: var(--b3-border-radius);
     display: flex;
-    transition: top .15s cubic-bezier(0, 0, .2, 1) 0ms;
+
+    &__transition {
+      transition: top .15s cubic-bezier(0, 0, .2, 1) 0ms;
+    }
 
     &__item {
       color: var(--b3-theme-on-surface);

--- a/app/src/protyle/toolbar/index.ts
+++ b/app/src/protyle/toolbar/index.ts
@@ -164,12 +164,17 @@ export class Toolbar {
             this.element.classList.add("fn__none");
             return;
         }
-        this.element.classList.remove("fn__none");
+        this.element.classList.remove("fn__none", "protyle-toolbar__transition");
+        
         this.toolbarHeight = this.element.clientHeight;
         const rangePosition = getSelectionPosition(nodeElement, range, this.element.clientWidth);
-        const y = rangePosition.top - this.toolbarHeight - 4;
+        const y = rangePosition.isToolbarAtBottom ?
+            Math.min(rangePosition.top + 4, protyle.element.getBoundingClientRect().bottom - this.toolbarHeight) :
+            Math.max(rangePosition.top - this.toolbarHeight - 4, protyle.element.getBoundingClientRect().top + 30);
         this.element.setAttribute("data-inity", y + Constants.ZWSP + protyle.contentElement.scrollTop.toString());
-        setPosition(this.element, rangePosition.left, Math.max(y, protyle.element.getBoundingClientRect().top + 30));
+        setPosition(this.element, rangePosition.left, y);
+
+        this.element.classList.add("protyle-toolbar__transition");
         this.element.querySelectorAll(".protyle-toolbar__item--current").forEach(item => {
             item.classList.remove("protyle-toolbar__item--current");
         });

--- a/app/src/protyle/toolbar/index.ts
+++ b/app/src/protyle/toolbar/index.ts
@@ -164,12 +164,12 @@ export class Toolbar {
             this.element.classList.add("fn__none");
             return;
         }
-        const rangePosition = getSelectionPosition(nodeElement, range);
         this.element.classList.remove("fn__none");
         this.toolbarHeight = this.element.clientHeight;
+        const rangePosition = getSelectionPosition(nodeElement, range, this.element.clientWidth);
         const y = rangePosition.top - this.toolbarHeight - 4;
         this.element.setAttribute("data-inity", y + Constants.ZWSP + protyle.contentElement.scrollTop.toString());
-        setPosition(this.element, rangePosition.left - 52, Math.max(y, protyle.element.getBoundingClientRect().top + 30));
+        setPosition(this.element, rangePosition.left, Math.max(y, protyle.element.getBoundingClientRect().top + 30));
         this.element.querySelectorAll(".protyle-toolbar__item--current").forEach(item => {
             item.classList.remove("protyle-toolbar__item--current");
         });

--- a/app/src/protyle/util/selection.ts
+++ b/app/src/protyle/util/selection.ts
@@ -266,9 +266,11 @@ export const getSelectionPosition = (nodeElement: Element, range?: Range, toolba
             const isBackward = selection && "direction" in selection ?
                 (selection as { direction: "forward" | "backward" | "none" }).direction === "backward"
                 : range.startContainer === selection?.focusNode && range.startOffset === selection?.focusOffset;
-            // 检查是否有多个垂直位置不同的矩形
-            const hasMultipleVerticalRects = rects.length > 1 && Array.from(rects).some((rect: DOMRect) => rect.top !== rects[0].top);
-            const isToolbarAtBottom = hasMultipleVerticalRects && !isBackward;
+            let isToolbarAtBottom = false;
+            if (!isBackward) {
+                // 检查是否有多个垂直位置不同的矩形
+                isToolbarAtBottom = rects.length > 1 && Array.from(rects).some((rect: DOMRect) => rect.top !== rects[0].top);
+            }
 
             return {
                 // 向左选择：使用第一个矩形的左边界；向右选择：使用最后一个矩形的右边界

--- a/app/src/protyle/util/selection.ts
+++ b/app/src/protyle/util/selection.ts
@@ -266,12 +266,17 @@ export const getSelectionPosition = (nodeElement: Element, range?: Range, toolba
             const isBackward = selection && "direction" in selection ?
                 (selection as { direction: "forward" | "backward" | "none" }).direction === "backward"
                 : range.startContainer === selection?.focusNode && range.startOffset === selection?.focusOffset;
+            // 检查是否有多个垂直位置不同的矩形
+            const hasMultipleVerticalRects = rects.length > 1 && Array.from(rects).some((rect: DOMRect) => rect.top !== rects[0].top);
+            const isToolbarAtBottom = hasMultipleVerticalRects && !isBackward;
+
             return {
                 // 向左选择：使用第一个矩形的左边界；向右选择：使用最后一个矩形的右边界
                 // 减去工具栏宽度的1/4：将工具栏中不太常用的按钮往右偏一点
                 left: (isBackward ? rects[0].left : rects[rects.length - 1].right) - (toolbarWidth || 0) / 4,
-                // 选中多行不应遮挡第一行 https://github.com/siyuan-note/siyuan/issues/7541
-                top: rects[0].top
+                // 如果向右选择时有多个垂直位置不同的矩形：使用最后一个矩形的下边界；否则使用第一个矩形的上边界
+                top: isToolbarAtBottom ? rects[rects.length - 1].bottom : rects[0].top,
+                isToolbarAtBottom: isToolbarAtBottom,
             };
         } else {
             return {    // 代码块首 https://github.com/siyuan-note/siyuan/issues/13113


### PR DESCRIPTION
改进选中文本时弹出工具栏的位置。

之前始终是使用最后一个矩形的左边界（`rects[rects.length - 1].left`），体验很奇怪：

[video.webm](https://github.com/user-attachments/assets/0b253d90-24d9-4209-b53b-e53276e4c07a)

改进之后，向左选择时使用第一个矩形的左边界，向右选择时使用最后一个矩形的右边界，相当于是尽量靠近鼠标的位置：

[video.webm](https://github.com/user-attachments/assets/4844a69b-8147-46a3-85ed-8cf665c5d8ce)

另外，位置始终 `- 52` （引用按钮加上链接按钮的宽度）的话会让右边太长，常用的按钮也偏到右边去了。我改成了减去工具栏宽度的 1/4，把常用的按钮显示在鼠标的左上方和右上方：

<img width="1207" height="295" alt="image" src="https://github.com/user-attachments/assets/c9c7f699-1e95-41d7-8cfb-524bb071e1bc" />
