### PR TITLE
fix: `setAttributesViewGroup` timing error

### DIFF
--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -721,6 +721,8 @@ func ChangeAttrViewLayout(blockID, avID string, layout av.LayoutType) (err error
 		return
 	}
 
+	view.LayoutType = newLayout
+
 	switch newLayout {
 	case av.LayoutTypeTable:
 		if view.Name == av.GetAttributeViewI18n("gallery") || view.Name == av.GetAttributeViewI18n("kanban") {
@@ -787,8 +789,6 @@ func ChangeAttrViewLayout(blockID, avID string, layout av.LayoutType) (err error
 		group := &av.ViewGroup{Field: preferredGroupKey.ID}
 		setAttributeViewGroup(attrView, view, group)
 	}
-
-	view.LayoutType = newLayout
 
 	blockIDs := treenode.GetMirrorAttrViewBlockIDs(avID)
 	for _, bID := range blockIDs {

--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -2860,10 +2860,6 @@ func addAttrViewView(avID, viewID, blockID string, layout av.LayoutType) (err er
 				view.Kanban.Fields = append(view.Kanban.Fields, &av.ViewKanbanField{BaseField: &av.BaseField{ID: field.ID}})
 			}
 		}
-
-		preferredGroupKey := getKanbanPreferredGroupKey(attrView)
-		group := &av.ViewGroup{Field: preferredGroupKey.ID}
-		setAttributeViewGroup(attrView, view, group)
 	default:
 		err = av.ErrWrongLayoutType
 		logging.LogErrorf("wrong layout type [%s] for attribute view [%s]", layout, avID)
@@ -2874,6 +2870,12 @@ func addAttrViewView(avID, viewID, blockID string, layout av.LayoutType) (err er
 	attrView.ViewID = viewID
 	view.ID = viewID
 	attrView.Views = append(attrView.Views, view)
+
+	if av.LayoutTypeKanban == layout {
+		preferredGroupKey := getKanbanPreferredGroupKey(attrView)
+		group := &av.ViewGroup{Field: preferredGroupKey.ID}
+		setAttributeViewGroup(attrView, view, group)
+	}
 
 	node, tree, _ := getNodeByBlockID(nil, blockID)
 	if nil == node {


### PR DESCRIPTION
fixed error when `setAttributeViewGroup()` tries to access  `attrView.Views` before kanban view is added

### Cause
`setAttributeViewGroup()` accessing `attrView.Views` before new kanban view is appended

### Fix
Reorder so that new kanban is appended to views before `setAttributeViewGroup()` is called

closes https://github.com/siyuan-note/siyuan/issues/16274