### PR TITLE
Improve image clicking behavior in database asset field menu

### DIFF
--- a/app/src/protyle/render/av/openMenuPanel.ts
+++ b/app/src/protyle/render/av/openMenuPanel.ts
@@ -1354,23 +1354,24 @@ export const openMenuPanel = (options: {
                     event.stopPropagation();
                     break;
                 } else if (type === "openAssetItem") {
+                    const assetType = target.parentElement.dataset.type;
                     const assetLink = target.parentElement.dataset.content;
                     const suffix = pathPosix().extname(assetLink);
                     /// #if !MOBILE
-                    if (isLocalPath(assetLink) && (
-                        [".pdf"].concat(Constants.SIYUAN_ASSETS_AUDIO).concat(Constants.SIYUAN_ASSETS_VIDEO).includes(suffix) && (
-                            suffix !== ".pdf" || (suffix === ".pdf" && !assetLink.startsWith("file://"))
-                        )
-                    )) {
-                        openAsset(options.protyle.app, assetLink.trim(), parseInt(getSearch("page", assetLink)), "right");
-                    } else if (Constants.SIYUAN_ASSETS_IMAGE.includes(suffix)) {
+                    if (assetType === "image") {
                         previewAttrViewImages(assetLink, avID, options.blockElement.getAttribute(Constants.CUSTOM_SY_AV_VIEW),
                             (options.blockElement.querySelector('[data-type="av-search"]') as HTMLInputElement)?.value.trim() || "");
+                    } else if (isLocalPath(assetLink) && (
+                        assetType === "file" && Constants.SIYUAN_ASSETS_IMAGE.includes(suffix) || // data-type="file" 但内容是图片链接时，分屏打开
+                        suffix === ".pdf" && !assetLink.startsWith("file://") ||
+                        Constants.SIYUAN_ASSETS_AUDIO.concat(Constants.SIYUAN_ASSETS_VIDEO).includes(suffix)
+                    )) {
+                        openAsset(options.protyle.app, assetLink.trim(), parseInt(getSearch("page", assetLink)), "right");
                     } else {
                         window.open(assetLink);
                     }
                     /// #else
-                    if (Constants.SIYUAN_ASSETS_IMAGE.includes(suffix)) {
+                    if (assetType === "image") {
                         previewAttrViewImages(assetLink, avID, options.blockElement.getAttribute(Constants.CUSTOM_SY_AV_VIEW),
                             (options.blockElement.querySelector('[data-type="av-search"]') as HTMLInputElement)?.value.trim() || "");
                     } else {


### PR DESCRIPTION
改进在数据库资源字段菜单中点击图片的行为

- 修复：data-type="image" 中的无扩展名图片（如 api/icon/getDynamicIcon）点击后无法预览
- 修复：data-type="file" 但内容是图片链接时，桌面端点击后无法分屏打开、移动端点击后无法跳转到浏览器打开