### PR TITLE
Fix rootID reference in Title component

### DIFF
--- a/app/src/protyle/header/Title.ts
+++ b/app/src/protyle/header/Title.ts
@@ -360,6 +360,7 @@ export class Title {
                 this.element.classList.remove("fn__none");
             }
         }
+        protyle.block.rootID = response.data.rootID;
         if (this.element.getAttribute("data-render") === "true" && this.element.dataset.nodeId === protyle.block.rootID) {
             return false;
         }


### PR DESCRIPTION
搜索结果的文档标题上的 data-node-id 是错误的。

在渲染标题的时候 protyle.block.rootID 还是上一个文档的（如果是第一个文档那就是 undefined），要使用 response.data.rootID

p.s. 我的挂件在搜索窗口里坏掉了，于是才发现这个问题