### PR TITLE
Fix the issue where copying and pasting serial numbers causes abnormal states

### DIFF
--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -713,8 +713,8 @@
   }
 }
 
-// 只读情况下列表前的圆点需要可以点击进行缩放
 .protyle .protyle-wysiwyg {
+  // 只读情况下列表前的圆点需要可以点击进行缩放
   .li[data-subtype="o"] > .protyle-action,
   .li[data-subtype="u"] > .protyle-action,
   &[data-readonly="false"] .li[data-subtype="t"] > .protyle-action {
@@ -727,6 +727,11 @@
 
       color: var(--b3-theme-on-background);
     }
+  }
+
+  // 复制粘贴序号会状态异常 https://ld246.com/article/1762691143057
+  .li > .protyle-action {
+    user-select: none;
   }
 }
 


### PR DESCRIPTION
https://ld246.com/article/1762691143057 01

![PixPin_2025-11-09_22-56-03](https://github.com/user-attachments/assets/39eb0b6e-db03-463e-9275-486ff7de3b9e)

只读模式下复制列表能得到这样的 text/siyuan，粘贴到编辑器会导致状态异常：

```html
<div class="protyle-action protyle-action--order" contenteditable="false" draggable="false">1.</div>
<div data-node-id="20251109220925-6541g5e" data-node-index="1" data-type="NodeParagraph" class="p" updated="20251109220928"><div contenteditable="true" spellcheck="false">1111111111111</div></div>
```