### PR TITLE
Improve the left padding of the top bar in the browser environment

### DIFF
--- a/app/src/assets/scss/main/_main.scss
+++ b/app/src/assets/scss/main/_main.scss
@@ -66,7 +66,7 @@ html {
   border-bottom: .5px solid var(--b3-border-color);
 
   &--browser {
-    padding-left: env(titlebar-area-x, 0);
+    padding-left: env(titlebar-area-x, 5px);
     padding-right: calc(100% - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
     height: calc(env(titlebar-area-height, 31px) + 1px);
   }


### PR DESCRIPTION
浏览器环境下主菜单按钮靠边比较难看：

![PixPin_2025-11-19_18-20-56](https://github.com/user-attachments/assets/e6afb8e8-3221-4601-bb24-8a8e5813b2e9)

增加 5px，跟下面的按钮对齐：

![PixPin_2025-11-19_18-20-12](https://github.com/user-attachments/assets/d6516c43-ce8a-42f6-8c71-10b364a69bde)
