### PR TITLE
Show native window controls on macOS crash dialog

### DIFF
--- a/app/electron/error.html
+++ b/app/electron/error.html
@@ -91,7 +91,7 @@
 
         .drag {
             -webkit-app-region: drag;
-            height: 22px;
+            height: 32px;
             cursor: pointer;
             position: fixed;
             top: 0;
@@ -180,7 +180,28 @@
     }
 
     (() => {
-        document.querySelector('#icon').innerHTML = `<img src="${decodeURIComponent(getSearch('icon'))}"> SiYuan v${getSearch('v')}`
+        if (process.platform === 'darwin') {
+            document.getElementById('min').style.display = 'none';
+            document.getElementById('close').style.display = 'none';
+            document.querySelector('.drag').style.right = '0';
+            document.querySelector('#icon').style.left = '74px';
+        } else {
+            document.querySelector('#icon').style.right = '70px';
+        }
+
+        const os = require('os')
+        const platformMap = {
+            'darwin': 'macOS',
+            'win32': 'Windows',
+            'linux': 'Linux'
+        }
+        const platform = platformMap[process.platform] || process.platform
+        const release = os.release()
+        const arch = os.arch()
+        const cpus = os.cpus()
+        const cpuModel = cpus.length > 0 ? cpus[0].model : ''
+        const systemInfo = `· ${platform} ${release} · ${arch} · ${cpuModel}`
+        document.querySelector('#icon').innerHTML = `<img src="${decodeURIComponent(getSearch('icon'))}"> SiYuan v${getSearch('v')} ${systemInfo}`
 
         document.getElementById('title').innerHTML = decodeURIComponent(getSearch('title'))
         document.getElementById('content').innerHTML = decodeURIComponent(getSearch('content'))

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -196,7 +196,9 @@ const showErrorWindow = (title, content) => {
     const errWindow = new BrowserWindow({
         width: Math.floor(screen.getPrimaryDisplay().size.width * 0.5),
         height: Math.floor(screen.getPrimaryDisplay().workAreaSize.height * 0.8),
-        frame: false,
+        frame: "darwin" === process.platform,
+        titleBarStyle: "hidden",
+        fullscreenable: false,
         icon: path.join(appDir, "stage", "icon-large.png"),
         webPreferences: {
             nodeIntegration: true, webviewTag: true, webSecurity: false, contextIsolation: false,


### PR DESCRIPTION
macOS 上崩溃弹窗显示原生窗口控制按钮：

<img width="1546" height="1452" alt="PixPin_2025-11-16_05-35-24" src="https://github.com/user-attachments/assets/c0360fae-bb6b-41d4-ad8d-a8a3050caa33" />

有时候直接看按钮就知道用户是哪个平台的也会比较方便。