### PR TITLE
Fix incorrect sorting in database relation field list due to premature pagination

### DIFF
--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -1314,6 +1314,10 @@ func GetAttributeViewPrimaryKeyValues(avID, keyword string, page, pageSize int) 
 	}
 	keyValues.Values = values
 
+	sort.Slice(keyValues.Values, func(i, j int) bool {
+		return keyValues.Values[i].Block.Updated > keyValues.Values[j].Block.Updated
+	})
+
 	if 1 > pageSize {
 		pageSize = 16
 	}
@@ -1323,10 +1327,6 @@ func GetAttributeViewPrimaryKeyValues(avID, keyword string, page, pageSize int) 
 		end = len(keyValues.Values)
 	}
 	keyValues.Values = keyValues.Values[start:end]
-
-	sort.Slice(keyValues.Values, func(i, j int) bool {
-		return keyValues.Values[i].Block.Updated > keyValues.Values[j].Block.Updated
-	})
 	return
 }
 


### PR DESCRIPTION
怪不得感觉关联字段的列表总是一样的，先分页再排序那当然一直是一样的。

修改之后就能把刚刚添加的新条目显示在列表前面了。