### PR TITLE
`Duplicate` then select the block

### DIFF
--- a/app/src/protyle/wysiwyg/commonHotkey.ts
+++ b/app/src/protyle/wysiwyg/commonHotkey.ts
@@ -280,7 +280,6 @@ export const duplicateBlock = async (nodeElements: Element[], protyle: IProtyle)
     const foldHeadingIds = [];
     for (let index = nodeElements.length - 1; index >= 0; --index) {
         const item = nodeElements[index];
-        item.classList.remove("protyle-wysiwyg--select");
         let tempElement = item.cloneNode(true) as HTMLElement;
         const newId = Lute.NewNodeID();
         if (item.getAttribute("data-type") !== "NodeBlockQueryEmbed" &&
@@ -327,6 +326,7 @@ export const duplicateBlock = async (nodeElements: Element[], protyle: IProtyle)
             childItem.removeAttribute("refcount");
             childItem.lastElementChild.querySelector(".protyle-attr--refcount")?.remove();
         });
+        item.classList.remove("protyle-wysiwyg--select");
         if (typeof starIndex === "number") {
             const orderIndex = starIndex + index + 1;
             tempElement.setAttribute("data-marker", (orderIndex) + ".");


### PR DESCRIPTION
`复制为副本` 之后选中块

之前在 https://github.com/siyuan-note/siyuan/issues/14567 实现了，但在 https://github.com/siyuan-note/siyuan/commit/4499a12107e34caa97aadb2b9a29abc3eb45e69c 又改没了，本 PR 恢复原来的逻辑