### PR TITLE
Support triggering the `open-siyuan-url-plugin` on mobile

### DIFF
--- a/app/src/protyle/util/compatibility.ts
+++ b/app/src/protyle/util/compatibility.ts
@@ -53,6 +53,33 @@ export const openByMobile = (uri: string) => {
     if (!uri) {
         return;
     }
+    //https://github.com/siyuan-note/siyuan/issues/15892
+    if (uri.startsWith("siyuan://")) {
+        let urlObj: URL;
+        try {
+            urlObj = new URL(uri);
+        if (urlObj.protocol !== "siyuan:") {
+            return;
+        }
+        } catch (error) {
+            return;
+        }
+        if (urlObj && urlObj.hostname === "plugins") {
+            const pluginNameType = urlObj.pathname.split("/")[1];
+            if (!pluginNameType) {
+                return;
+            }
+            window.siyuan.ws.app.plugins.find((plugin) => {
+                if (pluginNameType.startsWith(plugin.name)) {
+                    // siyuan://plugins/plugin-name/foo?bar=baz
+                    plugin.eventBus.emit("open-siyuan-url-plugin", {
+                        url: uri
+                    });
+                }
+            });
+            return;
+        }
+    }
     if (isInIOS()) {
         if (uri.startsWith("assets/")) {
             // iOS 16.7 之前的版本，uri 需要 encodeURIComponent


### PR DESCRIPTION
✨移动端支持触发open-siyuan-url-plugin

[#15892](https://github.com/siyuan-note/siyuan/issues/15892)

在 iOS 测试通过。

参考 https://github.com/siyuan-note/siyuan/blob/319cdbb98ab694154615308214cdced6f1a22f0c/app/src/boot/onGetConfig.ts#L175 的实现。

没有实现对 `siyuan://plugins/plugin-samplecustom_tab...` 链接的处理，我理解以这种形式的链接打开 Tab 应该是历史原因。这种效果插件监听 `open-siyuan-url-plugin` 已经可以自己实现了。