### PR TITLE
Improve the inline memo and hyperlink tooltip display

### DIFF
--- a/app/src/block/popover.ts
+++ b/app/src/block/popover.ts
@@ -81,13 +81,13 @@ export const initBlockPopover = (app: App) => {
                 }
             }
             let tooltipSpace: number | undefined;
-            if (!tip && aElement.getAttribute("data-type") === "inline-memo") {
+            if (!tip && aElement.getAttribute("data-type")?.includes("inline-memo")) {
                 tip = escapeHtml(aElement.getAttribute("data-inline-memo-content"));
                 tooltipClass = "memo"; // 为行级备注添加 class https://github.com/siyuan-note/siyuan/issues/6161
                 tooltipSpace = 0; // tooltip 和备注元素之间不能有空隙 https://github.com/siyuan-note/siyuan/issues/14796#issuecomment-3649757267
             }
             if (!tip) {
-                if (aElement.getAttribute("data-type") === "a") {
+                if (aElement.getAttribute("data-type")?.includes("a")) {
                     tooltipClass = "href"; // 为超链接添加 class https://github.com/siyuan-note/siyuan/issues/11440#issuecomment-2119080691
                     tooltipSpace = 0;
                 }


### PR DESCRIPTION
https://ld246.com/article/1765979871054

严格来说用 `includes("a")` 匹配超链接不严谨，因为其他类型的行级元素 type 中也可能有字母 a，应该用 `aElement.getAttribute("data-type")?.split(" ").includes("a")`。

但实际情况下只有行级备注和超链接才有 tooltip，同一时间只能显示其中一个，不会产生冲突（即使一个元素同时是行级备注和超链接），所以为了提高性能去掉了 `.split(" ")`。