### PR TITLE
The input box cannot continuously input or delete characters

### DIFF
--- a/app/src/dialog/index.ts
+++ b/app/src/dialog/index.ts
@@ -112,7 +112,7 @@ left:${left || "auto"};top:${top || "auto"}">
         inputElement.focus();
         let timeStamp: number;
         inputElement.addEventListener("keydown", (event: KeyboardEvent) => {
-            if (event.isComposing || event.repeat) {
+            if (event.isComposing) {
                 event.preventDefault();
                 return;
             }
@@ -123,7 +123,7 @@ left:${left || "auto"};top:${top || "auto"}">
                 return;
             }
             if (!event.shiftKey && isNotCtrl(event) && event.key === "Enter" && enterEvent && bindEnter) {
-                if (timeStamp && event.timeStamp - timeStamp < 124) {
+                if (timeStamp && event.timeStamp - timeStamp < 200) {
                     return;
                 }
                 timeStamp = event.timeStamp;


### PR DESCRIPTION
长按键盘无法在 textarea 里连续输入文本或者删除文本，只能一个字母一个字母按，所以把 event.repeat 去掉。

之前连续按回车会重复创建笔记本的问题 https://github.com/siyuan-note/siyuan/issues/15150 仍然存在，把间隔时间改大了一点到 200ms。