### PR TITLE
Reset recent-doc.json on unmarshal failure

### DIFF
--- a/kernel/model/storage.go
+++ b/kernel/model/storage.go
@@ -232,6 +232,10 @@ func getRecentDocs(sortBy string) (ret []*RecentDoc, err error) {
 
 	if err = gulu.JSON.UnmarshalJSON(data, &tmp); err != nil {
 		logging.LogErrorf("unmarshal storage [recent-doc] failed: %s", err)
+		if err = setRecentDocs([]*RecentDoc{}); err != nil {
+			logging.LogErrorf("reset storage [recent-doc] failed: %s", err)
+		}
+		ret = []*RecentDoc{}
 		return
 	}
 


### PR DESCRIPTION
[recent-doc.json](https://github.com/user-attachments/files/23239971/recent-doc.json) 文件损坏的情况下，在思源中会频繁报错：

```
invalid character '\x00' looking for beginning of value
```

<img width="576" height="252" alt="image" src="https://github.com/user-attachments/assets/f0c83ba0-238f-45ff-aa9c-59ca0647d87a" />

对应内核日志：

```
unmarshal storage [recent-doc] failed: invalid character '\x00' looking for beginning of value
```