### PR TITLE
Add onDataChanged method to handle data changes in the plugin

### DIFF
--- a/app/src/config/bazaar.ts
+++ b/app/src/config/bazaar.ts
@@ -798,7 +798,8 @@ export const bazaar = {
                                     app.plugins.find((item: Plugin) => {
                                         if (item.name === dataObj.name) {
                                             reloadPlugin(app, {
-                                                upsertPlugins: [dataObj.name],
+                                                upsertCodePlugins: [dataObj.name],
+                                                upsertDataPlugins: [],
                                                 removePlugins: []
                                             });
                                             return true;

--- a/app/src/plugin/index.ts
+++ b/app/src/plugin/index.ts
@@ -113,6 +113,10 @@ export class Plugin {
         // 卸载
     }
 
+    public onDataChanged() {
+        // 存储数据变更
+    }
+
     public async updateCards(options: ICardData) {
         return options;
     }

--- a/kernel/api/petal.go
+++ b/kernel/api/petal.go
@@ -67,10 +67,10 @@ func setPetalEnabled(c *gin.Context) {
 		app = arg["app"].(string)
 	}
 	if enabled {
-		upsertPluginSet := hashset.New(packageName)
-		model.PushReloadPlugin(upsertPluginSet, nil, app)
+		upsertPluginCodeSet := hashset.New(packageName)
+		model.PushReloadPlugin(upsertPluginCodeSet, nil, nil, app)
 	} else {
 		removePluginSet := hashset.New(packageName)
-		model.PushReloadPlugin(nil, removePluginSet, app)
+		model.PushReloadPlugin(nil, nil, removePluginSet, app)
 	}
 }

--- a/kernel/model/bazzar.go
+++ b/kernel/model/bazzar.go
@@ -257,7 +257,7 @@ func UninstallBazaarPlugin(pluginName, frontend string) error {
 	savePetals(petals)
 
 	removePluginSet := hashset.New(pluginName)
-	pushReloadPlugin(nil, removePluginSet, "")
+	PushReloadPlugin(nil, nil, removePluginSet, "")
 	return nil
 }
 


### PR DESCRIPTION
给插件添加 onDataChanged 方法，用来替代同步之后插件先 onunload 再 onload，解决我在 https://github.com/siyuan-note/siyuan/issues/15444#issue-3292505500 遇到的问题

基于前一个 PR 修改，需要先合并：https://github.com/siyuan-note/siyuan/pull/16243

---

需要测试：

- [x] 存在 onDataChanged 方法
- [x] 不存在 onDataChanged 方法

---

- [x] 文件删除
- [x] 文件夹删除
- [x] 文件新增
- [x] 文件夹新增
- [x] 文件内容更新

---

- [ ] 还需要修改示例插件和 petal https://github.com/siyuan-note/petal/issues/42