### PR TITLE
Better English Localization for Kernel Service Port Failure Message

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -607,7 +607,7 @@ const initKernel = (workspace, port, lang) => {
                 writeLog("get kernel version failed: " + e.message);
                 if (14 < ++count) {
                     writeLog("get kernel ver failed");
-                    showErrorWindow("⚠️ 获取内核服务端口失败 Failed to get kernel serve port", "<div>获取内核服务端口失败，请确保程序拥有网络权限并不受防火墙和杀毒软件阻止。</div><div>Failed to get kernel serve port, please make sure the program has network permissions and is not blocked by firewalls and antivirus software.</div>");
+                    showErrorWindow("⚠️ 获取内核服务端口失败 Failed to Obtain Kernel Service Port", "<div>获取内核服务端口失败，请确保程序拥有网络权限并不受防火墙和杀毒软件阻止。</div><div>Failed to get obtain kernel service port, please make sure Siyuan has network permissions and is not blocked by firewalls or antivirus software.</div>");
                     bootWindow.destroy();
                     resolve(false);
                     return;

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -607,7 +607,7 @@ const initKernel = (workspace, port, lang) => {
                 writeLog("get kernel version failed: " + e.message);
                 if (14 < ++count) {
                     writeLog("get kernel ver failed");
-                    showErrorWindow("⚠️ 获取内核服务端口失败 Failed to Obtain Kernel Service Port", "<div>获取内核服务端口失败，请确保程序拥有网络权限并不受防火墙和杀毒软件阻止。</div><div>Failed to obtain kernel service port, please make sure Siyuan has network permissions and is not blocked by firewalls or antivirus software.</div>");
+                    showErrorWindow("⚠️ 获取内核服务端口失败 Failed to Obtain Kernel Service Port", "<div>获取内核服务端口失败，请确保程序拥有网络权限并不受防火墙和杀毒软件阻止。</div><div>Failed to obtain kernel service port. Please ensure Siyuan has network permissions and is not blocked by firewalls or antivirus software.</div>");
                     bootWindow.destroy();
                     resolve(false);
                     return;

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -607,7 +607,7 @@ const initKernel = (workspace, port, lang) => {
                 writeLog("get kernel version failed: " + e.message);
                 if (14 < ++count) {
                     writeLog("get kernel ver failed");
-                    showErrorWindow("⚠️ 获取内核服务端口失败 Failed to Obtain Kernel Service Port", "<div>获取内核服务端口失败，请确保程序拥有网络权限并不受防火墙和杀毒软件阻止。</div><div>Failed to get obtain kernel service port, please make sure Siyuan has network permissions and is not blocked by firewalls or antivirus software.</div>");
+                    showErrorWindow("⚠️ 获取内核服务端口失败 Failed to Obtain Kernel Service Port", "<div>获取内核服务端口失败，请确保程序拥有网络权限并不受防火墙和杀毒软件阻止。</div><div>Failed to obtain kernel service port, please make sure Siyuan has network permissions and is not blocked by firewalls or antivirus software.</div>");
                     bootWindow.destroy();
                     resolve(false);
                     return;


### PR DESCRIPTION
Found this minor localization glitch when I was browsing through threads on ld246.com, so there you go!

Original message in Chinese:
```
获取内核服务端口失败
获取内核服务端口失败，请确保程序拥有网络权限并不受防火墙和杀毒软件阻止。
```

Original message in English:
```
Failed to get kernel serve port
Failed to get kernel serve port, please make sure the program has network permissions and is not blocked by firewalls and antivirus software.
```

**Improved English Localization**:
```
Failed to Obtain Kernel Service Port
Failed to obtain kernel service port. Please ensure Siyuan has network permissions and is not blocked by firewalls or antivirus software.
```


It's my first time submitting a PR. Apologies if I'm doing anything wrong. Just wanted to contribute to this awesome project I've been using.