### PR TITLE
Improve the right padding of the top bar in the browser environment

### DIFF
--- a/app/src/assets/scss/main/_main.scss
+++ b/app/src/assets/scss/main/_main.scss
@@ -67,7 +67,7 @@ html {
 
   &--browser {
     padding-left: env(titlebar-area-x, 5px);
-    padding-right: calc(100% - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0));
+    padding-right: calc(100% - env(titlebar-area-width, 100%) - env(titlebar-area-x, -5px));
     height: calc(env(titlebar-area-height, 31px) + 1px);
   }
 


### PR DESCRIPTION
上次改了左边距 https://github.com/siyuan-note/siyuan/pull/16392 ，现在发现右边距也有问题。

没有 titlebar-area-x 时回退到默认的右边距：

<img width="779" height="970" alt="image" src="https://github.com/user-attachments/assets/677ed9db-cd15-41e2-a4ca-e31ed6009d65" />
