### PR TITLE
Sublist of `Add to Database` clearly displays the view name

### DIFF
--- a/app/src/protyle/render/av/relation.ts
+++ b/app/src/protyle/render/av/relation.ts
@@ -52,8 +52,8 @@ const genSearchList = (element: Element, keyword: string, avId?: string, exclude
                 item.children.forEach((subItem) => {
                     const viewDefaultName = getViewName(subItem.viewLayout);
                     html += `<div style="padding-left: 48px;" class="b3-list-item b3-list-item--narrow" data-av-id="${subItem.avID}" data-view-id="${subItem.viewID}">
-<span class="b3-list-item__text">${escapeHtml(subItem.avName || window.siyuan.languages._kernel[267])}</span> 
-<span class="b3-list-item__meta">${escapeHtml(subItem.viewName)}${viewDefaultName === subItem.viewName ? "" : " - " + viewDefaultName}</span>
+<span class="b3-list-item__text">${escapeHtml(subItem.viewName || window.siyuan.languages._kernel[267])}</span> 
+<span class="b3-list-item__meta">${viewDefaultName}</span>
 </div>`;
                 });
                 html += "</div>";


### PR DESCRIPTION
https://github.com/siyuan-note/siyuan/issues/10659#issuecomment-3221019912

我还是觉得这里显示重复的数据库名称看起来太蠢了：

![Image](https://github.com/user-attachments/assets/6d41ff5a-5a62-43cc-9e28-4c8de317f44d)

改成这样显示视图名称才合理：

![Image](https://github.com/user-attachments/assets/33af08b5-2079-47a1-9fde-06ce26e2e1a4)