### PR TITLE
Fix border appearing when resizing window on Mac

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -325,6 +325,7 @@ const initMainWindow = () => {
         fullscreenable: true,
         fullscreen: windowState.fullscreen,
         trafficLightPosition: {x: 8, y: 8},
+        transparent: "darwin" === process.platform, // 避免缩放窗口时出现边框
         webPreferences: {
             nodeIntegration: true,
             webviewTag: true,
@@ -1090,6 +1091,7 @@ app.whenReady().then(() => {
             minWidth: 493,
             minHeight: 376,
             fullscreenable: true,
+            transparent: "darwin" === process.platform, // 避免缩放窗口时出现边框
             frame: "darwin" === process.platform,
             icon: path.join(appDir, "stage", "icon-large.png"),
             titleBarStyle: "hidden",


### PR DESCRIPTION
在 macOS 中缩放窗口会出现边框：


https://github.com/user-attachments/assets/9224a9b9-d974-4cbb-b32f-c9af136c102d

把窗口背景改成透明的，虽然不能解决内部抖动的问题，但确实就看不见边框了：


https://github.com/user-attachments/assets/21fca797-4f15-4d24-a8a7-16528062fe0c

