### PR TITLE
Fix executing the uninstall method when closing the plugin

### DIFF
--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -225,11 +225,17 @@ export const afterLoadPlugin = (plugin: Plugin) => {
 export const reloadPlugin = async (app: App, data: {
     upsertCodePlugins?: string[],
     upsertDataPlugins?: string[],
-    unloadPlugins?: string[]
+    unloadPlugins?: string[],
+    uninstallPlugins?: string[],
 } = {}) => {
-    const {upsertCodePlugins = [], upsertDataPlugins = [], unloadPlugins = []} = data;
+    const {upsertCodePlugins = [], upsertDataPlugins = [], unloadPlugins = [], uninstallPlugins = []} = data;
+    // 禁用
     unloadPlugins.forEach((item) => {
         uninstall(app, item, true);
+    });
+    // 卸载
+    uninstallPlugins.forEach((item) => {
+        uninstall(app, item, false);
     });
     upsertCodePlugins.forEach((item) => {
         uninstall(app, item, true);

--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -225,11 +225,11 @@ export const afterLoadPlugin = (plugin: Plugin) => {
 export const reloadPlugin = async (app: App, data: {
     upsertCodePlugins?: string[],
     upsertDataPlugins?: string[],
-    removePlugins?: string[]
+    unloadPlugins?: string[]
 } = {}) => {
-    const {upsertCodePlugins = [], upsertDataPlugins = [], removePlugins = []} = data;
-    removePlugins.forEach((item) => {
-        uninstall(app, item, false);
+    const {upsertCodePlugins = [], upsertDataPlugins = [], unloadPlugins = []} = data;
+    unloadPlugins.forEach((item) => {
+        uninstall(app, item, true);
     });
     upsertCodePlugins.forEach((item) => {
         uninstall(app, item, true);

--- a/kernel/api/petal.go
+++ b/kernel/api/petal.go
@@ -68,9 +68,9 @@ func setPetalEnabled(c *gin.Context) {
 	}
 	if enabled {
 		upsertPluginCodeSet := hashset.New(packageName)
-		model.PushReloadPlugin(upsertPluginCodeSet, nil, nil, app)
+		model.PushReloadPlugin(upsertPluginCodeSet, nil, nil, nil, app)
 	} else {
 		unloadPluginSet := hashset.New(packageName)
-		model.PushReloadPlugin(nil, nil, unloadPluginSet, app)
+		model.PushReloadPlugin(nil, nil, unloadPluginSet, nil, app)
 	}
 }

--- a/kernel/api/petal.go
+++ b/kernel/api/petal.go
@@ -70,7 +70,7 @@ func setPetalEnabled(c *gin.Context) {
 		upsertPluginCodeSet := hashset.New(packageName)
 		model.PushReloadPlugin(upsertPluginCodeSet, nil, nil, app)
 	} else {
-		removePluginSet := hashset.New(packageName)
-		model.PushReloadPlugin(nil, nil, removePluginSet, app)
+		unloadPluginSet := hashset.New(packageName)
+		model.PushReloadPlugin(nil, nil, unloadPluginSet, app)
 	}
 }

--- a/kernel/model/bazzar.go
+++ b/kernel/model/bazzar.go
@@ -256,8 +256,8 @@ func UninstallBazaarPlugin(pluginName, frontend string) error {
 	petals = tmp
 	savePetals(petals)
 
-	removePluginSet := hashset.New(pluginName)
-	PushReloadPlugin(nil, nil, removePluginSet, "")
+	unloadPluginSet := hashset.New(pluginName)
+	PushReloadPlugin(nil, nil, unloadPluginSet, "")
 	return nil
 }
 

--- a/kernel/model/bazzar.go
+++ b/kernel/model/bazzar.go
@@ -256,8 +256,8 @@ func UninstallBazaarPlugin(pluginName, frontend string) error {
 	petals = tmp
 	savePetals(petals)
 
-	unloadPluginSet := hashset.New(pluginName)
-	PushReloadPlugin(nil, nil, unloadPluginSet, "")
+	uninstallPluginSet := hashset.New(pluginName)
+	PushReloadPlugin(nil, nil, nil, uninstallPluginSet, "")
 	return nil
 }
 

--- a/kernel/model/push_reload.go
+++ b/kernel/model/push_reload.go
@@ -38,11 +38,11 @@ import (
 	"github.com/siyuan-note/siyuan/kernel/util"
 )
 
-func PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, removePluginNameSet *hashset.Set, excludeApp string) {
-	if nil != removePluginNameSet {
-		for _, n := range removePluginNameSet.Values() {
+func PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, unloadPluginNameSet *hashset.Set, excludeApp string) {
+	if nil != unloadPluginNameSet {
+		for _, n := range unloadPluginNameSet.Values() {
 			pluginName := n.(string)
-			// 如果插件在 removePluginSet 中，从其他集合中移除
+			// 如果插件在 unloadPluginSet 中，从其他集合中移除
 			if nil != upsertCodePluginSet {
 				upsertCodePluginSet.Remove(pluginName)
 			}
@@ -61,7 +61,7 @@ func PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, removePluginName
 		}
 	}
 
-	upsertCodePlugins, upsertDataPlugins, removePlugins := []string{}, []string{}, []string{}
+	upsertCodePlugins, upsertDataPlugins, unloadPlugins := []string{}, []string{}, []string{}
 	if nil != upsertCodePluginSet {
 		for _, n := range upsertCodePluginSet.Values() {
 			upsertCodePlugins = append(upsertCodePlugins, n.(string))
@@ -72,22 +72,22 @@ func PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, removePluginName
 			upsertDataPlugins = append(upsertDataPlugins, n.(string))
 		}
 	}
-	if nil != removePluginNameSet {
-		for _, n := range removePluginNameSet.Values() {
-			removePlugins = append(removePlugins, n.(string))
+	if nil != unloadPluginNameSet {
+		for _, n := range unloadPluginNameSet.Values() {
+			unloadPlugins = append(unloadPlugins, n.(string))
 		}
 	}
 
-	pushReloadPlugin0(upsertCodePlugins, upsertDataPlugins, removePlugins, excludeApp)
+	pushReloadPlugin0(upsertCodePlugins, upsertDataPlugins, unloadPlugins, excludeApp)
 }
 
-func pushReloadPlugin0(upsertCodePlugins, upsertDataPlugins, removePlugins []string, excludeApp string) {
-	logging.LogInfof("reload plugins [codeChanges=%v, dataChanges=%v, removes=%v]", upsertCodePlugins, upsertDataPlugins, removePlugins)
+func pushReloadPlugin0(upsertCodePlugins, upsertDataPlugins, unloadPlugins []string, excludeApp string) {
+	logging.LogInfof("reload plugins [codeChanges=%v, dataChanges=%v, unloads=%v]", upsertCodePlugins, upsertDataPlugins, unloadPlugins)
 	if "" == excludeApp {
 		util.BroadcastByType("main", "reloadPlugin", 0, "", map[string]interface{}{
 			"upsertCodePlugins": upsertCodePlugins,
 			"upsertDataPlugins": upsertDataPlugins,
-			"removePlugins":     removePlugins,
+			"unloadPlugins":     unloadPlugins,
 		})
 		return
 	}
@@ -95,7 +95,7 @@ func pushReloadPlugin0(upsertCodePlugins, upsertDataPlugins, removePlugins []str
 	util.BroadcastByTypeAndExcludeApp(excludeApp, "main", "reloadPlugin", 0, "", map[string]interface{}{
 		"upsertCodePlugins": upsertCodePlugins,
 		"upsertDataPlugins": upsertDataPlugins,
-		"removePlugins":     removePlugins,
+		"unloadPlugins":     unloadPlugins,
 	})
 }
 

--- a/kernel/model/repository.go
+++ b/kernel/model/repository.go
@@ -1635,7 +1635,7 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 		}
 	}
 
-	removeWidgetDirSet, removePluginSet := hashset.New(), hashset.New()
+	removeWidgetDirSet, unloadPluginSet := hashset.New(), hashset.New()
 	for _, file := range mergeResult.Removes {
 		removes = append(removes, file.Path)
 		if strings.HasPrefix(file.Path, "/storage/riff/") {
@@ -1664,7 +1664,7 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 		if strings.HasPrefix(file.Path, "/plugins/") {
 			if parts := strings.Split(file.Path, "/"); 2 < len(parts) {
 				needReloadPlugin = true
-				removePluginSet.Add(parts[2])
+				unloadPluginSet.Add(parts[2])
 			}
 		}
 
@@ -1681,7 +1681,7 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 	}
 	for _, removePetal := range mergeResult.RemovePetals {
 		needReloadPlugin = true
-		removePluginSet.Add(removePetal)
+		unloadPluginSet.Add(removePetal)
 	}
 
 	if needReloadFlashcard {
@@ -1693,7 +1693,7 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 	}
 
 	if needReloadPlugin {
-		PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, removePluginSet, "")
+		PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, unloadPluginSet, "")
 	}
 
 	for _, widgetDir := range removeWidgetDirSet.Values() {

--- a/kernel/model/repository.go
+++ b/kernel/model/repository.go
@@ -1635,7 +1635,7 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 		}
 	}
 
-	removeWidgetDirSet, unloadPluginSet := hashset.New(), hashset.New()
+	removeWidgetDirSet, unloadPluginSet, uninstallPluginSet := hashset.New(), hashset.New(), hashset.New()
 	for _, file := range mergeResult.Removes {
 		removes = append(removes, file.Path)
 		if strings.HasPrefix(file.Path, "/storage/riff/") {
@@ -1664,7 +1664,8 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 		if strings.HasPrefix(file.Path, "/plugins/") {
 			if parts := strings.Split(file.Path, "/"); 2 < len(parts) {
 				needReloadPlugin = true
-				unloadPluginSet.Add(parts[2])
+				// 删除插件目录：卸载
+				uninstallPluginSet.Add(parts[2])
 			}
 		}
 
@@ -1681,7 +1682,8 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 	}
 	for _, removePetal := range mergeResult.RemovePetals {
 		needReloadPlugin = true
-		unloadPluginSet.Add(removePetal)
+		// Petal 中删除插件：卸载
+		uninstallPluginSet.Add(removePetal)
 	}
 
 	if needReloadFlashcard {
@@ -1693,7 +1695,7 @@ func processSyncMergeResult(exit, byHand bool, mergeResult *dejavu.MergeResult, 
 	}
 
 	if needReloadPlugin {
-		PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, unloadPluginSet, "")
+		PushReloadPlugin(upsertCodePluginSet, upsertDataPluginSet, unloadPluginSet, uninstallPluginSet, "")
 	}
 
 	for _, widgetDir := range removeWidgetDirSet.Values() {


### PR DESCRIPTION
之前修改 https://github.com/siyuan-note/siyuan/pull/16243 的时候被变量名误导了，以为 removePlugins 是卸载的插件。刚刚看代码发现 removePlugins 其实同时包含了禁用的插件和卸载的插件。这就导致了目前如果用户同时使用多个前端，无论用户是关闭还是卸载插件，内核推送 reloadPlugin 之后其他前端都会执行插件的卸载方法。

- 重构：区分开插件的禁用和卸载，"removePlugins" 相关变量名拆分为 "unloadPlugins" 和 "uninstallPlugins"
- 修复：插件禁用时执行 `uninstall(app, item, true);`，插件卸载时执行 `uninstall(app, item, false);`

关联 https://github.com/siyuan-note/siyuan/issues/16156