### PR TITLE
Fix JSON response parsing error

### DIFF
--- a/app/src/util/fetch.ts
+++ b/app/src/util/fetch.ts
@@ -50,7 +50,13 @@ export const fetchPost = (url: string, data?: any, cb?: (response: IWebSocketDat
                 }
 
                 if (response.headers.get("content-type")?.indexOf("application/json") > -1) {
-                    return response.json();
+                    return response.text().then((text) => {
+                        try {
+                            return JSON.parse(text);
+                        } catch {
+                            return text;
+                        }
+                    });
                 } else {
                     return response.text();
                 }
@@ -76,7 +82,7 @@ export const fetchPost = (url: string, data?: any, cb?: (response: IWebSocketDat
             cb(response);
         }
     }).catch((e) => {
-        console.warn("fetch post failed [" + e + "], url [" + url + "]");
+        console.error("fetch post failed [" + e + "], url [" + url + "]");
         if (url === "/api/transactions" && (e.message === "Failed to fetch" || e.message === "Unexpected end of JSON input")) {
             kernelError();
             return;


### PR DESCRIPTION
修复 JSON 文件响应解析错误 https://github.com/siyuan-note/siyuan/issues/15818

当 Content-Type 为 application/json 但实际内容是纯文本时，先读取为文本再尝试 JSON 解析，解析失败则返回文本，避免 SyntaxError。