### PR TITLE
Remove the av-names attribute from block elements

### DIFF
--- a/app/src/protyle/util/clear.ts
+++ b/app/src/protyle/util/clear.ts
@@ -8,7 +8,6 @@ export const clearBlockElement = (element: Element) => {
     element.querySelector(".protyle-attr--av")?.remove();
     element.querySelector(".protyle-attr--refcount")?.remove();
     element.removeAttribute("custom-avs");
-    element.removeAttribute("av-names");
     element.getAttributeNames().forEach(attr => {
         if (attr.startsWith("custom-sy-av-s-text-")) {
             element.removeAttribute(attr);

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -152,7 +152,7 @@ export class WYSIWYG {
             }
         }
         ialKeys.forEach((key: string) => {
-            if (!["title-img", "title", "updated", "icon", "id", "type", "class", "spellcheck", "contenteditable", "data-doc-type", "style", "data-realwidth", "data-readonly"].includes(key)) {
+            if (!["title-img", "title", "updated", "icon", "id", "type", "class", "spellcheck", "contenteditable", "data-doc-type", "style", "data-realwidth", "data-readonly", "av-names"].includes(key)) {
                 this.element.setAttribute(key, ial[key]);
             }
         });

--- a/app/src/protyle/wysiwyg/transaction.ts
+++ b/app/src/protyle/wysiwyg/transaction.ts
@@ -611,13 +611,14 @@ export const onTransaction = (protyle: IProtyle, operation: IOperation, isUndo: 
                 data.new.style += ";animation:addCard 450ms linear";
             }
             Object.keys(data.new).forEach(key => {
-                if ("id" === key) {
+                if ("id" === key || "av-names" === key) {
                     // 设置属性以后不应该给块元素添加 id 属性 No longer add the `id` attribute to block elements after setting the attribute https://github.com/siyuan-note/siyuan/issues/15327
+                    // av-names 属性仅用于生成角标，不添加到元素
                     return;
                 }
 
                 item.setAttribute(key, data.new[key]);
-                if (key === Constants.CUSTOM_RIFF_DECKS && data.new[Constants.CUSTOM_RIFF_DECKS] !== data.old[Constants.CUSTOM_RIFF_DECKS]) {
+                if (key === Constants.CUSTOM_RIFF_DECKS && key !== data.old[Constants.CUSTOM_RIFF_DECKS]) {
                     item.style.animation = "addCard 450ms linear";
                     setTimeout(() => {
                         if (item.parentElement) {

--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -2970,6 +2970,7 @@ func (tx *Transaction) setAttributeViewName(operation *Operation) (err error) {
 		oldAttrs := parse.IAL2Map(node.KramdownIAL)
 		node.SetIALAttr(av.NodeAttrViewNames, avNames)
 		pushBroadcastAttrTransactions(oldAttrs, node)
+		node.RemoveIALAttr(av.NodeAttrViewNames)
 	}
 	return
 }
@@ -3561,6 +3562,7 @@ func removeNodeAvID(node *ast.Node, avID string, tx *Transaction, tree *parse.Tr
 		node.RemoveIALAttr("custom-hidden")
 	}
 
+	var avNames string
 	if avs := attrs[av.NodeAttrNameAvs]; "" != avs {
 		avIDs := strings.Split(avs, ",")
 		avIDs = gulu.Str.RemoveElem(avIDs, avID)
@@ -3577,7 +3579,7 @@ func removeNodeAvID(node *ast.Node, avID string, tx *Transaction, tree *parse.Tr
 		} else {
 			attrs[av.NodeAttrNameAvs] = strings.Join(avIDs, ",")
 			node.SetIALAttr(av.NodeAttrNameAvs, strings.Join(avIDs, ","))
-			avNames := getAvNames(node.IALAttr(av.NodeAttrNameAvs))
+			avNames = getAvNames(node.IALAttr(av.NodeAttrNameAvs))
 			attrs[av.NodeAttrViewNames] = avNames
 		}
 	}
@@ -3590,6 +3592,9 @@ func removeNodeAvID(node *ast.Node, avID string, tx *Transaction, tree *parse.Tr
 		if err = setNodeAttrs(node, tree, attrs); err != nil {
 			return
 		}
+	}
+	if "" != avNames {
+		node.RemoveIALAttr(av.NodeAttrViewNames)
 	}
 	return
 }
@@ -5050,6 +5055,9 @@ func unbindBlockAv(tx *Transaction, avID, nodeID string) {
 		logging.LogWarnf("set node [%s] attrs failed: %s", nodeID, err)
 		return
 	}
+	if "" != avNames {
+		node.RemoveIALAttr(av.NodeAttrViewNames)
+	}
 	return
 }
 
@@ -5088,6 +5096,9 @@ func bindBlockAv0(tx *Transaction, avID string, node *ast.Node, tree *parse.Tree
 	if err != nil {
 		logging.LogWarnf("set node [%s] attrs failed: %s", node.ID, err)
 		return
+	}
+	if "" != avNames {
+		node.RemoveIALAttr(av.NodeAttrViewNames)
 	}
 	return
 }
@@ -5521,6 +5532,9 @@ func updateBoundBlockAvsAttribute(avIDs []string) {
 			}
 			cache.PutBlockIAL(node.ID, parse.IAL2Map(node.KramdownIAL))
 			pushBroadcastAttrTransactions(oldAttrs, node)
+			if "" != avNames {
+				node.RemoveIALAttr(av.NodeAttrViewNames)
+			}
 		}
 	}
 

--- a/kernel/model/file.go
+++ b/kernel/model/file.go
@@ -988,7 +988,6 @@ func DuplicateDoc(tree *parse.Tree) {
 		}
 
 		n.RemoveIALAttr(av.NodeAttrNameAvs)
-		n.RemoveIALAttr(av.NodeAttrViewNames)
 		n.RemoveIALAttrsByPrefix(av.NodeAttrViewStaticText)
 		return ast.WalkContinue
 	})

--- a/kernel/model/render.go
+++ b/kernel/model/render.go
@@ -190,6 +190,11 @@ func renderBlockDOMByNodes(nodes []*ast.Node, luteEngine *lute.Lute) string {
 						}
 					}
 				}
+			} else {
+				// 填充属性视图角标之后即可移除 av-names 属性
+				if n.IsBlock() && "" != n.IALAttr(av.NodeAttrViewNames) {
+					n.RemoveIALAttr(av.NodeAttrViewNames)
+				}
 			}
 
 			rendererFunc := blockRenderer.RendererFuncs[n.Type]

--- a/kernel/model/transaction.go
+++ b/kernel/model/transaction.go
@@ -1073,6 +1073,7 @@ func (tx *Transaction) syncDelete2Block(node *ast.Node, nodeTree *parse.Tree) (c
 			oldAttrs := parse.IAL2Map(toChangNode.KramdownIAL)
 			toChangNode.SetIALAttr(av.NodeAttrViewNames, avNames)
 			pushBroadcastAttrTransactions(oldAttrs, toChangNode)
+			toChangNode.RemoveIALAttr(av.NodeAttrViewNames)
 		}
 
 		for _, tree := range trees {
@@ -1208,7 +1209,6 @@ func (tx *Transaction) doLargeInsert(previousID string) (ret *TxErr) {
 
 		// 复制为副本时移除数据库绑定状态 https://github.com/siyuan-note/siyuan/issues/12294
 		insertedNode.RemoveIALAttr(av.NodeAttrNameAvs)
-		insertedNode.RemoveIALAttr(av.NodeAttrViewNames)
 		insertedNode.RemoveIALAttrsByPrefix(av.NodeAttrViewStaticText)
 
 		if ast.NodeAttributeView == insertedNode.Type {
@@ -1387,7 +1387,6 @@ func (tx *Transaction) doInsert(operation *Operation) (ret *TxErr) {
 
 	// 复制为副本时移除数据库绑定状态 https://github.com/siyuan-note/siyuan/issues/12294
 	insertedNode.RemoveIALAttr(av.NodeAttrNameAvs)
-	insertedNode.RemoveIALAttr(av.NodeAttrViewNames)
 	insertedNode.RemoveIALAttrsByPrefix(av.NodeAttrViewStaticText)
 
 	if ast.NodeAttributeView == insertedNode.Type {


### PR DESCRIPTION
前端只有更新块属性和角标的时候用到 av-names 属性，没必要一直留着，应该用完就删；后端使用 av-names 属性来生成角标，也应该用完就删。

还有一个 PR：https://github.com/88250/lute/pull/215

另外关联讨论：https://github.com/siyuan-note/siyuan/issues/12294#issuecomment-3566754523