### PR TITLE
The plugin was not executed uninstall() when being uninstalled

### DIFF
--- a/app/src/config/bazaar.ts
+++ b/app/src/config/bazaar.ts
@@ -838,9 +838,6 @@ export const bazaar = {
                             }, response => {
                                 this._genMyHTML(bazaarType, app);
                                 bazaar._onBazaar(response, bazaarType, ["themes", "icons"].includes(bazaarType));
-                                if (bazaarType === "plugins") {
-                                    uninstall(app, packageName, true);
-                                }
                             });
                         });
                     }
@@ -923,7 +920,7 @@ export const bazaar = {
                             if (window.siyuan.config.bazaar.petalDisabled) {
                                 bazaar.element.querySelectorAll("#configBazaarDownloaded .b3-card").forEach(item => {
                                     item.classList.add("b3-card--disabled");
-                                    uninstall(app, JSON.parse(item.getAttribute("data-obj")).name);
+                                    uninstall(app, JSON.parse(item.getAttribute("data-obj")).name, false);
                                 });
                             } else {
                                 bazaar.element.querySelectorAll("#configBazaarDownloaded .b3-card").forEach(item => {
@@ -961,7 +958,7 @@ export const bazaar = {
                                     }
                                 });
                             } else {
-                                uninstall(app, dataObj.name);
+                                uninstall(app, dataObj.name, false);
                                 target.parentElement.querySelector('[data-type="setting"]').classList.add("fn__none");
                             }
                         });

--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -211,8 +211,11 @@ export const afterLoadPlugin = (plugin: Plugin) => {
 };
 
 export const reloadPlugin = async (app: App, data: { upsertPlugins: string[], removePlugins: string[] }) => {
-    data.removePlugins.concat(data.upsertPlugins).forEach((item) => {
-        uninstall(app, item);
+    data.removePlugins.forEach((item) => {
+        uninstall(app, item, true);
+    });
+    data.upsertPlugins.forEach((item) => {
+        uninstall(app, item, false);
     });
     loadPlugins(app, data.upsertPlugins).then(() => {
         app.plugins.forEach(item => {

--- a/app/src/plugin/uninstall.ts
+++ b/app/src/plugin/uninstall.ts
@@ -1,5 +1,5 @@
 import {App} from "../index";
-import {Plugin} from "../plugin";
+import {Plugin} from "./index";
 /// #if !MOBILE
 import {getAllModels} from "../layout/getAll";
 import {resizeTopBar} from "../layout/util";
@@ -8,19 +8,22 @@ import {Constants} from "../constants";
 import {setStorageVal} from "../protyle/util/compatibility";
 import {getAllEditor} from "../layout/getAll";
 
-export const uninstall = (app: App, name: string, isUninstall = false) => {
+export const uninstall = (app: App, name: string, isUninstall: boolean) => {
     app.plugins.find((plugin: Plugin, index) => {
         if (plugin.name === name) {
-            // rm command
             try {
                 plugin.onunload();
-                if (isUninstall) {
-                    plugin.uninstall();
-                    window.siyuan.storage[Constants.LOCAL_PLUGIN_DOCKS][plugin.name] = {};
-                    setStorageVal(Constants.LOCAL_PLUGIN_DOCKS, window.siyuan.storage[Constants.LOCAL_PLUGIN_DOCKS]);
-                }
             } catch (e) {
                 console.error(`plugin ${plugin.name} onunload error:`, e);
+            }
+            if (isUninstall) {
+                try {
+                    plugin.uninstall();
+                } catch (e) {
+                    console.error(`plugin ${plugin.name} uninstall error:`, e);
+                }
+                window.siyuan.storage[Constants.LOCAL_PLUGIN_DOCKS][plugin.name] = {};
+                setStorageVal(Constants.LOCAL_PLUGIN_DOCKS, window.siyuan.storage[Constants.LOCAL_PLUGIN_DOCKS]);
             }
             // rm tab
             /// #if !MOBILE


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/16156

卸载插件目前由内核推送，调用 reloadPlugin() 函数之后没有执行插件的 uninstall() 方法。