### PR TITLE
Add package manager section to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 * [🚀 Download Setup](#-download-setup)
   * [App Market](#app-market)
   * [Installation Package](#installation-package)
+  * [Package Manager](#package-manager)
   * [Docker Hosting](#docker-hosting)
   * [Unraid Hosting](#unraid-hosting)
   * [Insider Preview](#insider-preview)
@@ -158,6 +159,16 @@ Desktop:
 
 * [B3log](https://b3log.org/siyuan/en/download.html)
 * [GitHub](https://github.com/siyuan-note/siyuan/releases)
+
+### Package Manager
+
+#### `siyuan`
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/siyuan.svg)](https://repology.org/project/siyuan/versions)
+
+#### `siyuan-note`
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/siyuan-note.svg)](https://repology.org/project/siyuan-note/versions)
 
 ### Docker Hosting
 

--- a/README_ja_JP.md
+++ b/README_ja_JP.md
@@ -40,6 +40,7 @@
 * [🚀 ダウンロードとセットアップ](#-ダウンロードとセットアップ)
   * [アプリマーケット](#アプリマーケット)
   * [インストールパッケージ](#インストールパッケージ)
+  * [パッケージマネージャー](#パッケージマネージャー)
   * [Docker ホスティング](#docker-ホスティング)
   * [Unraid ホスティング](#unraid-ホスティング)
   * [インサイダープレビュー](#インサイダープレビュー)
@@ -157,6 +158,16 @@ SiYuanは、プライバシーを最優先とする個人の知識管理シス�
 
 * [B3log](https://b3log.org/siyuan/en/download.html)
 * [GitHub](https://github.com/siyuan-note/siyuan/releases)
+
+### パッケージマネージャー
+
+#### `siyuan`
+
+[![梱包状態](https://repology.org/badge/vertical-allrepos/siyuan.svg)](https://repology.org/project/siyuan/versions)
+
+#### `siyuan-note`
+
+[![梱包状態](https://repology.org/badge/vertical-allrepos/siyuan-note.svg)](https://repology.org/project/siyuan-note/versions)
 
 ### Docker ホスティング
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -40,6 +40,7 @@
 * [🚀 下载安装](#-下载安装)
   * [应用市场](#应用市场)
   * [安装包](#安装包)
+  * [包管理器](#包管理器)
   * [Docker 部署](#docker-部署)
   * [Unraid 部署](#unraid-部署)
   * [宝塔面板 部署](#宝塔面板部署)
@@ -164,6 +165,16 @@
 
 * [B3log](https://b3log.org/siyuan/download.html)
 * [GitHub](https://github.com/siyuan-note/siyuan/releases)
+
+### 包管理器
+
+#### `siyuan`
+
+[![siyuan 包状态](https://repology.org/badge/vertical-allrepos/siyuan.svg)](https://repology.org/project/siyuan/versions)
+
+#### `siyuan-note`
+
+[![siyuan-note 包状态](https://repology.org/badge/vertical-allrepos/siyuan-note.svg)](https://repology.org/project/siyuan-note/versions)
 
 ### Docker 部署
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -170,11 +170,11 @@
 
 #### `siyuan`
 
-[![siyuan 包状态](https://repology.org/badge/vertical-allrepos/siyuan.svg)](https://repology.org/project/siyuan/versions)
+[![包状态](https://repology.org/badge/vertical-allrepos/siyuan.svg)](https://repology.org/project/siyuan/versions)
 
 #### `siyuan-note`
 
-[![siyuan-note 包状态](https://repology.org/badge/vertical-allrepos/siyuan-note.svg)](https://repology.org/project/siyuan-note/versions)
+[![包状态](https://repology.org/badge/vertical-allrepos/siyuan-note.svg)](https://repology.org/project/siyuan-note/versions)
 
 ### Docker 部署
 


### PR DESCRIPTION
Introduced a new 'Package Manager' section to the English, Japanese, and Chinese README files, including badges and links for `siyuan` and `siyuan-note` packages. This provides users with more installation options and visibility into package availability across repositories.

