### PR TITLE
Improve database card style

### DIFF
--- a/app/src/assets/scss/business/_av.scss
+++ b/app/src/assets/scss/business/_av.scss
@@ -276,7 +276,6 @@
       display: flex;
       flex-direction: column;
       position: relative;
-      min-height: 40px;
 
       &::before {
         transition: background 100ms ease-out;
@@ -379,7 +378,7 @@
       flex: 1;
       white-space: nowrap;
       font-size: 85%;
-      min-height: 23px;
+      min-height: calc(1.625em + 4px);
       padding: 5px 4px;
 
       &:hover {


### PR DESCRIPTION
卡片只显示一个字段的时候，上下边距有差别，而且编辑器字号不同的话差别也不同：

![Image](https://github.com/user-attachments/assets/706de05f-0926-40be-b1f1-6f8d65de9766)

https://github.com/user-attachments/assets/a9284b4e-56ad-4547-93bb-a72693188b31

把 .av__gallery-fields 的 min-height 改成一个单元格的高度，边距就始终一样了：

https://github.com/user-attachments/assets/3b156b93-6a14-42b4-9603-76c3a75a6d3b