### PR TITLE
Add focus handling for paste actions in content menu and toolbar

### DIFF
--- a/app/src/menus/protyle.ts
+++ b/app/src/menus/protyle.ts
@@ -825,6 +825,7 @@ export const contentMenu = (protyle: IProtyle, nodeElement: Element) => {
             icon: "iconPaste",
             accelerator: "⌘V",
             async click() {
+                focusByRange(getEditorRange(nodeElement));
                 if (document.queryCommandSupported("paste")) {
                     document.execCommand("paste");
                 } else {
@@ -850,6 +851,7 @@ export const contentMenu = (protyle: IProtyle, nodeElement: Element) => {
             id: "pasteEscaped",
             label: window.siyuan.languages.pasteEscaped,
             click() {
+                focusByRange(getEditorRange(nodeElement));
                 pasteEscaped(protyle, nodeElement);
             }
         }).element);

--- a/app/src/protyle/toolbar/index.ts
+++ b/app/src/protyle/toolbar/index.ts
@@ -1685,6 +1685,7 @@ ${item.name}
                 updateTransaction(protyle, nodeElement.getAttribute("data-node-id"), nodeElement.outerHTML, oldHTML);
                 this.subElement.classList.add("fn__none");
             } else if (action === "paste") {
+                focusByRange(getEditorRange(nodeElement));
                 if (document.queryCommandSupported("paste")) {
                     document.execCommand("paste");
                 } else {
@@ -1708,6 +1709,7 @@ ${item.name}
                 pasteAsPlainText(protyle);
                 this.subElement.classList.add("fn__none");
             } else if (action === "pasteEscaped") {
+                focusByRange(getEditorRange(nodeElement));
                 pasteEscaped(protyle, nodeElement);
                 this.subElement.classList.add("fn__none");
             } else if (action === "back") {


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/16100 02

按照“粘贴为纯文本”的逻辑，依葫芦画瓢加了一行 `focusByRange(getEditorRange(nodeElement));`

> 我这里在两种情况可以重现光标移动到文档开头：
> 
> - 右键菜单 - 粘贴 - 弹出网页对话框 - 按回车
> - 右键菜单 - 粘贴转义文本 - 弹出网页对话框 - 鼠标点击“确定”按钮
> 
> 虽然我没搞明白这是为什么，但我这样改了一下之后就没有问题了