### PR TITLE
Improve the background color of auth page on macOS

### DIFF
--- a/app/stage/auth.html
+++ b/app/stage/auth.html
@@ -21,6 +21,7 @@
             --b3-theme-background: #fff;
             --b3-theme-on-background: #202124;
             --b3-theme-on-primary: #fff;
+            background-color: var(--b3-theme-background);
         }
 
         .dark {
@@ -33,7 +34,6 @@
             --b3-theme-background: #1e1e1e;
             --b3-theme-on-background: #c9d1d9;
             --b3-theme-on-primary: #fff;
-            background-color: var(--b3-theme-background);
         }
 
         .b3-button {


### PR DESCRIPTION
fix https://ld246.com/article/1764154209756

[上次](https://github.com/siyuan-note/siyuan/pull/16358)把 MacOS 的窗口背景改成透明的，导致验证页面在明亮主题下因为没有背景色而变成透明的。

把背景色样式从 .dark 移到 body 上就解决问题了，明亮模式和暗黑模式都有背景色。