### PR TITLE
Fix focus issues on Windows after dialog interactions

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -866,6 +866,13 @@ app.whenReady().then(() => {
             event.sender.send("siyuan-event", "leave-full-screen");
         });
     });
+    ipcMain.on("siyuan-focus-fix", (event) => {
+        const currentWindow = getWindowByContentId(event.sender.id);
+        if (currentWindow && process.platform === "win32") {
+            currentWindow.blur();
+            currentWindow.focus();
+        }
+    });
     ipcMain.on("siyuan-cmd", (event, data) => {
         let cmd = data;
         let webContentsId = event.sender.id;

--- a/app/src/boot/onGetConfig.ts
+++ b/app/src/boot/onGetConfig.ts
@@ -7,6 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 import {afterExport} from "../protyle/export/util";
 import {onWindowsMsg} from "../window/onWindowsMsg";
+import {initFocusFix} from "../protyle/util/compatibility";
 /// #endif
 import {Constants} from "../constants";
 import {appearance} from "../config/appearance";
@@ -68,6 +69,9 @@ export const onGetConfig = (isStart: boolean, app: App) => {
     initBar(app);
     initStatus();
     initWindow(app);
+    /// #if !BROWSER
+    initFocusFix();
+    /// #endif
     appearance.onSetAppearance(window.siyuan.config.appearance);
     initAssets();
     setInlineStyle();

--- a/app/src/protyle/util/compatibility.ts
+++ b/app/src/protyle/util/compatibility.ts
@@ -3,6 +3,7 @@ import {fetchPost, fetchSyncPost} from "../../util/fetch";
 import {Constants} from "../../constants";
 /// #if !BROWSER
 import {clipboard} from "electron";
+import {ipcRenderer} from "electron";
 /// #endif
 
 export const encodeBase64 = (text: string): string => {
@@ -507,3 +508,38 @@ export const setStorageVal = (key: string, val: any, cb?: () => void) => {
         }
     });
 };
+
+/// #if !BROWSER
+export const initFocusFix = () => {
+    if (!isWindows()) {
+        return;
+    }
+    const originalAlert = window.alert;
+    const originalConfirm = window.confirm;
+    const fixFocusAfterDialog = () => {
+        ipcRenderer.send("siyuan-focus-fix");
+    };
+    window.alert = function(message: string) {
+        try {
+            const result = originalAlert.call(this, message);
+            fixFocusAfterDialog();
+            return result;
+        } catch (error) {
+            console.error("alert error:", error);
+            fixFocusAfterDialog();
+            return undefined;
+        }
+    };
+    window.confirm = function(message: string) {
+        try {
+            const result = originalConfirm.call(this, message);
+            fixFocusAfterDialog();
+            return result;
+        } catch (error) {
+            console.error("confirm error:", error);
+            fixFocusAfterDialog();
+            return false;
+        }
+    };
+};
+/// #endif


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/16071 https://github.com/siyuan-note/siyuan/issues/12349

修复了使用 `alert()` 和 `confirm()` 之后在 Windows 客户端中出现的焦点问题。修复之后焦点正常：

[video.webm](https://github.com/user-attachments/assets/a206ce3a-9eec-49af-ba3b-eb6de1bab331)
