### PR TITLE
Improve the fallback logic of the marketplace

### DIFF
--- a/kernel/bazaar/package.go
+++ b/kernel/bazaar/package.go
@@ -244,6 +244,8 @@ func getPreferredReadme(readme *Readme) string {
 		defaultReadme := strings.TrimSpace(readme.Default)
 		if defaultReadme != "" {
 			ret = defaultReadme
+		} else if "" != readme.EnUS {
+			ret = readme.EnUS
 		} else {
 			ret = "README.md"
 		}
@@ -323,6 +325,8 @@ func GetPreferredName(pkg *Package) string {
 		defaultName := strings.TrimSpace(pkg.DisplayName.Default)
 		if defaultName != "" {
 			ret = defaultName
+		} else if "" != pkg.DisplayName.EnUS {
+			ret = pkg.DisplayName.EnUS
 		} else {
 			ret = pkg.Name
 		}
@@ -402,6 +406,8 @@ func getPreferredDesc(desc *Description) string {
 		defaultDesc := strings.TrimSpace(desc.Default)
 		if defaultDesc != "" {
 			ret = defaultDesc
+		} else if "" != desc.EnUS {
+			ret = desc.EnUS
 		}
 	}
 	return ret

--- a/kernel/bazaar/plugin.go
+++ b/kernel/bazaar/plugin.go
@@ -247,9 +247,10 @@ func isIncompatiblePlugin(plugin *Plugin, currentFrontend string) bool {
 		return false
 	}
 
+	currentBackend := getCurrentBackend()
 	backendOk := false
 	for _, backend := range plugin.Backends {
-		if backend == getCurrentBackend() || "all" == backend {
+		if backend == currentBackend || "all" == backend {
 			backendOk = true
 			break
 		}


### PR DESCRIPTION
https://github.com/siyuan-note/siyuan/pull/16551 改成默认回退到 default 字段，但是我统计了一下发现有大量的集市包缺少 default 字段，不知道是按哪个模板用了 en_US，导致在非简体中文或英文环境下就没法显示集市包信息，因此再增加一层 en_US 的回退。

---

集市包统计，总包数: 416

**default 字段统计**
displayName.default: 266 / 416 (63.94%)
description.default: 265 / 416 (63.70%)
readme.default: 261 / 416 (62.74%)

**en_US 字段统计**
displayName.en_US: 174 / 416 (41.83%)
description.en_US: 166 / 416 (39.90%)
readme.en_US: 166 / 416 (39.90%)

**有 default 但没有 en_US**
displayName.default (无 en_US): 239 / 416 (57.45%)
description.default (无 en_US): 239 / 416 (57.45%)
readme.default (无 en_US): 238 / 416 (57.21%)

**有 en_US 但没有 default**
displayName.en_US (无 default): 147 / 416 (35.34%)
description.en_US (无 default): 140 / 416 (33.65%)
readme.en_US (无 default): 143 / 416 (34.38%)

---

我使用的 bazaar 统计脚本：

```js
const fs = require('fs');
const path = require('path');

// 所有集市包类别文件
const packageFiles = [
  'plugins.json',
  'themes.json',
  'templates.json',
  'widgets.json',
  'icons.json'
];

// 合并所有类别的 repos
let allRepos = [];
packageFiles.forEach(file => {
  const filePath = path.join(__dirname, file);
  if (fs.existsSync(filePath)) {
    try {
      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
      if (data.repos && Array.isArray(data.repos)) {
        allRepos = allRepos.concat(data.repos);
      }
    } catch (err) {
      console.error(`读取文件 ${file} 时出错:`, err.message);
    }
  }
});

const repos = allRepos;
const total = repos.length;

// 统计函数：检查字段是否存在且非空
function hasValidField(obj, field) {
  return obj && obj[field] && typeof obj[field] === 'string' && obj[field].trim() !== '';
}

// 统计 default 字段
let hasDisplayNameDefault = 0;
let hasDescriptionDefault = 0;
let hasReadmeDefault = 0;

// 统计 en_US 字段
let hasDisplayNameEnUS = 0;
let hasDescriptionEnUS = 0;
let hasReadmeEnUS = 0;

// 统计有 default 但没有 en_US
let hasDisplayNameDefaultButNotEnUS = 0;
let hasDescriptionDefaultButNotEnUS = 0;
let hasReadmeDefaultButNotEnUS = 0;

// 统计有 en_US 但没有 default
let hasDisplayNameEnUSButNotDefault = 0;
let hasDescriptionEnUSButNotDefault = 0;
let hasReadmeEnUSButNotDefault = 0;

repos.forEach(repo => {
  const pkg = repo.package;
  if (!pkg) return;

  // 统计 default 字段
  const hasDisplayNameDefaultField = hasValidField(pkg.displayName, 'default');
  const hasDescriptionDefaultField = hasValidField(pkg.description, 'default');
  const hasReadmeDefaultField = hasValidField(pkg.readme, 'default');

  if (hasDisplayNameDefaultField) {
    hasDisplayNameDefault++;
  }
  if (hasDescriptionDefaultField) {
    hasDescriptionDefault++;
  }
  if (hasReadmeDefaultField) {
    hasReadmeDefault++;
  }

  // 统计 en_US 字段
  const hasDisplayNameEnUSField = hasValidField(pkg.displayName, 'en_US');
  const hasDescriptionEnUSField = hasValidField(pkg.description, 'en_US');
  const hasReadmeEnUSField = hasValidField(pkg.readme, 'en_US');

  if (hasDisplayNameEnUSField) {
    hasDisplayNameEnUS++;
  }
  if (hasDescriptionEnUSField) {
    hasDescriptionEnUS++;
  }
  if (hasReadmeEnUSField) {
    hasReadmeEnUS++;
  }

  // 统计有 default 但没有 en_US
  if (hasDisplayNameDefaultField && !hasDisplayNameEnUSField) {
    hasDisplayNameDefaultButNotEnUS++;
  }
  if (hasDescriptionDefaultField && !hasDescriptionEnUSField) {
    hasDescriptionDefaultButNotEnUS++;
  }
  if (hasReadmeDefaultField && !hasReadmeEnUSField) {
    hasReadmeDefaultButNotEnUS++;
  }

  // 统计有 en_US 但没有 default
  if (hasDisplayNameEnUSField && !hasDisplayNameDefaultField) {
    hasDisplayNameEnUSButNotDefault++;
  }
  if (hasDescriptionEnUSField && !hasDescriptionDefaultField) {
    hasDescriptionEnUSButNotDefault++;
  }
  if (hasReadmeEnUSField && !hasReadmeDefaultField) {
    hasReadmeEnUSButNotDefault++;
  }
});

// 计算占比
const displayNameDefaultPercent = ((hasDisplayNameDefault / total) * 100).toFixed(2);
const descriptionDefaultPercent = ((hasDescriptionDefault / total) * 100).toFixed(2);
const readmeDefaultPercent = ((hasReadmeDefault / total) * 100).toFixed(2);

const displayNameEnUSPercent = ((hasDisplayNameEnUS / total) * 100).toFixed(2);
const descriptionEnUSPercent = ((hasDescriptionEnUS / total) * 100).toFixed(2);
const readmeEnUSPercent = ((hasReadmeEnUS / total) * 100).toFixed(2);

// 计算占比：有 default 但没有 en_US
const displayNameDefaultButNotEnUSPercent = ((hasDisplayNameDefaultButNotEnUS / total) * 100).toFixed(2);
const descriptionDefaultButNotEnUSPercent = ((hasDescriptionDefaultButNotEnUS / total) * 100).toFixed(2);
const readmeDefaultButNotEnUSPercent = ((hasReadmeDefaultButNotEnUS / total) * 100).toFixed(2);

// 计算占比：有 en_US 但没有 default
const displayNameEnUSButNotDefaultPercent = ((hasDisplayNameEnUSButNotDefault / total) * 100).toFixed(2);
const descriptionEnUSButNotDefaultPercent = ((hasDescriptionEnUSButNotDefault / total) * 100).toFixed(2);
const readmeEnUSButNotDefaultPercent = ((hasReadmeEnUSButNotDefault / total) * 100).toFixed(2);

// 输出结果
console.log('='.repeat(60));
console.log('集市包统计结果（所有类别）');
console.log('='.repeat(60));
console.log(`总包数: ${total}`);
console.log('\n**default 字段统计**');
console.log(`displayName.default: ${hasDisplayNameDefault} / ${total} (${displayNameDefaultPercent}%)`);
console.log(`description.default: ${hasDescriptionDefault} / ${total} (${descriptionDefaultPercent}%)`);
console.log(`readme.default: ${hasReadmeDefault} / ${total} (${readmeDefaultPercent}%)`);
console.log('\n**en_US 字段统计**');
console.log(`displayName.en_US: ${hasDisplayNameEnUS} / ${total} (${displayNameEnUSPercent}%)`);
console.log(`description.en_US: ${hasDescriptionEnUS} / ${total} (${descriptionEnUSPercent}%)`);
console.log(`readme.en_US: ${hasReadmeEnUS} / ${total} (${readmeEnUSPercent}%)`);
console.log('\n**有 default 但没有 en_US**');
console.log(`displayName.default (无 en_US): ${hasDisplayNameDefaultButNotEnUS} / ${total} (${displayNameDefaultButNotEnUSPercent}%)`);
console.log(`description.default (无 en_US): ${hasDescriptionDefaultButNotEnUS} / ${total} (${descriptionDefaultButNotEnUSPercent}%)`);
console.log(`readme.default (无 en_US): ${hasReadmeDefaultButNotEnUS} / ${total} (${readmeDefaultButNotEnUSPercent}%)`);
console.log('\n**有 en_US 但没有 default**');
console.log(`displayName.en_US (无 default): ${hasDisplayNameEnUSButNotDefault} / ${total} (${displayNameEnUSButNotDefaultPercent}%)`);
console.log(`description.en_US (无 default): ${hasDescriptionEnUSButNotDefault} / ${total} (${descriptionEnUSButNotDefaultPercent}%)`);
console.log(`readme.en_US (无 default): ${hasReadmeEnUSButNotDefault} / ${total} (${readmeEnUSButNotDefaultPercent}%)`);
console.log('='.repeat(60));
```