### PR TITLE
When preferredName is the same as the package name, the package name is not displayed redundantly

### DIFF
--- a/app/src/config/bazaar.ts
+++ b/app/src/config/bazaar.ts
@@ -261,7 +261,7 @@ export const bazaar = {
     </div>
     <div class="fn__flex-1 fn__flex-column">
         <div class="b3-card__info fn__flex-1">
-            ${item.preferredName} <span class="ft__on-surface ft__smaller">${item.name}</span>
+            ${item.preferredName}${item.preferredName !== item.name ? ` <span class="ft__on-surface ft__smaller">${item.name}</span>` : ""}
             <div class="b3-card__desc" title="${escapeAttr(item.preferredDesc) || ""}">
                 ${item.preferredDesc || ""}
             </div>
@@ -304,7 +304,7 @@ export const bazaar = {
     <div class="b3-card__img"><img src="${item.iconURL}" onerror="this.src='/stage/images/icon.png'"/></div>
     <div class="fn__flex-1 fn__flex-column">
         <div class="b3-card__info b3-card__info--left fn__flex-1">
-            ${item.preferredName} <span class="ft__on-surface ft__smaller">${item.name}</span>
+            ${item.preferredName}${item.preferredName !== item.name ? ` <span class="ft__on-surface ft__smaller">${item.name}</span>` : ""}
             <div class="b3-card__desc" title="${escapeAttr(item.preferredDesc) || ""}">${item.preferredDesc || ""}</div>
         </div>
     </div>
@@ -413,7 +413,7 @@ export const bazaar = {
     <div class="b3-card__img"><img src="${item.iconURL}" onerror="this.src='/stage/images/icon.png'"/></div>
     <div class="fn__flex-1 fn__flex-column">
         <div class="b3-card__info b3-card__info--left fn__flex-1">
-            ${item.preferredName} <span class="ft__on-surface ft__smaller">${item.name}</span>
+            ${item.preferredName}${item.preferredName !== item.name ? ` <span class="ft__on-surface ft__smaller">${item.name}</span>` : ""}
             <div class="b3-card__desc" title="${escapeAttr(item.preferredDesc) || ""}">${item.preferredDesc || ""}</div>
         </div>
     </div>


### PR DESCRIPTION
preferredName 和包名相同时，不重复显示包名：

![PixPin_2025-12-17_01-31-47](https://github.com/user-attachments/assets/f90b355e-e4b7-4683-866d-0397d0112bfc)

↓

![PixPin_2025-12-17_01-31-11](https://github.com/user-attachments/assets/dc26d040-4c1b-4d96-b521-eaea5876305a)
