### PR TITLE
Prevent scroll jump on heading expansion

### DIFF
--- a/app/src/protyle/wysiwyg/transaction.ts
+++ b/app/src/protyle/wysiwyg/transaction.ts
@@ -389,7 +389,6 @@ export const onTransaction = (protyle: IProtyle, operation: IOperation, isUndo: 
         return;
     }
     if (operation.action === "unfoldHeading") {
-        const scrollTop = protyle.contentElement.scrollTop;
         protyle.wysiwyg.element.querySelectorAll(`[data-node-id="${operation.id}"]`).forEach(item => {
             item.removeAttribute("fold");
             // undo 会走 transaction
@@ -418,8 +417,6 @@ export const onTransaction = (protyle: IProtyle, operation: IOperation, isUndo: 
             highlightRender(protyle.wysiwyg.element);
             avRender(protyle.wysiwyg.element, protyle);
             blockRender(protyle, protyle.wysiwyg.element);
-            protyle.contentElement.scrollTop = scrollTop;
-            protyle.scroll.lastScrollTop = scrollTop;
         }
         return;
     }


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/15715

其他编辑器收到展开标题块的推送时，不恢复滚动位置，让浏览器自然处理。这样可以避免在分屏编辑时，一个编辑器展开标题块导致另一个编辑器滚动。

本 PR 修改之后的效果：

[video.webm](https://github.com/user-attachments/assets/ea5d0921-f496-4a91-a665-c4be8d44154f)
