### PR TITLE
Change the mobile tap highlight color to gray in the reset styles

### DIFF
--- a/app/src/assets/scss/util/_reset.scss
+++ b/app/src/assets/scss/util/_reset.scss
@@ -17,6 +17,7 @@ body {
   background-color: var(--b3-theme-background);
   -webkit-font-smoothing: antialiased;
   -webkit-overflow-scrolling: touch;
+  -webkit-tap-highlight-color: var(--b3-list-hover);
   height: 100%;
   box-sizing: border-box;
   max-height: 100%;


### PR DESCRIPTION
在重置样式中更改移动设备点击高亮颜色为灰色。

默认的蓝色比较丑，参考了 ob，改成跟桌面端一样的灰色(--b3-list-hover)：

[video.webm](https://github.com/user-attachments/assets/4bb01670-2139-4357-a2e9-bea6e2ef9b00)
