### PR TITLE
Fix code block copy issue with ZWJ

### DIFF
--- a/app/src/boot/globalEvent/click.ts
+++ b/app/src/boot/globalEvent/click.ts
@@ -43,6 +43,8 @@ export const globalClick = (event: MouseEvent & { target: HTMLElement }) => {
     if (copyElement) {
         let text = copyElement.parentElement.nextElementSibling.textContent.replace(/\n$/, "");
         text = text.replace(/\u00A0/g, " "); // Replace non-breaking spaces with normal spaces when copying https://github.com/siyuan-note/siyuan/issues/9382
+        // https://github.com/siyuan-note/siyuan/issues/14800
+        text = text.replace(/\u200D```/g, "```");
         writeText(text);
         showMessage(window.siyuan.languages.copied, 2000);
         event.preventDefault();

--- a/app/src/protyle/export/index.ts
+++ b/app/src/protyle/export/index.ts
@@ -51,7 +51,7 @@ export const saveExport = (option: IExportOptions) => {
             }, zipResponse => {
                 hideMessage(msgId);
                 if (zipResponse.code === -1) {
-                    showMessage(window.siyuan.languages._kernel[14] + ": " + zipResponse.msg, 0, "error");
+                    showMessage(window.siyuan.languages._kernel[14].replace("%s", zipResponse.msg), 0, "error");
                     return;
                 }
                 window.open(zipResponse.data.zip);
@@ -532,6 +532,7 @@ ${getIconScript(servePath)}
                 } else if (target.classList.contains("protyle-action__copy")) {
                     let text = target.parentElement.nextElementSibling.textContent.trimEnd();
                     text = text.replace(/\u00A0/g, " "); // Replace non-breaking spaces with normal spaces when copying https://github.com/siyuan-note/siyuan/issues/9382
+                    text = text.replace(/\u200D\`\`\`/g, "\`\`\`");
                     navigator.clipboard.writeText(text);
                     event.preventDefault();
                     event.stopPropagation();
@@ -825,6 +826,7 @@ ${getIconScript(servePath)}
       item.addEventListener("click", (event) => {
             let text = item.parentElement.nextElementSibling.textContent.trimEnd();
             text = text.replace(/\u00A0/g, " "); // Replace non-breaking spaces with normal spaces when copying
+            text = text.replace(/\u200D\`\`\`/g, "\`\`\`");
             navigator.clipboard.writeText(text);
             event.preventDefault();
             event.stopPropagation();

--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -773,7 +773,10 @@ export class Gutter {
                 selectsElement.forEach((item: HTMLElement) => {
                     html += getPlainText(item) + "\n";
                 });
-                copyPlainText(html.trimEnd());
+                let plainText = html.trimEnd();
+                // https://github.com/siyuan-note/siyuan/issues/14800
+                plainText = plainText.replace(/\u200D```/g, "```");
+                copyPlainText(plainText);
                 focusBlock(selectsElement[0]);
             }
         }, {
@@ -1344,7 +1347,12 @@ export class Gutter {
             label: window.siyuan.languages.copyPlainText,
             accelerator: window.siyuan.config.keymap.editor.general.copyPlainText.custom,
             click() {
-                copyPlainText(getPlainText(nodeElement as HTMLElement).trimEnd());
+                let plainText = getPlainText(nodeElement as HTMLElement).trimEnd();
+                if (type === "NodeCodeBlock") {
+                    // https://github.com/siyuan-note/siyuan/issues/14800
+                    plainText = plainText.replace(/\u200D```/g, "```");
+                }
+                copyPlainText(plainText);
                 focusBlock(nodeElement);
             }
         }, {

--- a/app/src/protyle/util/paste.ts
+++ b/app/src/protyle/util/paste.ts
@@ -159,7 +159,7 @@ export const pasteAsPlainText = async (protyle: IProtyle) => {
         if (getSelection().rangeCount > 0) {
             const range = getSelection().getRangeAt(0);
             if (hasClosestByAttribute(range.startContainer, "data-type", "code") || hasClosestByClassName(range.startContainer, "hljs")) {
-                insertHTML(textPlain.replace(/\u200D```/g, "```").replace(/```/g, "\u200D```"), protyle);
+                insertHTML(textPlain.replace(/```/g, "\u200D```"), protyle);
                 return;
             }
         }
@@ -361,7 +361,7 @@ export const paste = async (protyle: IProtyle, event: (ClipboardEvent | DragEven
     if (nodeElement.getAttribute("data-type") === "NodeCodeBlock" ||
         protyle.toolbar.getCurrentType(range).includes("code")) {
         // https://github.com/siyuan-note/siyuan/issues/13552
-        insertHTML(textPlain.replace(/\u200D```/g, "```").replace(/```/g, "\u200D```"), protyle);
+        insertHTML(textPlain.replace(/```/g, "\u200D```"), protyle);
         return;
     } else if (siyuanHTML) {
         // 编辑器内部粘贴
@@ -439,10 +439,6 @@ export const paste = async (protyle: IProtyle, event: (ClipboardEvent | DragEven
                 // 复制 HTML 块粘贴出来的不是 HTML 块 https://github.com/siyuan-note/siyuan/issues/12994
                 tempInnerHTML = Lute.UnEscapeHTMLStr(tempInnerHTML);
             }
-
-            // https://github.com/siyuan-note/siyuan/issues/13552
-            tempInnerHTML = tempInnerHTML.replace(/\u200D```/g, "```");
-
             insertHTML(tempInnerHTML, protyle, isBlock, false, true);
         }
         blockRender(protyle, protyle.wysiwyg.element);
@@ -588,10 +584,6 @@ export const paste = async (protyle: IProtyle, event: (ClipboardEvent | DragEven
                     }
                 }
             }
-
-            // https://github.com/siyuan-note/siyuan/issues/13552
-            textPlain = textPlain.replace(/\u200D```/g, "```");
-
             const textPlainDom = protyle.lute.Md2BlockDOM(textPlain);
             insertHTML(textPlainDom, protyle, false, false, true);
         }

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -469,6 +469,8 @@ export class WYSIWYG {
                         if (isEndOfBlock(range)) {
                             textPlain = textPlain.replace(/\n$/, "");
                         }
+                        // https://github.com/siyuan-note/siyuan/issues/14800
+                        textPlain = textPlain.replace(/\u200D```/g, "```");
                         isInCodeBlock = true;
                     } else if (hasClosestByTag(range.startContainer, "TD") || hasClosestByTag(range.startContainer, "TH")) {
                         tempElement.innerHTML = tempElement.innerHTML.replace(/<br>/g, "\n").replace(/<br\/>/g, "\n");
@@ -2037,6 +2039,8 @@ export class WYSIWYG {
                 if (hasClosestByAttribute(range.startContainer, "data-type", "NodeCodeBlock") ||
                     hasClosestByTag(range.startContainer, "CODE")) {
                     textPlain = tempElement.textContent.replace(Constants.ZWSP, "");
+                    // https://github.com/siyuan-note/siyuan/issues/14800
+                    textPlain = textPlain.replace(/\u200D```/g, "```");
                     isInCodeBlock = true;
                 }
                 // https://github.com/siyuan-note/siyuan/issues/4321


### PR DESCRIPTION
fix https://github.com/siyuan-note/siyuan/issues/14800

Lute 会给代码块中的 `` ``` `` 前面添加 ZWJ，所以只能在复制的时候去替换掉。用户粘贴的内容中可能刚好有 `` ZWJ``` ``，所以粘贴的时候不要替换。