### PR TITLE
Improve the av-names attribute on block elements

### DIFF
--- a/app/src/block/popover.ts
+++ b/app/src/block/popover.ts
@@ -393,9 +393,9 @@ export const showPopover = async (app: App, showRef = false) => {
     } else if (popoverTargetElement.dataset.type === "url") {
         // 在 database 的 url 列中以思源协议开头的链接
         refDefs = [{refID: getIdFromSYProtocol(popoverTargetElement.textContent.trim())}];
-    } else if (popoverTargetElement.dataset.popoverUrl) {
+    } else if (popoverTargetElement.dataset.type === "av") {
         // 镜像数据库
-        const postResponse = await fetchSyncPost(popoverTargetElement.dataset.popoverUrl, {avID: popoverTargetElement.dataset.avId});
+        const postResponse = await fetchSyncPost("/api/av/getMirrorDatabaseBlocks", {avID: popoverTargetElement.dataset.avId});
         refDefs = postResponse.data.refDefs;
     } else {
         // pdf

--- a/app/src/protyle/header/Title.ts
+++ b/app/src/protyle/header/Title.ts
@@ -387,7 +387,7 @@ export class Title {
         if (response.data.ial["custom-avs"]) {
             let avTitle = "";
             response.data.attrViews.forEach((item: { id: string, name: string }) => {
-                avTitle += `<span data-av-id="${item.id}" data-popover-url="/api/av/getMirrorDatabaseBlocks" class="popover__block">${item.name}</span>&nbsp;`;
+                avTitle += `<span data-av-id="${item.id}" data-type="av" class="popover__block">${item.name}</span>&nbsp;`;
             });
             if (avTitle) {
                 avTitle = avTitle.substring(0, avTitle.length - 6);

--- a/app/src/protyle/render/av/render.ts
+++ b/app/src/protyle/render/av/render.ts
@@ -111,7 +111,7 @@ export const genTabHeaderHTML = (data: IAV, showSearch: boolean, editable: boole
                 <svg><use xlink:href="#iconAdd"></use></svg>
             </span>
             <div class="fn__space"></div>
-            ${data.isMirror ? ` <span data-av-id="${data.id}" data-popover-url="/api/av/getMirrorDatabaseBlocks" class="popover__block block__icon block__icon--show ariaLabel" data-position="8south" aria-label="${window.siyuan.languages.mirrorTip}">
+            ${data.isMirror ? ` <span data-av-id="${data.id}" data-type="av" class="popover__block block__icon block__icon--show ariaLabel" data-position="8south" aria-label="${window.siyuan.languages.mirrorTip}">
     <svg><use xlink:href="#iconSplitLR"></use></svg></span><div class="fn__space"></div>` : ""}
         </div>
         <div contenteditable="${editable}" spellcheck="${window.siyuan.config.editor.spellcheck.toString()}" class="av__title${viewData.hideAttrViewName ? " fn__none" : ""}" data-title="${data.name || ""}" data-tip="${window.siyuan.languages._kernel[267]}">${data.name || ""}</div>

--- a/app/src/protyle/util/clear.ts
+++ b/app/src/protyle/util/clear.ts
@@ -8,6 +8,7 @@ export const clearBlockElement = (element: Element) => {
     element.querySelector(".protyle-attr--av")?.remove();
     element.querySelector(".protyle-attr--refcount")?.remove();
     element.removeAttribute("custom-avs");
+    element.removeAttribute("av-names");
     element.getAttributeNames().forEach(attr => {
         if (attr.startsWith("custom-sy-av-s-text-")) {
             element.removeAttribute(attr);

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -152,7 +152,7 @@ export class WYSIWYG {
             }
         }
         ialKeys.forEach((key: string) => {
-            if (!["title-img", "title", "updated", "icon", "id", "type", "class", "spellcheck", "contenteditable", "data-doc-type", "style", "data-realwidth", "data-readonly", "av-names"].includes(key)) {
+            if (!["title-img", "title", "updated", "icon", "id", "type", "class", "spellcheck", "contenteditable", "data-doc-type", "style", "data-realwidth", "data-readonly"].includes(key)) {
                 this.element.setAttribute(key, ial[key]);
             }
         });

--- a/app/src/protyle/wysiwyg/transaction.ts
+++ b/app/src/protyle/wysiwyg/transaction.ts
@@ -611,14 +611,13 @@ export const onTransaction = (protyle: IProtyle, operation: IOperation, isUndo: 
                 data.new.style += ";animation:addCard 450ms linear";
             }
             Object.keys(data.new).forEach(key => {
-                if ("id" === key || "av-names" === key) {
+                if ("id" === key) {
                     // 设置属性以后不应该给块元素添加 id 属性 No longer add the `id` attribute to block elements after setting the attribute https://github.com/siyuan-note/siyuan/issues/15327
-                    // av-names 属性仅用于生成角标，不添加到元素
                     return;
                 }
 
                 item.setAttribute(key, data.new[key]);
-                if (key === Constants.CUSTOM_RIFF_DECKS && key !== data.old[Constants.CUSTOM_RIFF_DECKS]) {
+                if (key === Constants.CUSTOM_RIFF_DECKS && data.new[Constants.CUSTOM_RIFF_DECKS] !== data.old[Constants.CUSTOM_RIFF_DECKS]) {
                     item.style.animation = "addCard 450ms linear";
                     setTimeout(() => {
                         if (item.parentElement) {

--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -2948,7 +2948,7 @@ func (tx *Transaction) doSetAttrViewName(operation *Operation) (ret *TxErr) {
 	return
 }
 
-const attrAvNameTpl = `<span data-av-id="${avID}" data-popover-url="/api/av/getMirrorDatabaseBlocks" class="popover__block">${avName}</span>`
+const attrAvNameTpl = `<span data-av-id="${avID}" data-type="av" class="popover__block">${avName}</span>`
 
 func (tx *Transaction) setAttributeViewName(operation *Operation) (err error) {
 	avID := operation.ID

--- a/kernel/model/attribute_view.go
+++ b/kernel/model/attribute_view.go
@@ -2970,7 +2970,6 @@ func (tx *Transaction) setAttributeViewName(operation *Operation) (err error) {
 		oldAttrs := parse.IAL2Map(node.KramdownIAL)
 		node.SetIALAttr(av.NodeAttrViewNames, avNames)
 		pushBroadcastAttrTransactions(oldAttrs, node)
-		node.RemoveIALAttr(av.NodeAttrViewNames)
 	}
 	return
 }
@@ -3562,7 +3561,6 @@ func removeNodeAvID(node *ast.Node, avID string, tx *Transaction, tree *parse.Tr
 		node.RemoveIALAttr("custom-hidden")
 	}
 
-	var avNames string
 	if avs := attrs[av.NodeAttrNameAvs]; "" != avs {
 		avIDs := strings.Split(avs, ",")
 		avIDs = gulu.Str.RemoveElem(avIDs, avID)
@@ -3579,7 +3577,7 @@ func removeNodeAvID(node *ast.Node, avID string, tx *Transaction, tree *parse.Tr
 		} else {
 			attrs[av.NodeAttrNameAvs] = strings.Join(avIDs, ",")
 			node.SetIALAttr(av.NodeAttrNameAvs, strings.Join(avIDs, ","))
-			avNames = getAvNames(node.IALAttr(av.NodeAttrNameAvs))
+			avNames := getAvNames(node.IALAttr(av.NodeAttrNameAvs))
 			attrs[av.NodeAttrViewNames] = avNames
 		}
 	}
@@ -3592,9 +3590,6 @@ func removeNodeAvID(node *ast.Node, avID string, tx *Transaction, tree *parse.Tr
 		if err = setNodeAttrs(node, tree, attrs); err != nil {
 			return
 		}
-	}
-	if "" != avNames {
-		node.RemoveIALAttr(av.NodeAttrViewNames)
 	}
 	return
 }
@@ -5051,9 +5046,6 @@ func unbindBlockAv(tx *Transaction, avID, nodeID string) {
 		logging.LogWarnf("set node [%s] attrs failed: %s", nodeID, err)
 		return
 	}
-	if "" != avNames {
-		node.RemoveIALAttr(av.NodeAttrViewNames)
-	}
 	return
 }
 
@@ -5092,9 +5084,6 @@ func bindBlockAv0(tx *Transaction, avID string, node *ast.Node, tree *parse.Tree
 	if err != nil {
 		logging.LogWarnf("set node [%s] attrs failed: %s", node.ID, err)
 		return
-	}
-	if "" != avNames {
-		node.RemoveIALAttr(av.NodeAttrViewNames)
 	}
 	return
 }
@@ -5528,9 +5517,6 @@ func updateBoundBlockAvsAttribute(avIDs []string) {
 			}
 			cache.PutBlockIAL(node.ID, parse.IAL2Map(node.KramdownIAL))
 			pushBroadcastAttrTransactions(oldAttrs, node)
-			if "" != avNames {
-				node.RemoveIALAttr(av.NodeAttrViewNames)
-			}
 		}
 	}
 

--- a/kernel/model/file.go
+++ b/kernel/model/file.go
@@ -988,6 +988,7 @@ func DuplicateDoc(tree *parse.Tree) {
 		}
 
 		n.RemoveIALAttr(av.NodeAttrNameAvs)
+		n.RemoveIALAttr(av.NodeAttrViewNames)
 		n.RemoveIALAttrsByPrefix(av.NodeAttrViewStaticText)
 		return ast.WalkContinue
 	})

--- a/kernel/model/render.go
+++ b/kernel/model/render.go
@@ -190,11 +190,6 @@ func renderBlockDOMByNodes(nodes []*ast.Node, luteEngine *lute.Lute) string {
 						}
 					}
 				}
-			} else {
-				// 填充属性视图角标之后即可移除 av-names 属性
-				if n.IsBlock() && "" != n.IALAttr(av.NodeAttrViewNames) {
-					n.RemoveIALAttr(av.NodeAttrViewNames)
-				}
 			}
 
 			rendererFunc := blockRenderer.RendererFuncs[n.Type]

--- a/kernel/model/transaction.go
+++ b/kernel/model/transaction.go
@@ -1073,7 +1073,6 @@ func (tx *Transaction) syncDelete2Block(node *ast.Node, nodeTree *parse.Tree) (c
 			oldAttrs := parse.IAL2Map(toChangNode.KramdownIAL)
 			toChangNode.SetIALAttr(av.NodeAttrViewNames, avNames)
 			pushBroadcastAttrTransactions(oldAttrs, toChangNode)
-			toChangNode.RemoveIALAttr(av.NodeAttrViewNames)
 		}
 
 		for _, tree := range trees {
@@ -1209,6 +1208,7 @@ func (tx *Transaction) doLargeInsert(previousID string) (ret *TxErr) {
 
 		// 复制为副本时移除数据库绑定状态 https://github.com/siyuan-note/siyuan/issues/12294
 		insertedNode.RemoveIALAttr(av.NodeAttrNameAvs)
+		insertedNode.RemoveIALAttr(av.NodeAttrViewNames)
 		insertedNode.RemoveIALAttrsByPrefix(av.NodeAttrViewStaticText)
 
 		if ast.NodeAttributeView == insertedNode.Type {
@@ -1387,6 +1387,7 @@ func (tx *Transaction) doInsert(operation *Operation) (ret *TxErr) {
 
 	// 复制为副本时移除数据库绑定状态 https://github.com/siyuan-note/siyuan/issues/12294
 	insertedNode.RemoveIALAttr(av.NodeAttrNameAvs)
+	insertedNode.RemoveIALAttr(av.NodeAttrViewNames)
 	insertedNode.RemoveIALAttrsByPrefix(av.NodeAttrViewStaticText)
 
 	if ast.NodeAttributeView == insertedNode.Type {


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/16446

虽然去掉 av-names 属性也有办法解决，但是会增加一些开销，权衡之下我还是选性能更好的方法，把 av-names 加回来，但把 `data-popover-url="/api/av/getMirrorDatabaseBlocks"` 缩短为 `data-type="av"`

@88250 需要把 https://github.com/88250/lute/pull/215 这个 PR 的提交还原一下