### PR TITLE
Fix path retrieval in CreateWithMarkdown function

### DIFF
--- a/kernel/model/file.go
+++ b/kernel/model/file.go
@@ -1073,7 +1073,12 @@ func CreateWithMarkdown(tags, boxID, hPath, md, parentID, id string, withMath bo
 	SetBlockAttrs(retID, nameValues)
 
 	FlushTxQueue()
-	box.addMinSort(path.Dir(hPath), retID)
+	docPath, _, err := GetPathByID(retID)
+	if err != nil {
+		logging.LogWarnf("get path by id [%s] failed: %s", retID, err)
+		return
+	}
+	box.addMinSort(path.Dir(docPath), retID)
 	return
 }
 


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/16026

剪藏会有这样的报错：

```
E 2025/11/02 23:20:04 file.go:1994: list doc tree failed: open D:\Datafile\SiYuan\data\20230616211653-mofivww\收集箱\2025年 11月: The system cannot find the path specified.
E 2025/11/03 00:29:07 file.go:1994: list doc tree failed: open D:\Datafile\SiYuan\data\20230616211653-mofivww\网页剪藏: The system cannot find the file specified.
```