### PR TITLE
Improve line number rendering by copying font styles

### DIFF
--- a/app/src/protyle/render/highlightRender.ts
+++ b/app/src/protyle/render/highlightRender.ts
@@ -141,11 +141,16 @@ export const lineNumberRender = (block: HTMLElement, zoom = 1) => {
         const lineNumberTemp = document.createElement("div");
         lineNumberTemp.className = "hljs";
         // 不能使用 codeElement.clientWidth，被忽略小数点导致宽度不一致
+        // 需要手动复制字体样式 https://ld246.com/article/1762527296449
         lineNumberTemp.setAttribute("style", `padding-left:${codeElement.style.paddingLeft};
 width: ${codeElement.getBoundingClientRect().width / zoom}px;
 white-space:${codeElementStyle.whiteSpace};
 word-break:${codeElementStyle.wordBreak};
 font-variant-ligatures:${codeElementStyle.fontVariantLigatures};
+font-family:${codeElementStyle.fontFamily};
+font-size:${codeElementStyle.fontSize};
+line-height:${codeElementStyle.lineHeight};
+font-weight:${codeElementStyle.fontWeight};
 padding-right:0;max-height: none;box-sizing: border-box;position: absolute;padding-top:0 !important;padding-bottom:0 !important;min-height:auto !important;`);
         lineNumberTemp.setAttribute("contenteditable", "true");
         block.insertAdjacentElement("afterend", lineNumberTemp);


### PR DESCRIPTION
使用思源宋体时，代码块行号对不齐 https://ld246.com/article/1762527296449

---

- https://github.com/adobe-fonts/source-han-serif/tree/release/?tab=readme-ov-file#otf
- 字体文件：https://github.com/adobe-fonts/source-han-serif/raw/release/Variable/WOFF2/OTF/SourceHanSerifSC-VF.otf.woff2

```css
@font-face {
	font-family:"Noto Serif CJK";
	src:local("Noto Serif CJK"),url("./snippets/SourceHanSerifSC-VF.otf.woff2")format("woff2");
	font-style:normal;
	font-display:swap;
}
* {
  font-family:"Noto Serif CJK";
  font-weight: normal;
}
```