### PR TITLE
Clear container content when initializing mobile plugin sidebar

### DIFF
--- a/app/src/mobile/util/initFramework.ts
+++ b/app/src/mobile/util/initFramework.ts
@@ -45,7 +45,9 @@ const openDockMenu = (app: App) => {
                                 custom.destroy();
                             }
                         }
-                        custom = plugin.docks[dockId].mobileModel(document.querySelector('#sidebar [data-type="sidebar-plugin"]'));
+                        const pluginPanelElement = document.querySelector('#sidebar [data-type="sidebar-plugin"]');
+                        pluginPanelElement.innerHTML = "";
+                        custom = plugin.docks[dockId].mobileModel(pluginPanelElement);
                         window.siyuan.mobile.docks[dockId] = custom;
                     }
                 }


### PR DESCRIPTION
我观察到各种插件都没有清空侧边栏容器内容的习惯，导致切换不同的插件侧边栏时没有移除前一个侧边栏的元素：

[video.webm](https://github.com/user-attachments/assets/6fc40de0-d212-4d76-b156-1c511a22e0bb)

本 PR 修改之后，先清空侧边栏容器内容再初始化插件侧边栏：

[video.webm](https://github.com/user-attachments/assets/8cbb24d3-76fc-4189-b201-f9dceb22fe17)
