### PR TITLE
Fix kanban attrView followup

### DIFF
--- a/kernel/model/attribute_view_render.go
+++ b/kernel/model/attribute_view_render.go
@@ -87,10 +87,19 @@ func renderAttributeView(attrView *av.AttributeView, nodeID, viewID, query strin
 	return
 }
 
-func renderAttributeViewGroups(viewable av.Viewable, attrView *av.AttributeView, view *av.View, query string, page, pageSize int, groupPaging map[string]interface{}) (err error) {
+func renderAttributeViewGroups(viewable av.Viewable, attrView *av.AttributeView, view *av.View,
+	query string, page, pageSize int, groupPaging map[string]interface{}) (err error) {
 	groupKey := view.GetGroupKey(attrView)
 	if nil == groupKey {
-		return
+		if view.LayoutType == av.LayoutTypeKanban {
+			preferredGroupKey := getKanbanPreferredGroupKey(attrView)
+			group := &av.ViewGroup{Field: preferredGroupKey.ID}
+			setAttributeViewGroup(attrView, view, group)
+			av.SaveAttributeView(attrView)
+			groupKey = view.GetGroupKey(attrView)
+		} else {
+			return
+		}
 	}
 
 	// 当前日期可能会变，所以如果是按日期分组则需要重新生成分组

--- a/kernel/model/attribute_view_render.go
+++ b/kernel/model/attribute_view_render.go
@@ -87,8 +87,7 @@ func renderAttributeView(attrView *av.AttributeView, nodeID, viewID, query strin
 	return
 }
 
-func renderAttributeViewGroups(viewable av.Viewable, attrView *av.AttributeView, view *av.View,
-	query string, page, pageSize int, groupPaging map[string]interface{}) (err error) {
+func renderAttributeViewGroups(viewable av.Viewable, attrView *av.AttributeView, view *av.View, query string, page, pageSize int, groupPaging map[string]interface{}) (err error) {
 	groupKey := view.GetGroupKey(attrView)
 	if nil == groupKey {
 		if view.LayoutType == av.LayoutTypeKanban {


### PR DESCRIPTION
Followup to https://github.com/siyuan-note/siyuan/pull/16275

### Issue
After previous change, "Cannot read properties of undefined (reading 'forEach')" error still occurs in other scenarios where kanban group key becomes null:
1. user changes field type (e.g. select -> multiselect)
2. user deletes group key column
3. user manually sets Group -> Grouping method -> None

### Fix
Use existing `getKanbanPreferredGroupKey()` logic from kenban view creation in any scenario where kenban `groupKey` is nil
