### PR TITLE
Add --target parameter for selective architecture builds

### DIFF
--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -9,9 +9,8 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         *)
-            echo "Error: Unknown option '$1'"
-            echo "Only --variant=value is supported"
-            exit 1
+            # Skip unknown options
+            shift
             ;;
     esac
 done

--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# SiYuan Darwin Build Script
+# Usage: ./scripts/darwin-build.sh [--variant=<variant>]
+# Options:
+#   --variant=<variant>  Build variant: amd64, arm64, or all (default: all)
+
 VARIANT="all"
 
 while [[ $# -gt 0 ]]; do
@@ -7,6 +12,12 @@ while [[ $# -gt 0 ]]; do
         --variant=*)
             VARIANT="${1#*=}"
             shift
+            ;;
+        --variant)
+            echo "Error: --variant option requires an equal sign and value"
+            echo "Usage: --variant=<variant>"
+            echo "Example: --variant=amd64"
+            exit 1
             ;;
         *)
             # Skip unknown options

--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -1,36 +1,36 @@
 #!/bin/bash
 
 echo 'TIP: This script must be run from the project root directory'
-echo 'Usage: ./scripts/darwin-build.sh [--variant=<variant>]'
+echo 'Usage: ./scripts/darwin-build.sh [--target=<target>]'
 echo 'Options:'
-echo '  --variant=<variant>  Build variant: amd64, arm64, or all (default: all)'
+echo '  --target=<target>  Build target: amd64, arm64, or all (default: all)'
 echo
 
-VARIANT='all'
+TARGET='all'
 
-validate_variant() {
+validate_target() {
     if [[ -z "$1" ]]; then
-        echo 'Error: --variant option requires a value'
-        echo 'Usage: --variant=<variant>'
-        echo 'Examples: --variant=amd64'
+        echo 'Error: --target option requires a value'
+        echo 'Usage: --target=<target>'
+        echo 'Examples: --target=amd64'
         exit 1
     elif [[ "$1" != 'amd64' && "$1" != 'arm64' && "$1" != 'all' ]]; then
-        echo "Error: Invalid variant '$1'"
-        echo 'Valid variants are: amd64, arm64, all'
+        echo "Error: Invalid target '$1'"
+        echo 'Valid targets are: amd64, arm64, all'
         exit 1
     fi
 }
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --variant=*)
-            VARIANT="${1#*=}"
-            validate_variant "$VARIANT"
+        --target=*)
+            TARGET="${1#*=}"
+            validate_target "$TARGET"
             shift
             ;;
-        --variant)
-            VARIANT="$2"
-            validate_variant "$VARIANT"
+        --target)
+            TARGET="$2"
+            validate_target "$TARGET"
             [ -n "$2" ] && shift 2 || shift
             ;;
         *)
@@ -58,14 +58,14 @@ export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
 
-if [[ "$VARIANT" == 'amd64' || "$VARIANT" == 'all' ]]; then
+if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
     echo 'Building Kernel amd64'
     export GOOS=darwin
     export GOARCH=amd64
     go build --tags fts5 -v -o "../app/kernel-darwin/SiYuan-Kernel" -ldflags "-s -w" .
 fi
 
-if [[ "$VARIANT" == 'arm64' || "$VARIANT" == 'all' ]]; then
+if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
     echo 'Building Kernel arm64'
     export GOOS=darwin
     export GOARCH=arm64
@@ -75,12 +75,12 @@ cd .. || exit
 
 cd app || exit
 
-if [[ "$VARIANT" == 'amd64' || "$VARIANT" == 'all' ]]; then
+if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
     echo 'Building Electron App amd64'
     pnpm run dist-darwin
 fi
 
-if [[ "$VARIANT" == 'arm64' || "$VARIANT" == 'all' ]]; then
+if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
     echo 'Building Electron App arm64'
     pnpm run dist-darwin-arm64
 fi

--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -1,9 +1,31 @@
 #!/bin/bash
 
+ARCH="all"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --arch=*)
+            ARCH="${1#*=}"
+            shift
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            echo "Only --arch=value is supported"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" && "$ARCH" != "all" ]]; then
+    echo "Error: Invalid architecture '$ARCH'"
+    echo "Valid architectures are: amd64, arm64, all"
+    exit 1
+fi
+
 echo 'Building UI'
-cd app
+cd app || exit
 pnpm install && pnpm run build
-cd ..
+cd .. || exit
 
 echo 'Cleaning Builds'
 rm -rf app/build
@@ -12,26 +34,37 @@ rm -rf app/kernel-darwin-arm64
 
 echo 'Building Kernel'
 
-cd kernel
+cd kernel || exit
 go version
 export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
 
-echo 'Building Kernel amd64'
-export GOOS=darwin
-export GOARCH=amd64
-go build --tags fts5 -v -o "../app/kernel-darwin/SiYuan-Kernel" -ldflags "-s -w" .
+if [[ "$ARCH" == "amd64" || "$ARCH" == "all" ]]; then
+    echo 'Building Kernel amd64'
+    export GOOS=darwin
+    export GOARCH=amd64
+    go build --tags fts5 -v -o "../app/kernel-darwin/SiYuan-Kernel" -ldflags "-s -w" .
+fi
 
-echo 'Building Kernel arm64'
-export GOOS=darwin
-export GOARCH=arm64
-go build --tags fts5 -v -o "../app/kernel-darwin-arm64/SiYuan-Kernel" -ldflags "-s -w" .
-cd ..
+if [[ "$ARCH" == "arm64" || "$ARCH" == "all" ]]; then
+    echo 'Building Kernel arm64'
+    export GOOS=darwin
+    export GOARCH=arm64
+    go build --tags fts5 -v -o "../app/kernel-darwin-arm64/SiYuan-Kernel" -ldflags "-s -w" .
+fi
+cd .. || exit
 
-echo 'Building Electron App amd64'
-cd app
-pnpm run dist-darwin
-echo 'Building Electron App arm64'
-pnpm run dist-darwin-arm64
-cd ..
+cd app || exit
+
+if [[ "$ARCH" == "amd64" || "$ARCH" == "all" ]]; then
+    echo 'Building Electron App amd64'
+    pnpm run dist-darwin
+fi
+
+if [[ "$ARCH" == "arm64" || "$ARCH" == "all" ]]; then
+    echo 'Building Electron App arm64'
+    pnpm run dist-darwin-arm64
+fi
+
+cd .. || exit

--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# SiYuan Darwin Build Script
-
 echo 'TIP: This script must be run from the project root directory'
 echo 'Usage: ./scripts/darwin-build.sh [--variant=<variant>]'
 echo 'Options:'
@@ -10,17 +8,30 @@ echo
 
 VARIANT='all'
 
+validate_variant() {
+    if [[ -z "$1" ]]; then
+        echo 'Error: --variant option requires a value'
+        echo 'Usage: --variant=<variant>'
+        echo 'Examples: --variant=amd64'
+        exit 1
+    elif [[ "$1" != 'amd64' && "$1" != 'arm64' && "$1" != 'all' ]]; then
+        echo "Error: Invalid variant '$1'"
+        echo 'Valid variants are: amd64, arm64, all'
+        exit 1
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         --variant=*)
             VARIANT="${1#*=}"
+            validate_variant "$VARIANT"
             shift
             ;;
         --variant)
-            echo 'Error: --variant option requires an equal sign and value'
-            echo 'Usage: --variant=<variant>'
-            echo 'Example: --variant=amd64'
-            exit 1
+            VARIANT="$2"
+            validate_variant "$VARIANT"
+            [ -n "$2" ] && shift 2 || shift
             ;;
         *)
             # Skip unknown options
@@ -28,12 +39,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-
-if [[ "$VARIANT" != 'amd64' && "$VARIANT" != 'arm64' && "$VARIANT" != 'all' ]]; then
-    echo "Error: Invalid variant '$VARIANT'"
-    echo 'Valid variants are: amd64, arm64, all'
-    exit 1
-fi
 
 echo 'Building UI'
 cd app || exit

--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 # SiYuan Darwin Build Script
-# Usage: ./scripts/darwin-build.sh [--variant=<variant>]
-# Options:
-#   --variant=<variant>  Build variant: amd64, arm64, or all (default: all)
 
-VARIANT="all"
+echo 'TIP: This script must be run from the project root directory'
+echo 'Usage: ./scripts/darwin-build.sh [--variant=<variant>]'
+echo 'Options:'
+echo '  --variant=<variant>  Build variant: amd64, arm64, or all (default: all)'
+echo
+
+VARIANT='all'
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -14,9 +17,9 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --variant)
-            echo "Error: --variant option requires an equal sign and value"
-            echo "Usage: --variant=<variant>"
-            echo "Example: --variant=amd64"
+            echo 'Error: --variant option requires an equal sign and value'
+            echo 'Usage: --variant=<variant>'
+            echo 'Example: --variant=amd64'
             exit 1
             ;;
         *)
@@ -26,9 +29,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "$VARIANT" != "amd64" && "$VARIANT" != "arm64" && "$VARIANT" != "all" ]]; then
+if [[ "$VARIANT" != 'amd64' && "$VARIANT" != 'arm64' && "$VARIANT" != 'all' ]]; then
     echo "Error: Invalid variant '$VARIANT'"
-    echo "Valid variants are: amd64, arm64, all"
+    echo 'Valid variants are: amd64, arm64, all'
     exit 1
 fi
 
@@ -50,14 +53,14 @@ export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
 
-if [[ "$VARIANT" == "amd64" || "$VARIANT" == "all" ]]; then
+if [[ "$VARIANT" == 'amd64' || "$VARIANT" == 'all' ]]; then
     echo 'Building Kernel amd64'
     export GOOS=darwin
     export GOARCH=amd64
     go build --tags fts5 -v -o "../app/kernel-darwin/SiYuan-Kernel" -ldflags "-s -w" .
 fi
 
-if [[ "$VARIANT" == "arm64" || "$VARIANT" == "all" ]]; then
+if [[ "$VARIANT" == 'arm64' || "$VARIANT" == 'all' ]]; then
     echo 'Building Kernel arm64'
     export GOOS=darwin
     export GOARCH=arm64
@@ -67,12 +70,12 @@ cd .. || exit
 
 cd app || exit
 
-if [[ "$VARIANT" == "amd64" || "$VARIANT" == "all" ]]; then
+if [[ "$VARIANT" == 'amd64' || "$VARIANT" == 'all' ]]; then
     echo 'Building Electron App amd64'
     pnpm run dist-darwin
 fi
 
-if [[ "$VARIANT" == "arm64" || "$VARIANT" == "all" ]]; then
+if [[ "$VARIANT" == 'arm64' || "$VARIANT" == 'all' ]]; then
     echo 'Building Electron App arm64'
     pnpm run dist-darwin-arm64
 fi

--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-ARCH="all"
+VARIANT="all"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --arch=*)
-            ARCH="${1#*=}"
+        --variant=*)
+            VARIANT="${1#*=}"
             shift
             ;;
         *)
             echo "Error: Unknown option '$1'"
-            echo "Only --arch=value is supported"
+            echo "Only --variant=value is supported"
             exit 1
             ;;
     esac
 done
 
-if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" && "$ARCH" != "all" ]]; then
-    echo "Error: Invalid architecture '$ARCH'"
-    echo "Valid architectures are: amd64, arm64, all"
+if [[ "$VARIANT" != "amd64" && "$VARIANT" != "arm64" && "$VARIANT" != "all" ]]; then
+    echo "Error: Invalid variant '$VARIANT'"
+    echo "Valid variants are: amd64, arm64, all"
     exit 1
 fi
 
@@ -40,14 +40,14 @@ export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
 
-if [[ "$ARCH" == "amd64" || "$ARCH" == "all" ]]; then
+if [[ "$VARIANT" == "amd64" || "$VARIANT" == "all" ]]; then
     echo 'Building Kernel amd64'
     export GOOS=darwin
     export GOARCH=amd64
     go build --tags fts5 -v -o "../app/kernel-darwin/SiYuan-Kernel" -ldflags "-s -w" .
 fi
 
-if [[ "$ARCH" == "arm64" || "$ARCH" == "all" ]]; then
+if [[ "$VARIANT" == "arm64" || "$VARIANT" == "all" ]]; then
     echo 'Building Kernel arm64'
     export GOOS=darwin
     export GOARCH=arm64
@@ -57,12 +57,12 @@ cd .. || exit
 
 cd app || exit
 
-if [[ "$ARCH" == "amd64" || "$ARCH" == "all" ]]; then
+if [[ "$VARIANT" == "amd64" || "$VARIANT" == "all" ]]; then
     echo 'Building Electron App amd64'
     pnpm run dist-darwin
 fi
 
-if [[ "$ARCH" == "arm64" || "$ARCH" == "all" ]]; then
+if [[ "$VARIANT" == "arm64" || "$VARIANT" == "all" ]]; then
     echo 'Building Electron App arm64'
     pnpm run dist-darwin-arm64
 fi

--- a/scripts/linux-build.sh
+++ b/scripts/linux-build.sh
@@ -1,9 +1,49 @@
 #!/bin/bash
 
+echo 'TIP: This script must be run from the project root directory'
+echo 'Usage: ./scripts/linux-build.sh [--target=<target>]'
+echo 'Options:'
+echo '  --target=<target>  Build target: amd64, arm64, or all (default: all)'
+echo
+
+TARGET='all'
+
+validate_target() {
+    if [[ -z "$1" ]]; then
+        echo 'Error: --target option requires a value'
+        echo 'Usage: --target=<target>'
+        echo 'Examples: --target=amd64'
+        exit 1
+    elif [[ "$1" != 'amd64' && "$1" != 'arm64' && "$1" != 'all' ]]; then
+        echo "Error: Invalid target '$1'"
+        echo 'Valid targets are: amd64, arm64, all'
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --target=*)
+            TARGET="${1#*=}"
+            validate_target "$TARGET"
+            shift
+            ;;
+        --target)
+            TARGET="$2"
+            validate_target "$TARGET"
+            [ -n "$2" ] && shift 2 || shift
+            ;;
+        *)
+            # Skip unknown options
+            shift
+            ;;
+    esac
+done
+
 echo 'Building UI'
-cd app
+cd app || exit
 pnpm install && pnpm run build
-cd ..
+cd .. || exit
 
 echo 'Cleaning Builds'
 rm -rf app/build
@@ -12,27 +52,38 @@ rm -rf app/kernel-linux-arm64
 
 echo 'Building Kernel'
 
-cd kernel
+cd kernel || exit
 go version
 export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
 
-echo 'Building Kernel amd64'
-export GOOS=linux
-export GOARCH=amd64
-export CC=~/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-go build -buildmode=pie --tags fts5 -v -o "../app/kernel-linux/SiYuan-Kernel" -ldflags "-s -w -extldflags -static-pie" .
+if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
+    echo 'Building Kernel amd64'
+    export GOOS=linux
+    export GOARCH=amd64
+    export CC=~/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    go build -buildmode=pie --tags fts5 -v -o "../app/kernel-linux/SiYuan-Kernel" -ldflags "-s -w -extldflags -static-pie" .
+fi
 
-echo 'Building Kernel arm64'
-export GOARCH=arm64
-export CC=~/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-go build -buildmode=pie --tags fts5 -v -o "../app/kernel-linux-arm64/SiYuan-Kernel" -ldflags "-s -w -extldflags -static-pie" .
-cd ..
+if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
+    echo 'Building Kernel arm64'
+    export GOARCH=arm64
+    export CC=~/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    go build -buildmode=pie --tags fts5 -v -o "../app/kernel-linux-arm64/SiYuan-Kernel" -ldflags "-s -w -extldflags -static-pie" .
+fi
+cd .. || exit
 
-echo 'Building Electron App amd64'
-cd app
-pnpm run dist-linux
-echo 'Building Electron App arm64'
-pnpm run dist-linux-arm64
-cd ..
+cd app || exit
+
+if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
+    echo 'Building Electron App amd64'
+    pnpm run dist-linux
+fi
+
+if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
+    echo 'Building Electron App arm64'
+    pnpm run dist-linux-arm64
+fi
+
+cd .. || exit

--- a/scripts/win-build.bat
+++ b/scripts/win-build.bat
@@ -1,28 +1,28 @@
 @echo off
 
 echo TIP: This script must be run from the project root directory
-echo Usage: .\scripts\win-build.bat [--variant=^<variant^>]
-echo Options: 
-echo   --variant=^<variant^>  Build variant: amd64, arm64, appx-amd64, appx-arm64, or all (default: all)
+echo Usage: .\scripts\win-build.bat [--target=^<target^>]
+echo Options:
+echo   --target=^<target^>  Build target: amd64, arm64, appx-amd64, appx-arm64, or all (default: all)
 echo.
 
-set "VARIANT=all"
+set "TARGET=all"
 
 :parse_args
 if "%1"=="" goto :end_parse_args
-if "%1"=="--variant" (
+if "%1"=="--target" (
     if "%2"=="" (
-        echo Error: --variant option requires an equal sign and value
-        echo Usage: --variant=^<variant^>
-        echo Example: --variant=amd64
+        echo Error: --target option requires an equal sign and value
+        echo Usage: --target=^<target^>
+        echo Example: --target=amd64
         exit /b 1
     ) else (
         if not "%2"=="amd64" if not "%2"=="arm64" if not "%2"=="appx-amd64" if not "%2"=="appx-arm64" if not "%2"=="all" (
-            echo Error: Invalid variant '%2'
-            echo Valid variants are: amd64, arm64, appx-amd64, appx-arm64, all
+            echo Error: Invalid target '%2'
+            echo Valid targets are: amd64, arm64, appx-amd64, appx-arm64, all
             exit /b 1
         )
-        set "VARIANT=%2"
+        set "TARGET=%2"
         shift
         shift
         goto :parse_args
@@ -34,13 +34,13 @@ if "%1"=="--variant" (
 )
 :end_parse_args
 
-if "%VARIANT%"=="amd64" (
+if "%TARGET%"=="amd64" (
     set BUILD_AMD64=1
-) else if "%VARIANT%"=="arm64" (
+) else if "%TARGET%"=="arm64" (
     set BUILD_ARM64=1
-) else if "%VARIANT%"=="appx-amd64" (
+) else if "%TARGET%"=="appx-amd64" (
     set BUILD_APPX_AMD64=1
-) else if "%VARIANT%"=="appx-arm64" (
+) else if "%TARGET%"=="appx-arm64" (
     set BUILD_APPX_ARM64=1
 ) else (
     REM all: build everything

--- a/scripts/win-build.bat
+++ b/scripts/win-build.bat
@@ -1,8 +1,60 @@
 @echo off
-echo 'use ".\scripts\win-build.bat" instead of "win-build.bat"'
 
-echo 'Building UI'
+echo TIP: This script must be run from the project root directory
+echo Usage: .\scripts\win-build.bat [--variant=^<variant^>]
+echo Options: 
+echo   --variant=^<variant^>  Build variant: amd64, arm64, appx-amd64, appx-arm64, or all (default: all)
+echo.
+
+set "VARIANT=all"
+
+:parse_args
+if "%1"=="" goto :end_parse_args
+if "%1"=="--variant" (
+    if "%2"=="" (
+        echo Error: --variant option requires an equal sign and value
+        echo Usage: --variant=^<variant^>
+        echo Example: --variant=amd64
+        exit /b 1
+    ) else (
+        if not "%2"=="amd64" if not "%2"=="arm64" if not "%2"=="appx-amd64" if not "%2"=="appx-arm64" if not "%2"=="all" (
+            echo Error: Invalid variant '%2'
+            echo Valid variants are: amd64, arm64, appx-amd64, appx-arm64, all
+            exit /b 1
+        )
+        set "VARIANT=%2"
+        shift
+        shift
+        goto :parse_args
+    )
+) else (
+    @REM Skip unknown options
+    shift
+    goto :parse_args
+)
+:end_parse_args
+
+if "%VARIANT%"=="amd64" (
+    set BUILD_AMD64=1
+) else if "%VARIANT%"=="arm64" (
+    set BUILD_ARM64=1
+) else if "%VARIANT%"=="appx-amd64" (
+    set BUILD_APPX_AMD64=1
+) else if "%VARIANT%"=="appx-arm64" (
+    set BUILD_APPX_ARM64=1
+) else (
+    REM all: build everything
+    set BUILD_AMD64=1
+    set BUILD_ARM64=1
+    set BUILD_APPX_AMD64=1
+    set BUILD_APPX_ARM64=1
+)
+
+echo Building UI
 cd app
+if errorlevel 1 (
+    exit /b %errorlevel%
+)
 call pnpm install
 if errorlevel 1 (
     exit /b %errorlevel%
@@ -12,69 +64,102 @@ if errorlevel 1 (
     exit /b %errorlevel%
 )
 cd ..
+if errorlevel 1 (
+    exit /b %errorlevel%
+)
 
-echo 'Cleaning Builds'
+echo Cleaning Builds
 rmdir /S /Q app\build 1>nul
 rmdir /S /Q app\kernel 1>nul
 rmdir /S /Q app\kernel-arm64 1>nul
 
-echo 'Building Kernel'
+echo Building Kernel
 @REM the C compiler "gcc" is necessary https://sourceforge.net/projects/mingw-w64/files/mingw-w64/
 go version
 set GO111MODULE=on
 set GOPROXY=https://mirrors.aliyun.com/goproxy/
 set CGO_ENABLED=1
+set GOOS=windows
 
 cd kernel
+if errorlevel 1 (
+    exit /b %errorlevel%
+)
 @REM you can use `go mod tidy` to update kernel dependency before build
 @REM you can use `go generate` instead (need add something in main.go)
 goversioninfo -platform-specific=true -icon=resource/icon.ico -manifest=resource/goversioninfo.exe.manifest
 
-echo 'Building Kernel amd64'
-set GOOS=windows
-set GOARCH=amd64
-go build --tags fts5 -v -o "../app/kernel/SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
-if errorlevel 1 (
-    exit /b %errorlevel%
+if defined BUILD_AMD64 (
+    echo Building Kernel amd64
+    set GOARCH=amd64
+    go build --tags fts5 -v -o "../app/kernel/SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
+    if errorlevel 1 (
+        exit /b %errorlevel%
+    )
 )
 
-echo 'Building Kernel arm64'
-set GOARCH=arm64
-@REM if you want to build arm64, you need to install aarch64-w64-mingw32-gcc
-set CC="D:/Program Files/llvm-mingw-20240518-ucrt-x86_64/bin/aarch64-w64-mingw32-gcc.exe"
-go build --tags fts5 -v -o "../app/kernel-arm64/SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
-if errorlevel 1 (
-    exit /b %errorlevel%
+if defined BUILD_ARM64 (
+    echo Building Kernel arm64
+    set GOARCH=arm64
+    @REM if you want to build arm64, you need to install aarch64-w64-mingw32-gcc
+    set CC="D:/Program Files/llvm-mingw-20240518-ucrt-x86_64/bin/aarch64-w64-mingw32-gcc.exe"
+    go build --tags fts5 -v -o "../app/kernel-arm64/SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
+    if errorlevel 1 (
+        exit /b %errorlevel%
+    )
 )
 cd ..
+if errorlevel 1 (
+    exit /b %errorlevel%
+)
 
-echo 'Building Electron App amd64'
 cd app
-
-copy "elevator\elevator-amd64.exe" "kernel\elevator.exe"
-copy "elevator\elevator-arm64.exe" "kernel-arm64\elevator.exe"
-
-call pnpm run dist
 if errorlevel 1 (
     exit /b %errorlevel%
 )
-echo 'Building Electron App arm64'
-call pnpm run dist-arm64
-if errorlevel 1 (
-    exit /b %errorlevel%
+
+if defined BUILD_AMD64 (
+    echo Building Electron App amd64
+    copy "elevator\elevator-amd64.exe" "kernel\elevator.exe"
+    call pnpm run dist
+    if errorlevel 1 (
+        exit /b %errorlevel%
+    )
+)
+
+if defined BUILD_ARM64 (
+    echo Building Electron App arm64
+    copy "elevator\elevator-arm64.exe" "kernel-arm64\elevator.exe"
+    call pnpm run dist-arm64
+    if errorlevel 1 (
+        exit /b %errorlevel%
+    )
 )
 cd ..
+if errorlevel 1 (
+    exit /b %errorlevel%
+)
 
-echo 'Building Appx'
-echo 'Building Appx should be disabled if you do not need it. Not configured correctly will lead to build failures'
-cd . > app\build\win-unpacked\resources\ms-store
-call electron-windows-store --input-directory app\build\win-unpacked --output-directory app\build\ --package-version 1.0.0.0 --package-name SiYuan --manifest app\appx\AppxManifest.xml --assets app\appx\assets\ --make-pri true
+if defined BUILD_APPX_AMD64 (
+    echo Building Appx amd64
+    echo Building Appx amd64 should be disabled if you do not need it. Not configured correctly will lead to build failures
+    cd . > app\build\win-unpacked\resources\ms-store
+    if errorlevel 1 (
+        exit /b %errorlevel%
+    )
+    call electron-windows-store --input-directory app\build\win-unpacked --output-directory app\build\ --package-version 1.0.0.0 --package-name SiYuan --manifest app\appx\AppxManifest.xml --assets app\appx\assets\ --make-pri true
 
-rmdir /S /Q app\build\pre-appx 1>nul
+    rmdir /S /Q app\build\pre-appx 1>nul
+)
 
-echo 'Building Appx arm64'
-echo 'Building Appx arm64 should be disabled if you do not need it. Not configured correctly will lead to build failures'
-cd . > app\build\win-arm64-unpacked\resources\ms-store
-call electron-windows-store --input-directory app\build\win-arm64-unpacked --output-directory app\build\ --package-version 1.0.0.0 --package-name SiYuan-arm64 --manifest app\appx\AppxManifest-arm64.xml --assets app\appx\assets\ --make-pri true
+if defined BUILD_APPX_ARM64 (
+    echo Building Appx arm64
+    echo Building Appx arm64 should be disabled if you do not need it. Not configured correctly will lead to build failures
+    cd . > app\build\win-arm64-unpacked\resources\ms-store
+    if errorlevel 1 (
+        exit /b %errorlevel%
+    )
+    call electron-windows-store --input-directory app\build\win-arm64-unpacked --output-directory app\build\ --package-version 1.0.0.0 --package-name SiYuan-arm64 --manifest app\appx\AppxManifest-arm64.xml --assets app\appx\assets\ --make-pri true
 
-rmdir /S /Q app\build\pre-appx 1>nul
+    rmdir /S /Q app\build\pre-appx 1>nul
+)


### PR DESCRIPTION
- 运行目录不是仓库根目录时 `cd` 会出现问题，增加了对应的错误处理
- 用户想要构建特定的变体时不再需要手动修改脚本，只需使用新增的 `--target=*` 参数来指定即可
- 不使用参数时默认构建所有变体
- 尽可能保证了不同平台的参数处理是一致的，可以使用 `--target=*` 和 `--target *`（p.s. 本来只打算支持有等号的形式，但 Windows 上默认支持不带等号，两种脚本语言差别又很大，我改了半天）