### PR TITLE
Do not validate file names when updating existing files

### DIFF
--- a/kernel/api/file.go
+++ b/kernel/api/file.go
@@ -380,10 +380,13 @@ func putFile(c *gin.Context) {
 		return
 	}
 
-	if !util.IsValidUploadFileName(filepath.Base(fileAbsPath)) { // Improve kernel API `/api/file/putFile` parameter validation https://github.com/siyuan-note/siyuan/issues/14658
-		ret.Code = http.StatusBadRequest
-		ret.Msg = "invalid file path, please check https://github.com/siyuan-note/siyuan/issues/14658 for more details"
-		return
+	fileExists := filelock.IsExist(fileAbsPath)
+	if !fileExists {
+		if !util.IsValidUploadFileName(filepath.Base(fileAbsPath)) { // Improve kernel API `/api/file/putFile` parameter validation https://github.com/siyuan-note/siyuan/issues/14658
+			ret.Code = http.StatusBadRequest
+			ret.Msg = "invalid file path, please check https://github.com/siyuan-note/siyuan/issues/14658 for more details"
+			return
+		}
 	}
 
 	isDirStr := c.PostForm("isDir")


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/16536

更新已存在的文件时不验证文件名。

问题的原因是 InsertLocalAssets 和 putFile 接口对文件名长度的限制不同，putFile 少 23 个字符（`-ID` 的长度）。本来我还改了 TruncateLenFileName，但是影响范围太大了最后还是不敢动，就只改了 putFile，不对已存在的文件进行验证。