### PR TITLE
Fix getActiveEditor function returning inactive editor

### DIFF
--- a/app/src/plugin/API.ts
+++ b/app/src/plugin/API.ts
@@ -229,7 +229,7 @@ const getActiveEditor = (wndActive = true) => {
     }
     if (!editor) {
         editor = allEditor.find(item => {
-            if (hasClosestByClassName(item.protyle.element, "layout__wnd--active", true)) {
+            if (!item.protyle.element.classList.contains("fn__none") && hasClosestByClassName(item.protyle.element, "layout__wnd--active", true)) {
                 return true;
             }
         });


### PR DESCRIPTION
使用「文档高亮搜索」插件时 range 不在编辑器中，调用 getActiveEditor() 不会进入第一个分支 if (range)，而是会进入第二个分支 if (!editor)，但该分支没有判断编辑器是否正在显示，导致始终会获取到从左往右的首个已加载的编辑器。

![PixPin_2025-12-24_01-41-01](https://github.com/user-attachments/assets/946b9050-641e-408f-8247-4a341c91a02c)

