### PR TITLE
Improve #commonMenu menu

### DIFF
--- a/app/appearance/langs/ar_SA.json
+++ b/app/appearance/langs/ar_SA.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "إلغاء القفل المؤقت",
   "addFilter": "إضافة عامل تصفية",
   "removeFilters": "مسح عامل تصفية",
+  "addSort": "إضافة ترتيب",
+  "removeSorts": "مسح الترتيب",
   "checked": "مكتمل",
   "unchecked": "غير مكتمل",
   "percentChecked": "نسبة المكتمل",

--- a/app/appearance/langs/de_DE.json
+++ b/app/appearance/langs/de_DE.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Temporäres Entsperren abbrechen",
   "addFilter": "Filter hinzufügen",
   "removeFilters": "Filter zurücksetzen",
+  "addSort": "Sortierung hinzufügen",
+  "removeSorts": "Sortierung zurücksetzen",
   "checked": "Überprüft",
   "unchecked": "Nicht überprüft",
   "percentChecked": "Prozent geprüft",

--- a/app/appearance/langs/en_US.json
+++ b/app/appearance/langs/en_US.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Cancel temporary unlock",
   "addFilter": "Add filter",
   "removeFilters": "Clear filter",
+  "addSort": "Add sort",
+  "removeSorts": "Clear sort",
   "checked": "Checked",
   "unchecked": "Unchecked",
   "percentChecked": "Percent checked",

--- a/app/appearance/langs/es_ES.json
+++ b/app/appearance/langs/es_ES.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Cancelar desbloqueo temporal",
   "addFilter": "Agregar filtro",
   "removeFilters": "Borrar filtro",
+  "addSort": "Agregar ordenación",
+  "removeSorts": "Borrar ordenación",
   "checked": "marcado",
   "unchecked": "desmarcado",
   "percentChecked": "Porcentaje comprobado",

--- a/app/appearance/langs/fr_FR.json
+++ b/app/appearance/langs/fr_FR.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Annuler le déverrouillage temporaire",
   "addFilter": "Ajouter un filtre",
   "removeFilters": "Effacer le filtre",
+  "addSort": "Ajouter un tri",
+  "removeSorts": "Effacer le tri",
   "checked": "Coché",
   "unchecked": "Décoché",
   "percentChecked": "Pourcentage vérifié",

--- a/app/appearance/langs/he_IL.json
+++ b/app/appearance/langs/he_IL.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "בטל שחרור זמני",
   "addFilter": "הוסף מסנן",
   "removeFilters": "נקה מסננים",
+  "addSort": "הוסף מיון",
+  "removeSorts": "נקה מיון",
   "checked": "נבדק",
   "unchecked": "לא נבדק",
   "percentChecked": "אחוז נבדק",

--- a/app/appearance/langs/it_IT.json
+++ b/app/appearance/langs/it_IT.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Annulla sblocco temporaneo",
   "addFilter": "Aggiungi filtro",
   "removeFilters": "Pulisci filtro",
+  "addSort": "Aggiungi ordinamento",
+  "removeSorts": "Pulisci ordinamento",
   "checked": "Selezionato",
   "unchecked": "Deselezionato",
   "percentChecked": "Percentuale selezionata",

--- a/app/appearance/langs/ja_JP.json
+++ b/app/appearance/langs/ja_JP.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "一時的なロック解除をキャンセル",
   "addFilter": "フィルタを追加",
   "removeFilters": "フィルタを削除",
+  "addSort": "ソートを追加",
+  "removeSorts": "ソートを削除",
   "checked": "チェック済み",
   "unchecked": "未チェック",
   "percentChecked": "チェック済みの割合",

--- a/app/appearance/langs/pl_PL.json
+++ b/app/appearance/langs/pl_PL.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Anuluj tymczasowe odblokowanie",
   "addFilter": "Dodaj filtr",
   "removeFilters": "Wyczyść filtr",
+  "addSort": "Dodaj sortowanie",
+  "removeSorts": "Wyczyść sortowanie",
   "checked": "Zaznaczone",
   "unchecked": "Nie zaznaczone",
   "percentChecked": "Procent zaznaczonych",

--- a/app/appearance/langs/pt_BR.json
+++ b/app/appearance/langs/pt_BR.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Cancelar desbloqueio temporário",
   "addFilter": "Adicionar filtro",
   "removeFilters": "Limpar filtro",
+  "addSort": "Adicionar ordenação",
+  "removeSorts": "Limpar ordenação",
   "checked": "Marcado",
   "unchecked": "Desmarcado",
   "percentChecked": "Porcentagem marcada",

--- a/app/appearance/langs/ru_RU.json
+++ b/app/appearance/langs/ru_RU.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "Отменить временную разблокировку",
   "addFilter": "Добавить фильтр",
   "removeFilters": "Очистить фильтр",
+  "addSort": "Добавить сортировку",
+  "removeSorts": "Очистить сортировку",
   "checked": "Отмечено",
   "unchecked": "Не отмечено",
   "percentChecked": "Процент отмеченных",

--- a/app/appearance/langs/zh_CHT.json
+++ b/app/appearance/langs/zh_CHT.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "取消暫時解鎖",
   "addFilter": "新增篩選條件",
   "removeFilters": "清空篩選規則",
+  "addSort": "新增排序條件",
+  "removeSorts": "清空排序規則",
   "checked": "已完成",
   "unchecked": "未完成",
   "percentChecked": "已完成佔比",

--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -231,6 +231,8 @@
   "cancelTempUnlock": "取消临时解锁",
   "addFilter": "添加筛选条件",
   "removeFilters": "清空筛选规则",
+  "addSort": "添加排序条件",
+  "removeSorts": "清空排序规则",
   "checked": "已完成",
   "unchecked": "未完成",
   "percentChecked": "已完成占比",

--- a/app/src/ai/actions.ts
+++ b/app/src/ai/actions.ts
@@ -161,7 +161,7 @@ export const AIActions = (elements: Element[], protyle: IProtyle) => {
     elements.forEach(item => {
         ids.push(item.getAttribute("data-node-id"));
     });
-    const menu = new Menu("ai", () => {
+    const menu = new Menu(Constants.MENU_AI, () => {
         focusByRange(protyle.toolbar.range);
     });
     let customHTML = "";

--- a/app/src/block/popover.ts
+++ b/app/src/block/popover.ts
@@ -220,7 +220,7 @@ const hidePopover = (event: MouseEvent & { path: HTMLElement[] }) => {
     } else {
         // 浮窗上点击菜单，浮窗不能消失 https://ld246.com/article/1632668091023
         const menuElement = hasClosestByClassName(target, "b3-menu");
-        if (menuElement && menuElement.getAttribute("data-name") !== "docTreeMore") {
+        if (menuElement && menuElement.getAttribute("data-name") !== Constants.MENU_DOC_TREE_MORE) {
             const blockPanel = window.siyuan.blockPanels.find((item) => {
                 if (item.element.style.zIndex < menuElement.style.zIndex) {
                     return true;

--- a/app/src/boot/globalEvent/command/panel.ts
+++ b/app/src/boot/globalEvent/command/panel.ts
@@ -442,7 +442,7 @@ export const execByCommand = async (options: {
         case "move":
             if (!isFileFocus) {
                 const nodeElement = hasClosestBlock(range.startContainer);
-                if (protyle.title?.editElement.contains(range.startContainer) || !nodeElement || window.siyuan.menus.menu.element.getAttribute("data-name") === "titleMenu") {
+                if (protyle.title?.editElement.contains(range.startContainer) || !nodeElement || window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_TITLE) {
                     movePathTo((toPath, toNotebook) => {
                         moveToPath([protyle.path], toNotebook[0], toPath[0]);
                     }, [protyle.path], range);

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -224,6 +224,10 @@ export abstract class Constants {
     public static readonly DIALOG_OPENWORKSPACE = "dialog-openworkspace"; // 打开工作空间
     public static readonly DIALOG_SAVEWORKSPACE = "dialog-saveworkspace"; // 保存工作空间
 
+    // menu
+    public static readonly MENU_OUTLINE_CONTEXT = "outlineContextMenu"; // 大纲标题右键菜单
+    public static readonly MENU_OUTLINE_EXPAND_LEVEL = "outlineExpandLevelMenu"; // 大纲展开层级菜单
+
     // timeout
     public static readonly TIMEOUT_OPENDIALOG = 50;
     public static readonly TIMEOUT_DBLCLICK = 190;

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -233,11 +233,18 @@ export abstract class Constants {
     public static readonly MENU_STATUS_BACKGROUND_TASK = "statusBackgroundTask"; // 状态栏后台任务菜单
     public static readonly MENU_DOCK_MOBILE = "dockMobileMenu"; // 移动端侧栏插件选项菜单
 
+    public static readonly MENU_BLOCK_SINGLE = "block-single"; // 单选块菜单
+    public static readonly MENU_BLOCK_MULTI = "block-multi"; // 多选块菜单
     public static readonly MENU_TITLE = "titleMenu"; // 文档块菜单
+    public static readonly MENU_TITLE_PROTYLE = "title-protyle"; // 在 Protyle 触发的文档块菜单
+    public static readonly MENU_TITLE_BREADCRUMB = "title-breadcrumb"; // 在面包屑触发的文档块菜单
     public static readonly MENU_BREADCRUMB_MORE = "breadcrumbMore"; // 面包屑更多菜单
     public static readonly MENU_BREADCRUMB_MOBILE_PATH = "breadcrumb-mobile-path"; // 移动端面包屑菜单
 
-    public static readonly MENU_DOC_TREE_MORE = "docTreeMore"; // 侧栏文档树文档的更多菜单
+    public static readonly MENU_DOC_TREE_MORE = "docTreeMore"; // 侧栏文档树右键菜单
+    public static readonly MENU_DOC_TREE_MORE_NOTEBOOK = "docTreeMore-notebook"; // 侧栏文档树右键菜单，单个笔记本
+    public static readonly MENU_DOC_TREE_MORE_DOC = "docTreeMore-doc"; // 侧栏文档树右键菜单，单个文档
+    public static readonly MENU_DOC_TREE_MORE_DOCS = "docTreeMore-docs"; // 侧栏文档树右键菜单，多个文档
     public static readonly MENU_TAG = "tagMenu"; // 侧栏标签菜单
     public static readonly MENU_BOOKMARK = "bookmarkMenu"; // 侧栏书签菜单
     public static readonly MENU_OUTLINE_CONTEXT = "outline-context"; // 大纲标题右键菜单
@@ -267,7 +274,7 @@ export abstract class Constants {
     public static readonly MENU_MOVE_PATH_HISTORY = "move-path-history"; // 移动文档窗口搜索历史菜单
 
     public static readonly MENU_BACKGROUND_ASSET = "background-asset"; // 资源文件选择器菜单
-    public static readonly MENU_AI = "ai"; // 块AI菜单
+    public static readonly MENU_AI = "ai"; // 块 AI 菜单
     public static readonly MENU_TAB_LIST = "tabList"; // 页签切换菜单
 
     // timeout

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -225,8 +225,50 @@ export abstract class Constants {
     public static readonly DIALOG_SAVEWORKSPACE = "dialog-saveworkspace"; // 保存工作空间
 
     // menu
-    public static readonly MENU_OUTLINE_CONTEXT = "outlineContextMenu"; // 大纲标题右键菜单
-    public static readonly MENU_OUTLINE_EXPAND_LEVEL = "outlineExpandLevelMenu"; // 大纲展开层级菜单
+    public static readonly MENU_BAR_WORKSPACE = "barWorkspace"; // 顶栏主菜单
+    public static readonly MENU_BAR_PLUGIN = "topBarPlugin"; // 顶栏插件菜单
+    public static readonly MENU_BAR_ZOOM = "barZoom"; // 顶栏缩放菜单
+    public static readonly MENU_BAR_MORE = "barmore"; // 顶栏外观菜单
+    public static readonly MENU_STATUS_HELP = "statusHelp"; // 状态栏帮助菜单
+    public static readonly MENU_STATUS_BACKGROUND_TASK = "statusBackgroundTask"; // 状态栏后台任务菜单
+    public static readonly MENU_DOCK_MOBILE = "dockMobileMenu"; // 移动端侧栏插件选项菜单
+
+    public static readonly MENU_TITLE = "titleMenu"; // 文档块菜单
+    public static readonly MENU_BREADCRUMB_MORE = "breadcrumbMore"; // 面包屑更多菜单
+    public static readonly MENU_BREADCRUMB_MOBILE_PATH = "breadcrumb-mobile-path"; // 移动端面包屑菜单
+
+    public static readonly MENU_DOC_TREE_MORE = "docTreeMore"; // 侧栏文档树文档的更多菜单
+    public static readonly MENU_TAG = "tagMenu"; // 侧栏标签菜单
+    public static readonly MENU_BOOKMARK = "bookmarkMenu"; // 侧栏书签菜单
+    public static readonly MENU_OUTLINE_CONTEXT = "outline-context"; // 大纲标题右键菜单
+    public static readonly MENU_OUTLINE_EXPAND_LEVEL = "outline-expand-level"; // 大纲展开层级菜单
+
+    public static readonly MENU_AV_VIEW = "av-view"; // 数据库视图标题菜单
+    public static readonly MENU_AV_HEADER_CELL = "av-header-cell"; // 数据库字段标题菜单
+    public static readonly MENU_AV_HEADER_ADD = "av-header-add"; // 数据库添加字段菜单
+    public static readonly MENU_AV_ADD_FILTER = "av-add-filter"; // 数据库添加筛选条件菜单
+    public static readonly MENU_AV_ADD_SORT = "av-add-sort"; // 数据库添加排序条件菜单
+    public static readonly MENU_AV_COL_OPTION = "av-col-option"; // 数据库单选多选字段的选项编辑菜单
+    public static readonly MENU_AV_COL_FORMAT_NUMBER = "av-col-format-number"; // 数据库数字字段格式化菜单
+    public static readonly MENU_AV_GROUP_DATE = "avGroupDate"; // 数据库日期字段分组菜单的日期菜单
+    public static readonly MENU_AV_GROUP_SORT = "avGroupSort"; // 数据库日期字段分组菜单的排序菜单
+    public static readonly MENU_AV_ASSET_EDIT = "av-asset-edit"; // 数据库资源字段链接菜单
+    public static readonly MENU_AV_CALC = "av-calc"; // 数据库计算菜单
+    public static readonly MENU_AV_PAGE_SIZE = "av-page-size"; // 数据库条目数菜单
+
+    public static readonly MENU_SEARCH_MORE = "searchMore"; // 搜索更多菜单
+    public static readonly MENU_SEARCH_METHOD = "searchMethod"; // 搜索方式菜单
+    public static readonly MENU_SEARCH_ASSET_MORE = "searchAssetMore"; // 资源文件搜索更多菜单
+    public static readonly MENU_SEARCH_ASSET_METHOD = "searchAssetMethod"; // 资源文件搜索方式菜单
+    public static readonly MENU_SEARCH_UNREF_MORE = "searchUnRefMore"; // 列出引用失效的块的更多菜单
+    public static readonly MENU_SEARCH_HISTORY = "search-history"; // 搜索历史菜单
+    public static readonly MENU_SEARCH_REPLACE_HISTORY = "search-replace-history"; // 替换历史菜单
+    public static readonly MENU_SEARCH_ASSET_HISTORY = "search-asset-history"; // 资源文件搜索历史菜单
+    public static readonly MENU_MOVE_PATH_HISTORY = "move-path-history"; // 移动文档窗口搜索历史菜单
+
+    public static readonly MENU_BACKGROUND_ASSET = "background-asset"; // 资源文件选择器菜单
+    public static readonly MENU_AI = "ai"; // 块AI菜单
+    public static readonly MENU_TAB_LIST = "tabList"; // 页签切换菜单
 
     // timeout
     public static readonly TIMEOUT_OPENDIALOG = 50;

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -259,7 +259,7 @@ export abstract class Constants {
     public static readonly MENU_AV_COL_FORMAT_NUMBER = "av-col-format-number"; // 数据库数字字段格式化菜单
     public static readonly MENU_AV_GROUP_DATE = "avGroupDate"; // 数据库日期字段分组菜单的日期菜单
     public static readonly MENU_AV_GROUP_SORT = "avGroupSort"; // 数据库日期字段分组菜单的排序菜单
-    public static readonly MENU_AV_ASSET_EDIT = "av-asset-edit"; // 数据库资源字段链接菜单
+    public static readonly MENU_AV_ASSET_EDIT = "av-asset-edit"; // 数据库资源字段链接或资源文件菜单
     public static readonly MENU_AV_CALC = "av-calc"; // 数据库计算菜单
     public static readonly MENU_AV_PAGE_SIZE = "av-page-size"; // 数据库条目数菜单
 
@@ -275,7 +275,16 @@ export abstract class Constants {
 
     public static readonly MENU_BACKGROUND_ASSET = "background-asset"; // 资源文件选择器菜单
     public static readonly MENU_AI = "ai"; // 块 AI 菜单
+    public static readonly MENU_TAB = "tab"; // 页签右键菜单
     public static readonly MENU_TAB_LIST = "tabList"; // 页签切换菜单
+
+    public static readonly MENU_INLINE_CONTEXT = "inline-context"; // 文本右键菜单
+    public static readonly MENU_INLINE_IMG = "inline-img"; // 图片元素菜单
+    public static readonly MENU_INLINE_FILE_ANNOTATION_REF = "inline-file-annotation-ref"; // PDF 标注元素菜单
+    public static readonly MENU_INLINE_REF = "inline-block-ref"; // 块引用元素菜单
+    public static readonly MENU_INLINE_A = "inline-a"; // 超链接元素菜单
+    public static readonly MENU_INLINE_TAG = "inline-tag"; // 行级标签元素菜单
+    public static readonly MENU_INLINE_MATH = "inline-math"; // 行级公式元素菜单
 
     // timeout
     public static readonly TIMEOUT_OPENDIALOG = 50;

--- a/app/src/dialog/processSystem.ts
+++ b/app/src/dialog/processSystem.ts
@@ -461,7 +461,7 @@ export const progressBackgroundTask = (tasks: { action: string }[]) => {
     if (tasks.length === 0) {
         backgroundTaskElement.classList.add("fn__none");
         if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-            window.siyuan.menus.menu.element.getAttribute("data-name") === "statusBackgroundTask") {
+            window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_STATUS_BACKGROUND_TASK) {
             window.siyuan.menus.menu.remove();
         }
     } else {

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -654,7 +654,7 @@ export class Wnd {
 
     private renderTabList(target: HTMLElement) {
         if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-            window.siyuan.menus.menu.element.getAttribute("data-name") === "tabList") {
+            window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_TAB_LIST) {
             window.siyuan.menus.menu.remove();
             return;
         }
@@ -703,7 +703,7 @@ export class Wnd {
                 current: item.classList.contains("item--focus")
             }).element);
         });
-        window.siyuan.menus.menu.element.setAttribute("data-name", "tabList");
+        window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_TAB_LIST);
         const rect = target.getBoundingClientRect();
         window.siyuan.menus.menu.popup({
             x: rect.left + rect.width,

--- a/app/src/layout/dock/Outline.ts
+++ b/app/src/layout/dock/Outline.ts
@@ -788,8 +788,10 @@ export class Outline extends Model {
      */
     private showExpandLevelMenu(target: HTMLElement) {
         window.siyuan.menus.menu.remove();
+        window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_OUTLINE_EXPAND_LEVEL);
         for (let i = 1; i <= 6; i++) {
             window.siyuan.menus.menu.append(new MenuItem({
+                id: `heading${i}`,
                 icon: `iconH${i}`,
                 label: window.siyuan.languages[`heading${i}`],
                 click: () => this.expandToLevel(i)
@@ -867,9 +869,11 @@ export class Outline extends Model {
         }
         const currentLevel = this.getHeadingLevel(element);
         window.siyuan.menus.menu.remove();
+        window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_OUTLINE_CONTEXT);
         // 升级
         if (currentLevel > 1) {
             window.siyuan.menus.menu.append(new MenuItem({
+                id: "upgrade",
                 icon: "iconUp",
                 label: window.siyuan.languages.upgrade,
                 click: () => {
@@ -889,6 +893,7 @@ export class Outline extends Model {
         // 降级
         if (currentLevel < 6) {
             window.siyuan.menus.menu.append(new MenuItem({
+                id: "downgrade",
                 icon: "iconDown",
                 label: window.siyuan.languages.downgrade,
                 click: () => {
@@ -945,10 +950,11 @@ export class Outline extends Model {
             }).element);
         }
 
-        window.siyuan.menus.menu.append(new MenuItem({type: "separator"}).element);
+        window.siyuan.menus.menu.append(new MenuItem({id: "separator_1", type: "separator"}).element);
 
         // 在前面插入同级标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "insertSameLevelHeadingBefore",
             icon: "iconBefore",
             label: window.siyuan.languages.insertSameLevelHeadingBefore,
             click: () => {
@@ -973,6 +979,7 @@ export class Outline extends Model {
 
         // 在后面插入同级标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "insertSameLevelHeadingAfter",
             icon: "iconAfter",
             label: window.siyuan.languages.insertSameLevelHeadingAfter,
             click: () => {
@@ -1006,6 +1013,7 @@ export class Outline extends Model {
         // 添加子标题
         if (currentLevel < 6) { // 只有当前级别小于6时才能添加子标题
             window.siyuan.menus.menu.append(new MenuItem({
+                id: "addChildHeading",
                 icon: "iconAdd",
                 label: window.siyuan.languages.addChildHeading,
                 click: () => {
@@ -1045,10 +1053,11 @@ export class Outline extends Model {
             }).element);
         }
 
-        window.siyuan.menus.menu.append(new MenuItem({type: "separator"}).element);
+        window.siyuan.menus.menu.append(new MenuItem({id: "separator_2", type: "separator"}).element);
 
         // 复制带子标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "copyHeadings1",
             icon: "iconCopy",
             label: `${window.siyuan.languages.copy} ${window.siyuan.languages.headings1}`,
             click: () => {
@@ -1070,6 +1079,7 @@ export class Outline extends Model {
 
         // 剪切带子标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "cutHeadings1",
             icon: "iconCut",
             label: `${window.siyuan.languages.cut} ${window.siyuan.languages.headings1}`,
             click: () => {
@@ -1117,6 +1127,7 @@ export class Outline extends Model {
 
         // 删除
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "deleteHeadings1",
             icon: "iconTrashcan",
             label: `${window.siyuan.languages.delete} ${window.siyuan.languages.headings1}`,
             click: () => {
@@ -1150,10 +1161,11 @@ export class Outline extends Model {
             }
         }).element);
 
-        window.siyuan.menus.menu.append(new MenuItem({type: "separator"}).element);
+        window.siyuan.menus.menu.append(new MenuItem({id: "separator_3", type: "separator"}).element);
 
         // 展开子标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "expandChildHeading",
             icon: "iconExpand",
             label: window.siyuan.languages.expandChildHeading,
             accelerator: updateHotkeyTip("⌘") + window.siyuan.languages.clickArrow,
@@ -1162,6 +1174,7 @@ export class Outline extends Model {
 
         // 折叠子标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "foldChildHeading",
             icon: "iconContract",
             label: window.siyuan.languages.foldChildHeading,
             accelerator: updateHotkeyTip("⌘") + window.siyuan.languages.clickArrow,
@@ -1170,6 +1183,7 @@ export class Outline extends Model {
 
         // 展开同级标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "expandSameLevelHeading",
             icon: "iconExpand",
             label: window.siyuan.languages.expandSameLevelHeading,
             accelerator: updateHotkeyTip("⌥") + window.siyuan.languages.clickArrow,
@@ -1178,6 +1192,7 @@ export class Outline extends Model {
 
         // 折叠同级标题
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "foldSameLevelHeading",
             icon: "iconContract",
             label: window.siyuan.languages.foldSameLevelHeading,
             accelerator: updateHotkeyTip("⌥") + window.siyuan.languages.clickArrow,
@@ -1186,6 +1201,7 @@ export class Outline extends Model {
 
         // 全部展开
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "expandAll",
             icon: "iconExpand",
             label: window.siyuan.languages.expandAll,
             click: () => {
@@ -1196,6 +1212,7 @@ export class Outline extends Model {
 
         // 全部折叠
         window.siyuan.menus.menu.append(new MenuItem({
+            id: "foldAll",
             icon: "iconContract",
             label: window.siyuan.languages.foldAll,
             click: () => {

--- a/app/src/layout/status.ts
+++ b/app/src/layout/status.ts
@@ -39,12 +39,12 @@ export const initStatus = (isWindow = false) => {
                 break;
             } else if (target.classList.contains("status__backgroundtask")) {
                 if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-                    window.siyuan.menus.menu.element.getAttribute("data-name") === "statusBackgroundTask") {
+                    window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_STATUS_BACKGROUND_TASK) {
                     window.siyuan.menus.menu.remove();
                     return;
                 }
                 window.siyuan.menus.menu.remove();
-                window.siyuan.menus.menu.element.setAttribute("data-name", "statusBackgroundTask");
+                window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_STATUS_BACKGROUND_TASK);
                 JSON.parse(target.getAttribute("data-tasks")).forEach((item: { action: string }) => {
                     window.siyuan.menus.menu.append(new MenuItem({
                         type: "readonly",
@@ -58,12 +58,12 @@ export const initStatus = (isWindow = false) => {
                 break;
             } else if (target.id === "statusHelp") {
                 if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-                    window.siyuan.menus.menu.element.getAttribute("data-name") === "statusHelp") {
+                    window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_STATUS_HELP) {
                     window.siyuan.menus.menu.remove();
                     return;
                 }
                 window.siyuan.menus.menu.remove();
-                window.siyuan.menus.menu.element.setAttribute("data-name", "statusHelp");
+                window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_STATUS_HELP);
                 window.siyuan.menus.menu.append(new MenuItem({
                     label: window.siyuan.languages.userGuide,
                     icon: "iconHelp",

--- a/app/src/layout/topBar.ts
+++ b/app/src/layout/topBar.ts
@@ -75,12 +75,12 @@ export const initBar = (app: App) => {
                 break;
             } else if (targetId === "barMore") {
                 if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-                    window.siyuan.menus.menu.element.getAttribute("data-name") === "barmore") {
+                    window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_BAR_MORE) {
                     window.siyuan.menus.menu.remove();
                     return;
                 }
                 window.siyuan.menus.menu.remove();
-                window.siyuan.menus.menu.element.setAttribute("data-name", "barmore");
+                window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BAR_MORE);
                 (target.getAttribute("data-hideids") || "").split(",").forEach((itemId) => {
                     const hideElement = toolbarElement.querySelector("#" + itemId);
                     const useElement = hideElement.querySelector("use");
@@ -127,12 +127,12 @@ export const initBar = (app: App) => {
                 break;
             } else if (targetId === "barMode") {
                 if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-                    window.siyuan.menus.menu.element.getAttribute("data-name") === "barmode") {
+                    window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_BAR_MORE) {
                     window.siyuan.menus.menu.remove();
                     return;
                 }
                 window.siyuan.menus.menu.remove();
-                window.siyuan.menus.menu.element.setAttribute("data-name", "barmode");
+                window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BAR_MORE);
                 window.siyuan.menus.menu.append(new MenuItem({
                     id: "themeLight",
                     label: window.siyuan.languages.themeLight,
@@ -191,12 +191,12 @@ export const initBar = (app: App) => {
                 break;
             } else if (targetId === "barZoom") {
                 if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-                    window.siyuan.menus.menu.element.getAttribute("data-name") === "barZoom") {
+                    window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_BAR_ZOOM) {
                     window.siyuan.menus.menu.remove();
                     return;
                 }
                 window.siyuan.menus.menu.remove();
-                window.siyuan.menus.menu.element.setAttribute("data-name", "barZoom");
+                window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BAR_ZOOM);
                 window.siyuan.menus.menu.append(new MenuItem({
                     label: window.siyuan.languages.zoomIn,
                     icon: "iconZoomIn",

--- a/app/src/menus/Menu.ts
+++ b/app/src/menus/Menu.ts
@@ -120,6 +120,7 @@ export class Menu {
         this.element.classList.remove("b3-menu--list", "b3-menu--fullscreen");
         this.element.removeAttribute("style");  // zIndex
         this.element.removeAttribute("data-name");    // 标识再次点击不消失
+        this.element.removeAttribute("data-subname");
         this.element.removeAttribute("data-from");    // 标识是否在浮窗内打开
         this.data = undefined;    // 移除数据
     }

--- a/app/src/menus/bookmark.ts
+++ b/app/src/menus/bookmark.ts
@@ -11,7 +11,7 @@ import {Constants} from "../constants";
 
 export const openBookmarkMenu = (element: HTMLElement, event: MouseEvent, bookmarkObj: Bookmark | MobileBookmarks) => {
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "bookmarkMenu") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_BOOKMARK) {
         window.siyuan.menus.menu.remove();
         return;
     }
@@ -92,6 +92,6 @@ export const openBookmarkMenu = (element: HTMLElement, event: MouseEvent, bookma
             }
         }).element);
     }
-    window.siyuan.menus.menu.element.setAttribute("data-name", "bookmarkMenu");
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BOOKMARK);
     window.siyuan.menus.menu.popup({x: event.clientX - 11, y: event.clientY + 11, h: 22, w: 12});
 };

--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -706,7 +706,7 @@ export const initFileMenu = (app: App, notebookId: string, pathString: string, l
             separatorPosition: "top",
         });
     }
-    window.siyuan.menus.menu.element.setAttribute("data-name", "docTreeMore");
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_DOC_TREE_MORE);
     return window.siyuan.menus.menu;
 };
 

--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -32,6 +32,7 @@ import {openByMobile} from "../protyle/util/compatibility";
 import {addFilesToDatabase} from "../protyle/render/av/addToDatabase";
 
 const initMultiMenu = (selectItemElements: NodeListOf<Element>, app: App) => {
+    window.siyuan.menus.menu.element.setAttribute("data-subname", Constants.MENU_DOC_TREE_MORE_DOCS);
     const fileItemElement = Array.from(selectItemElements).find(item => {
         if (item.getAttribute("data-type") === "navigation-file") {
             return true;
@@ -187,6 +188,7 @@ const initMultiMenu = (selectItemElements: NodeListOf<Element>, app: App) => {
 
 export const initNavigationMenu = (app: App, liElement: HTMLElement) => {
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_DOC_TREE_MORE);
     const fileElement = hasClosestByTag(liElement, "DIV");
     if (!fileElement) {
         return window.siyuan.menus.menu;
@@ -202,6 +204,8 @@ export const initNavigationMenu = (app: App, liElement: HTMLElement) => {
     const selectItemElements = fileElement.querySelectorAll(".b3-list-item--focus");
     if (selectItemElements.length > 1) {
         return initMultiMenu(selectItemElements, app);
+    } else {
+        window.siyuan.menus.menu.element.setAttribute("data-subname", Constants.MENU_DOC_TREE_MORE_NOTEBOOK);
     }
     const notebookId = liElement.parentElement.getAttribute("data-url");
     const name = getNotebookName(notebookId);
@@ -417,6 +421,7 @@ export const initNavigationMenu = (app: App, liElement: HTMLElement) => {
 
 export const initFileMenu = (app: App, notebookId: string, pathString: string, liElement: Element) => {
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_DOC_TREE_MORE);
     const fileElement = hasClosestByTag(liElement, "DIV");
     if (!fileElement) {
         return window.siyuan.menus.menu;
@@ -706,7 +711,7 @@ export const initFileMenu = (app: App, notebookId: string, pathString: string, l
             separatorPosition: "top",
         });
     }
-    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_DOC_TREE_MORE);
+    window.siyuan.menus.menu.element.setAttribute("data-subname", Constants.MENU_DOC_TREE_MORE_DOC);
     return window.siyuan.menus.menu;
 };
 

--- a/app/src/menus/protyle.ts
+++ b/app/src/menus/protyle.ts
@@ -95,7 +95,7 @@ const renderAssetList = (element: Element, k: string, position: IPosition, exts:
 };
 
 export const assetMenu = (protyle: IProtyle, position: IPosition, callback?: (url: string, name: string) => void, exts?: string[]) => {
-    const menu = new Menu("background-asset");
+    const menu = new Menu(Constants.MENU_BACKGROUND_ASSET);
     if (menu.isOpen) {
         return;
     }

--- a/app/src/menus/protyle.ts
+++ b/app/src/menus/protyle.ts
@@ -214,6 +214,7 @@ export const fileAnnotationRefMenu = (protyle: IProtyle, refElement: HTMLElement
     const id = nodeElement.getAttribute("data-node-id");
     let oldHTML = nodeElement.outerHTML;
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_INLINE_FILE_ANNOTATION_REF);
     let anchorElement: HTMLInputElement;
     window.siyuan.menus.menu.append(new MenuItem({
         id: "idAndAnchor",
@@ -348,6 +349,7 @@ export const refMenu = (protyle: IProtyle, element: HTMLElement) => {
     const id = nodeElement.getAttribute("data-node-id");
     let oldHTML = nodeElement.outerHTML;
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_INLINE_REF);
     if (!protyle.disabled) {
         window.siyuan.menus.menu.append(new MenuItem({
             id: "anchor",
@@ -706,6 +708,7 @@ export const refMenu = (protyle: IProtyle, element: HTMLElement) => {
 export const contentMenu = (protyle: IProtyle, nodeElement: Element) => {
     const range = getEditorRange(nodeElement);
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_INLINE_CONTEXT);
     /// #if MOBILE
     protyle.toolbar.showContent(protyle, range, nodeElement);
     /// #else
@@ -1074,6 +1077,7 @@ export const imgMenu = (protyle: IProtyle, range: Range, assetElement: HTMLEleme
     clientY: number
 }) => {
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_INLINE_IMG);
     const nodeElement = hasClosestBlock(assetElement);
     if (!nodeElement) {
         return;
@@ -1085,7 +1089,7 @@ export const imgMenu = (protyle: IProtyle, range: Range, assetElement: HTMLEleme
     const html = nodeElement.outerHTML;
     let src = imgElement.getAttribute("src");
     if (!src) {
-        src = ""
+        src = "";
     }
     if (!protyle.disabled) {
         window.siyuan.menus.menu.append(new MenuItem({
@@ -1454,6 +1458,7 @@ export const imgMenu = (protyle: IProtyle, range: Range, assetElement: HTMLEleme
 
 export const linkMenu = (protyle: IProtyle, linkElement: HTMLElement, focusText = false) => {
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_INLINE_A);
     const nodeElement = hasClosestBlock(linkElement);
     if (!nodeElement) {
         return;
@@ -1742,6 +1747,7 @@ style="margin:4px 0;width: ${isMobile() ? "100%" : "360px"}" class="b3-text-fiel
 
 export const tagMenu = (protyle: IProtyle, tagElement: HTMLElement) => {
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_INLINE_TAG);
     const nodeElement = hasClosestBlock(tagElement);
     if (!nodeElement) {
         return;
@@ -1900,6 +1906,7 @@ export const tagMenu = (protyle: IProtyle, tagElement: HTMLElement) => {
 
 export const inlineMathMenu = (protyle: IProtyle, element: Element) => {
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_INLINE_MATH);
     const nodeElement = hasClosestBlock(element);
     if (!nodeElement) {
         return;

--- a/app/src/menus/tab.ts
+++ b/app/src/menus/tab.ts
@@ -13,6 +13,7 @@ import {getAllWnds} from "../layout/getAll";
 import {Asset} from "../asset";
 import {writeText} from "../protyle/util/compatibility";
 import {getAssetName, pathPosix} from "../util/pathName";
+import {Constants} from "../constants";
 
 const closeMenu = (tab: Tab) => {
     const unmodifiedTabs: Tab[] = [];
@@ -181,6 +182,7 @@ const splitSubMenu = (app: App, tab: Tab) => {
 
 export const initTabMenu = (app: App, tab: Tab) => {
     window.siyuan.menus.menu.remove();
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_TAB);
     closeMenu(tab);
     window.siyuan.menus.menu.append(new MenuItem({
         id: "split",

--- a/app/src/menus/tag.ts
+++ b/app/src/menus/tag.ts
@@ -5,10 +5,11 @@ import {escapeHtml} from "../util/escape";
 import {renameTag} from "../util/noRelyPCFunction";
 import {getDockByType} from "../layout/tabUtil";
 import {Tag} from "../layout/dock/Tag";
+import {Constants} from "../constants";
 
 export const openTagMenu = (element: HTMLElement, event: MouseEvent, labelName: string) => {
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "tagMenu") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_TAG) {
         window.siyuan.menus.menu.remove();
         return;
     }
@@ -36,6 +37,6 @@ export const openTagMenu = (element: HTMLElement, event: MouseEvent, labelName: 
             }, undefined, true);
         }
     }).element);
-    window.siyuan.menus.menu.element.setAttribute("data-name", "tagMenu");
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_TAG);
     window.siyuan.menus.menu.popup({x: event.clientX - 11, y: event.clientY + 11, h: 22, w: 12});
 };

--- a/app/src/menus/workspace.ts
+++ b/app/src/menus/workspace.ts
@@ -145,13 +145,13 @@ const togglePinDock = (id: string, dock: Dock, icon: string) => {
 
 export const workspaceMenu = (app: App, rect: DOMRect) => {
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "barWorkspace") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_BAR_WORKSPACE) {
         window.siyuan.menus.menu.remove();
         return;
     }
     fetchPost("/api/system/getWorkspaces", {}, (response) => {
         window.siyuan.menus.menu.remove();
-        window.siyuan.menus.menu.element.setAttribute("data-name", "barWorkspace");
+        window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BAR_WORKSPACE);
         if (!window.siyuan.config.readonly) {
             window.siyuan.menus.menu.append(new MenuItem({
                 id: "config",

--- a/app/src/mobile/util/initFramework.ts
+++ b/app/src/mobile/util/initFramework.ts
@@ -27,7 +27,7 @@ import {showMessage} from "../../dialog/message";
 
 let custom: MobileCustom;
 const openDockMenu = (app: App) => {
-    const menu = new Menu("dockMobileMenu");
+    const menu = new Menu(Constants.MENU_DOCK_MOBILE);
     if (menu.isOpen) {
         return;
     }

--- a/app/src/plugin/Menu.ts
+++ b/app/src/plugin/Menu.ts
@@ -18,7 +18,9 @@ export class Menu {
         }
         this.menu.remove();
         if (!this.isOpen) {
-            this.menu.element.setAttribute("data-name", id || "");
+            if (id) {
+                this.menu.element.setAttribute("data-name", id);
+            }
             this.menu.removeCB = closeCB;
         }
     }

--- a/app/src/plugin/openTopBarMenu.ts
+++ b/app/src/plugin/openTopBarMenu.ts
@@ -7,7 +7,7 @@ import {openSetting} from "../config";
 import {Constants} from "../constants";
 
 export const openTopBarMenu = (app: App, target?: Element) => {
-    const menu = new Menu("topBarPlugin");
+    const menu = new Menu(Constants.MENU_BAR_PLUGIN);
     /// #if !MOBILE
     menu.addItem({
         id: "manage",

--- a/app/src/protyle/breadcrumb/index.ts
+++ b/app/src/protyle/breadcrumb/index.ts
@@ -96,7 +96,7 @@ ${padHTML}
                         });
                     } else {
                         const targetRect = target.getBoundingClientRect();
-                        openTitleMenu(protyle, {x: targetRect.right, y: targetRect.bottom, isLeft: true});
+                        openTitleMenu(protyle, {x: targetRect.right, y: targetRect.bottom, isLeft: true}, Constants.MENU_TITLE_BREADCRUMB);
                     }
                     event.stopPropagation();
                     event.preventDefault();

--- a/app/src/protyle/breadcrumb/index.ts
+++ b/app/src/protyle/breadcrumb/index.ts
@@ -199,7 +199,7 @@ ${padHTML}
     }
 
     private genMobileMenu(protyle: IProtyle) {
-        const menu = new Menu("breadcrumb-mobile-path");
+        const menu = new Menu(Constants.MENU_BREADCRUMB_MOBILE_PATH);
         let blockElement: Element;
         if (getSelection().rangeCount > 0) {
             const range = getSelection().getRangeAt(0);
@@ -245,7 +245,7 @@ ${padHTML}
 
     public showMenu(protyle: IProtyle, position: IPosition) {
         if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-            window.siyuan.menus.menu.element.getAttribute("data-name") === "breadcrumbMore") {
+            window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_BREADCRUMB_MORE) {
             window.siyuan.menus.menu.remove();
             return;
         }
@@ -256,7 +256,7 @@ ${padHTML}
         }
         fetchPost("/api/block/getTreeStat", {id: id || (protyle.block.showAll ? protyle.block.id : protyle.block.rootID)}, (response) => {
             window.siyuan.menus.menu.remove();
-            window.siyuan.menus.menu.element.setAttribute("data-name", "breadcrumbMore");
+            window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BREADCRUMB_MORE);
             if (!protyle.contentElement.classList.contains("fn__none") && !protyle.disabled) {
                 let uploadHTML = "";
                 uploadHTML = '<input class="b3-form__upload" type="file" multiple="multiple"';

--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -929,6 +929,7 @@ export class Gutter {
         const id = buttonElement.getAttribute("data-node-id");
         const selectsElement = protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select");
         if (selectsElement.length > 1) {
+            window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BLOCK_MULTI);
             const match = Array.from(selectsElement).find(item => {
                 if (id === item.getAttribute("data-node-id")) {
                     return true;
@@ -937,6 +938,8 @@ export class Gutter {
             if (match) {
                 return this.renderMultipleMenu(protyle, Array.from(selectsElement));
             }
+        } else {
+            window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_BLOCK_SINGLE);
         }
 
         let nodeElement: Element;

--- a/app/src/protyle/header/Title.ts
+++ b/app/src/protyle/header/Title.ts
@@ -183,9 +183,10 @@ export class Title {
                     event.stopPropagation();
                 }
             });
-            const iconElement = this.element.querySelector(".protyle-title__icon");
-            iconElement.addEventListener("click", () => {
-                if (window.siyuan.shiftIsPressed) {
+            const iconElement = this.element.querySelector(".protyle-title__icon") as HTMLElement;
+            iconElement.addEventListener("click", (event) => {
+                // 不使用 window.siyuan.shiftIsPressed ，否则窗口未激活时按 Shift 点击块标无法打开属性面板 https://github.com/siyuan-note/siyuan/issues/15075
+                if (event.shiftKey) {
                     fetchPost("/api/block/getDocInfo", {
                         id: protyle.block.rootID
                     }, (response) => {
@@ -193,15 +194,15 @@ export class Title {
                     });
                 } else {
                     const iconRect = iconElement.getBoundingClientRect();
-                    openTitleMenu(protyle, {x: iconRect.left, y: iconRect.bottom});
+                    openTitleMenu(protyle, {x: iconRect.left, y: iconRect.bottom}, Constants.MENU_TITLE_PROTYLE);
                 }
             });
             this.element.addEventListener("contextmenu", (event) => {
                 if (event.shiftKey) {
                     return;
                 }
-                if (getSelection().rangeCount === 0) {
-                    openTitleMenu(protyle, {x: event.clientX, y: event.clientY});
+                if (iconElement.contains((event.target as HTMLElement))) {
+                    openTitleMenu(protyle, {x: event.clientX, y: event.clientY}, Constants.MENU_TITLE_PROTYLE);
                     return;
                 }
                 protyle.toolbar?.element.classList.add("fn__none");

--- a/app/src/protyle/header/openTitleMenu.ts
+++ b/app/src/protyle/header/openTitleMenu.ts
@@ -29,7 +29,7 @@ import {hasTopClosestByClassName} from "../util/hasClosest";
 export const openTitleMenu = (protyle: IProtyle, position: IPosition) => {
     hideTooltip();
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "titleMenu") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_TITLE) {
         window.siyuan.menus.menu.remove();
         return;
     }
@@ -37,7 +37,7 @@ export const openTitleMenu = (protyle: IProtyle, position: IPosition) => {
         id: protyle.block.rootID
     }, (response) => {
         window.siyuan.menus.menu.remove();
-        window.siyuan.menus.menu.element.setAttribute("data-name", "titleMenu");
+        window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_TITLE);
         window.siyuan.menus.menu.append(new MenuItem({
             id: "copy",
             label: window.siyuan.languages.copy,

--- a/app/src/protyle/header/openTitleMenu.ts
+++ b/app/src/protyle/header/openTitleMenu.ts
@@ -26,7 +26,7 @@ import {addEditorToDatabase} from "../render/av/addToDatabase";
 import {openFileById} from "../../editor/util";
 import {hasTopClosestByClassName} from "../util/hasClosest";
 
-export const openTitleMenu = (protyle: IProtyle, position: IPosition) => {
+export const openTitleMenu = (protyle: IProtyle, position: IPosition, subname: string) => {
     hideTooltip();
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
         window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_TITLE) {
@@ -38,6 +38,7 @@ export const openTitleMenu = (protyle: IProtyle, position: IPosition) => {
     }, (response) => {
         window.siyuan.menus.menu.remove();
         window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_TITLE);
+        window.siyuan.menus.menu.element.setAttribute("data-subname", subname);
         window.siyuan.menus.menu.append(new MenuItem({
             id: "copy",
             label: window.siyuan.languages.copy,

--- a/app/src/protyle/render/av/action.ts
+++ b/app/src/protyle/render/av/action.ts
@@ -606,7 +606,7 @@ export const avContextmenu = (protyle: IProtyle, rowElement: HTMLElement, positi
                 menu.addSeparator({id: "separator_1"});
             }
             menu.addItem({
-                id: "insertRowBefore",
+                id: avType === "table" ? "insertRowBefore" : "insertItemBefore",
                 icon: "iconBefore",
                 label: `<div class="fn__flex" style="align-items: center;">
 ${window.siyuan.languages[avType === "table" ? "insertRowBefore" : "insertItemBefore"].replace("${x}", `<span class="fn__space"></span><input style="width:64px" type="number" step="1" min="1" value="1" placeholder="${window.siyuan.languages.enterKey}" class="b3-text-field"><span class="fn__space"></span>`)}
@@ -641,7 +641,7 @@ ${window.siyuan.languages[avType === "table" ? "insertRowBefore" : "insertItemBe
                 }
             });
             menu.addItem({
-                id: "insertRowAfter",
+                id: avType === "table" ? "insertRowAfter" : "insertItemAfter",
                 icon: "iconAfter",
                 label: `<div class="fn__flex" style="align-items: center;">
 ${window.siyuan.languages[avType === "table" ? "insertRowAfter" : "insertItemAfter"].replace("${x}", `<span class="fn__space"></span><input style="width:64px" type="number" step="1" min="1" placeholder="${window.siyuan.languages.enterKey}" class="b3-text-field" value="1"><span class="fn__space"></span>`)}

--- a/app/src/protyle/render/av/asset.ts
+++ b/app/src/protyle/render/av/asset.ts
@@ -199,7 +199,7 @@ export const editAssetItem = (options: {
 }) => {
     const linkAddress = removeCompressURL(options.content);
     const type = options.type as "image" | "file";
-    const menu = new Menu("av-asset-edit", () => {
+    const menu = new Menu(Constants.MENU_AV_ASSET_EDIT, () => {
         if ((!textElements[1] && textElements[0].value === linkAddress) ||
             (textElements[1] && textElements[0].value === linkAddress && textElements[1].value === options.name)) {
             return;
@@ -382,7 +382,7 @@ export const editAssetItem = (options: {
 };
 
 export const addAssetLink = (protyle: IProtyle, cellElements: HTMLElement[], target: HTMLElement, blockElement: Element) => {
-    const menu = new Menu("av-asset-link", () => {
+    const menu = new Menu(Constants.MENU_AV_ASSET_EDIT, () => {
         const textElements = menu.element.querySelectorAll("textarea");
         if (!textElements[0].value && !textElements[1].value) {
             return;

--- a/app/src/protyle/render/av/calc.ts
+++ b/app/src/protyle/render/av/calc.ts
@@ -3,6 +3,7 @@ import {transaction} from "../../wysiwyg/transaction";
 import {hasClosestBlock, hasClosestByClassName} from "../../util/hasClosest";
 import {fetchSyncPost} from "../../../util/fetch";
 import {getFieldsByData} from "./view";
+import {Constants} from "../../../constants";
 
 const calcItem = (options: {
     menu: Menu,
@@ -112,7 +113,7 @@ export const openCalcMenu = async (protyle: IProtyle, calcElement: HTMLElement, 
     if (type === "lineNumber") {
         return;
     }
-    const menu = new Menu("av-calc", () => {
+    const menu = new Menu(Constants.MENU_AV_CALC, () => {
         if (rowElement) {
             rowElement.classList.remove("av__row--show");
         }

--- a/app/src/protyle/render/av/col.ts
+++ b/app/src/protyle/render/av/col.ts
@@ -666,7 +666,7 @@ export const showColMenu = (protyle: IProtyle, blockElement: Element, cellElemen
     const blockID = blockElement.getAttribute("data-node-id");
     const oldValue = cellElement.querySelector(".av__celltext").textContent.trim();
     const oldDesc = cellElement.dataset.desc;
-    const menu = new Menu("av-header-cell", () => {
+    const menu = new Menu(Constants.MENU_AV_HEADER_CELL, () => {
         const newValue = (menu.element.querySelector(".b3-text-field") as HTMLInputElement).value;
         if (newValue !== oldValue) {
             transaction(protyle, [{
@@ -1235,7 +1235,7 @@ const genUpdateColItem = (type: TAVCol, oldType: TAVCol) => {
 };
 
 export const addCol = (protyle: IProtyle, blockElement: Element, previousID?: string) => {
-    const menu = new Menu("av-header-add");
+    const menu = new Menu(Constants.MENU_AV_HEADER_ADD);
     const avID = blockElement.getAttribute("data-av-id");
     if (typeof previousID === "undefined" && blockElement.getAttribute("data-av-type") === "table") {
         previousID = Array.from(blockElement.querySelectorAll(".av__row--header .av__cell")).pop().getAttribute("data-col-id");

--- a/app/src/protyle/render/av/filter.ts
+++ b/app/src/protyle/render/av/filter.ts
@@ -12,6 +12,7 @@ import {fetchPost, fetchSyncPost} from "../../../util/fetch";
 import {showMessage} from "../../../dialog/message";
 import {upDownHint} from "../../../util/upDownHint";
 import {getFieldsByData} from "./view";
+import {Constants} from "../../../constants";
 
 export const getDefaultOperatorByType = (type: TAVCol) => {
     if (["select", "number", "date", "created", "updated"].includes(type)) {
@@ -676,7 +677,7 @@ export const addFilter = (options: {
     protyle: IProtyle
     blockElement: Element
 }) => {
-    const menu = new Menu("av-add-filter");
+    const menu = new Menu(Constants.MENU_AV_ADD_FILTER);
     getFieldsByData(options.data).forEach((column) => {
         let filter: IAVFilter;
         options.data.view.filters.find((item) => {

--- a/app/src/protyle/render/av/groups.ts
+++ b/app/src/protyle/render/av/groups.ts
@@ -6,6 +6,7 @@ import {getFieldsByData} from "./view";
 import {fetchSyncPost} from "../../../util/fetch";
 import {Menu} from "../../../plugin/Menu";
 import {objEquals} from "../../../util/functions";
+import {Constants} from "../../../constants";
 
 export const getPageSize = (blockElement: Element) => {
     const groupPageSize: {
@@ -304,7 +305,7 @@ export const goGroupsDate = (options: {
     data: IAV;
     blockElement: Element;
 }) => {
-    const menu = new Menu("avGroupDate");
+    const menu = new Menu(Constants.MENU_AV_GROUP_DATE);
     if (menu.isOpen) {
         return;
     }
@@ -351,7 +352,7 @@ export const goGroupsSort = (options: {
     menuElement: HTMLElement;
     blockElement: Element;
 }) => {
-    const menu = new Menu("avGroupSort");
+    const menu = new Menu(Constants.MENU_AV_GROUP_SORT);
     if (menu.isOpen) {
         return;
     }

--- a/app/src/protyle/render/av/number.ts
+++ b/app/src/protyle/render/av/number.ts
@@ -1,5 +1,6 @@
 import {Menu} from "../../../plugin/Menu";
 import {transaction} from "../../wysiwyg/transaction";
+import {Constants} from "../../../constants";
 
 const addFormatItem = (options: {
     menu: Menu,
@@ -40,7 +41,7 @@ export const formatNumber = (options: {
     avID: string,
     oldFormat: string
 }) => {
-    const menu = new Menu("av-col-format-number");
+    const menu = new Menu(Constants.MENU_AV_COL_FORMAT_NUMBER);
     addFormatItem({
         menu,
         protyle: options.protyle,

--- a/app/src/protyle/render/av/row.ts
+++ b/app/src/protyle/render/av/row.ts
@@ -263,7 +263,7 @@ export const setPageSize = (options: {
     avID: string,
     nodeElement: Element
 }) => {
-    const menu = new Menu("av-page-size");
+    const menu = new Menu(Constants.MENU_AV_PAGE_SIZE);
     if (menu.isOpen) {
         return;
     }

--- a/app/src/protyle/render/av/select.ts
+++ b/app/src/protyle/render/av/select.ts
@@ -11,6 +11,7 @@ import {genCellValueByElement, getTypeByCellElement} from "./cell";
 import * as dayjs from "dayjs";
 import {getFieldsByData} from "./view";
 import {getFieldIdByCellElement} from "./row";
+import {Constants} from "../../../constants";
 
 let cellValues: IAVCellValue[];
 
@@ -152,7 +153,7 @@ export const setColOption = (protyle: IProtyle, data: IAV, target: HTMLElement, 
     let desc = target.parentElement.dataset.desc;
     let color = target.parentElement.dataset.color;
     const fields = getFieldsByData(data);
-    const menu = new Menu("av-col-option", () => {
+    const menu = new Menu(Constants.MENU_AV_COL_OPTION, () => {
         if ((name === inputElement.value && desc === descElement.value) || !inputElement.value) {
             return;
         }

--- a/app/src/protyle/render/av/sort.ts
+++ b/app/src/protyle/render/av/sort.ts
@@ -4,6 +4,7 @@ import {transaction} from "../../wysiwyg/transaction";
 import {setPosition} from "../../../util/setPosition";
 import {unicode2Emoji} from "../../../emoji";
 import {getFieldsByData} from "./view";
+import {Constants} from "../../../constants";
 
 export const addSort = (options: {
     data: IAV,
@@ -14,7 +15,7 @@ export const addSort = (options: {
     protyle: IProtyle,
     blockID: string,
 }) => {
-    const menu = new Menu("av-add-sort");
+    const menu = new Menu(Constants.MENU_AV_ADD_SORT);
     const fields = getFieldsByData(options.data);
     fields.forEach((column) => {
         let hasSort = false;

--- a/app/src/protyle/render/av/sort.ts
+++ b/app/src/protyle/render/av/sort.ts
@@ -131,11 +131,11 @@ export const getSortsHTML = (columns: IAVColumn[], sorts: IAVSort[]) => {
 ${html}
 <button class="b3-menu__item${sorts.length === columns.length ? " fn__none" : ""}" data-type="addSort">
     <svg class="b3-menu__icon"><use xlink:href="#iconAdd"></use></svg>
-    <span class="b3-menu__label">${window.siyuan.languages.new}</span>
+    <span class="b3-menu__label">${window.siyuan.languages.addSort}</span>
 </button>
 <button class="b3-menu__item b3-menu__item--warning${html ? "" : " fn__none"}" data-type="removeSorts">
     <svg class="b3-menu__icon"><use xlink:href="#iconTrashcan"></use></svg>
-    <span class="b3-menu__label">${window.siyuan.languages.delete}</span>
+    <span class="b3-menu__label">${window.siyuan.languages.removeSorts}</span>
 </button>
 </div>`;
 };

--- a/app/src/protyle/render/av/view.ts
+++ b/app/src/protyle/render/av/view.ts
@@ -12,7 +12,7 @@ export const openViewMenu = (options: { protyle: IProtyle, blockElement: HTMLEle
     if (options.protyle.disabled) {
         return;
     }
-    const menu = new Menu("av-view");
+    const menu = new Menu(Constants.MENU_AV_VIEW);
     if (menu.isOpen) {
         return;
     }

--- a/app/src/search/assets.ts
+++ b/app/src/search/assets.ts
@@ -259,12 +259,12 @@ export const renderNextAssetMark = (element: Element) => {
 export const assetMethodMenu = (target: HTMLElement, cb: () => void) => {
     const method = window.siyuan.storage[Constants.LOCAL_SEARCHASSET].method;
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "searchAssetMethod") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_SEARCH_ASSET_METHOD) {
         window.siyuan.menus.menu.remove();
         return;
     }
     window.siyuan.menus.menu.remove();
-    window.siyuan.menus.menu.element.setAttribute("data-name", "searchAssetMethod");
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_SEARCH_ASSET_METHOD);
     window.siyuan.menus.menu.append(new MenuItem({
         icon: "iconExact",
         label: window.siyuan.languages.keyword,
@@ -345,12 +345,12 @@ export const assetFilterMenu = (assetsElement: Element) => {
 
 export const assetMoreMenu = (target: Element, element: Element, cb: () => void) => {
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "searchAssetMore") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_SEARCH_ASSET_MORE) {
         window.siyuan.menus.menu.remove();
         return;
     }
     window.siyuan.menus.menu.remove();
-    window.siyuan.menus.menu.element.setAttribute("data-name", "searchAssetMore");
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_SEARCH_ASSET_MORE);
     const localData = window.siyuan.storage[Constants.LOCAL_SEARCHASSET];
     const sortMenu = [{
         iconHTML: "",

--- a/app/src/search/menu.ts
+++ b/app/src/search/menu.ts
@@ -233,12 +233,12 @@ export const replaceFilterMenu = (config: Config.IUILayoutTabSearchConfig) => {
 
 export const queryMenu = (config: Config.IUILayoutTabSearchConfig, cb: () => void) => {
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "searchMethod") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_SEARCH_METHOD) {
         window.siyuan.menus.menu.remove();
         return;
     }
     window.siyuan.menus.menu.remove();
-    window.siyuan.menus.menu.element.setAttribute("data-name", "searchMethod");
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_SEARCH_METHOD);
     window.siyuan.menus.menu.append(new MenuItem({
         icon: "iconExact",
         label: window.siyuan.languages.keyword,
@@ -410,12 +410,12 @@ export const moreMenu = async (config: Config.IUILayoutTabSearchConfig,
                                removeCriterion: () => void,
                                layoutMenu?: () => void) => {
     if (!window.siyuan.menus.menu.element.classList.contains("fn__none") &&
-        window.siyuan.menus.menu.element.getAttribute("data-name") === "searchMore") {
+        window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_SEARCH_MORE) {
         window.siyuan.menus.menu.remove();
         return;
     }
     window.siyuan.menus.menu.remove();
-    window.siyuan.menus.menu.element.setAttribute("data-name", "searchMore");
+    window.siyuan.menus.menu.element.setAttribute("data-name", Constants.MENU_SEARCH_MORE);
     /// #if MOBILE
     window.siyuan.menus.menu.append(new MenuItem({
         iconHTML: "",

--- a/app/src/search/toggleHistory.ts
+++ b/app/src/search/toggleHistory.ts
@@ -16,7 +16,7 @@ export const toggleReplaceHistory = (replaceInputElement: HTMLInputElement) => {
     if (!list.replaceKeys || list.replaceKeys.length === 0 || (list.length === 1 && list[0] === replaceInputElement.value)) {
         return;
     }
-    const menu = new Menu("search-replace-history");
+    const menu = new Menu(Constants.MENU_SEARCH_REPLACE_HISTORY);
     if (menu.isOpen) {
         return;
     }
@@ -84,7 +84,7 @@ export const toggleSearchHistory = (searchElement: Element, config: Config.IUILa
     if (!list.keys || list.keys.length === 0 || (list.length === 1 && list[0] === searchInputElement.value)) {
         return;
     }
-    const menu = new Menu("search-history");
+    const menu = new Menu(Constants.MENU_SEARCH_HISTORY);
     if (menu.isOpen) {
         return;
     }
@@ -158,7 +158,7 @@ export const toggleAssetHistory = (assetElement: Element) => {
     if (!keys || keys.length === 0 || (keys.length === 1 && keys[0] === assetInputElement.value)) {
         return;
     }
-    const menu = new Menu("search-asset-history");
+    const menu = new Menu(Constants.MENU_SEARCH_ASSET_HISTORY);
     if (menu.isOpen) {
         return;
     }

--- a/app/src/search/unRef.ts
+++ b/app/src/search/unRef.ts
@@ -133,7 +133,7 @@ ${getAttr(item)}
 };
 
 export const unRefMoreMenu = (target: Element, element: Element, edit: Protyle) => {
-    const menu = new Menu("searchUnRefMore");
+    const menu = new Menu(Constants.MENU_SEARCH_UNREF_MORE);
     if (menu.isOpen) {
         return;
     }

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -272,7 +272,7 @@ export const movePathTo = (cb: (toPath: string[], toNotebook: string[]) => void,
         if (!keys || keys.length === 0 || (keys.length === 1 && keys[0] === inputElement.value)) {
             return;
         }
-        const menu = new Menu("move-path-history");
+        const menu = new Menu(Constants.MENU_MOVE_PATH_HISTORY);
         if (menu.isOpen) {
             return;
         }
@@ -364,7 +364,7 @@ export const movePathTo = (cb: (toPath: string[], toNotebook: string[]) => void,
             toggleMovePathHistory();
             return;
         }
-        if (window.siyuan.menus.menu.element.getAttribute("data-name") === "move-path-history") {
+        if (window.siyuan.menus.menu.element.getAttribute("data-name") === Constants.MENU_MOVE_PATH_HISTORY) {
             return;
         }
         const currentPanelElement = searchListElement.classList.contains("fn__none") ? searchTreeElement : searchListElement;


### PR DESCRIPTION
### 01

更换数据库排序菜单的文案为：

<img width="472" height="279" alt="image" src="https://github.com/user-attachments/assets/3c85ce25-43ae-48a3-9854-6b75231a6597" />

跟筛选菜单的文案形式保持一致：

<img width="469" height="270" alt="image" src="https://github.com/user-attachments/assets/f8fc227c-6e6d-4a9a-bc3f-f679fe301191" />

### 02

把已有的 #commonMenu 元素的 data-name 属性值都提取到 Constants 里，方便插件使用（还需要修改 petal）。例如：

<img width="916" height="77" alt="image" src="https://github.com/user-attachments/assets/aa097dfb-1d42-4351-807d-980de1dff8d6" />

### 03

为一些菜单增加了 data-name 属性或 data-subname 属性，以满足插件、主题、代码片段的开发需求 https://github.com/siyuan-note/siyuan/issues/12506 。例如：

<img width="1053" height="220" alt="image" src="https://github.com/user-attachments/assets/8d438422-e432-4a05-94a0-e40a4885901a" />

<img width="1014" height="72" alt="image" src="https://github.com/user-attachments/assets/90341e47-878e-42f1-924d-a961321a9efc" />

### 04

大纲相关菜单添加 data-name 和 data-id 属性 https://github.com/siyuan-note/siyuan/issues/16133 。例如：

<img width="477" height="120" alt="image" src="https://github.com/user-attachments/assets/773629d1-55e1-4474-b471-b54d663db949" />

### 05

改进点击文档块标打开菜单或属性面板：（还有另一半改进在 https://github.com/siyuan-note/siyuan/pull/16142 ）

<img width="1414" height="394" alt="image" src="https://github.com/user-attachments/assets/3be48c5a-3802-410c-ac4a-f22112f2e0cd" />

<img width="952" height="188" alt="image" src="https://github.com/user-attachments/assets/c450e6e3-72b9-473d-9c66-168367dc979c" />

