### PR TITLE
Improve adaptive width for message elements

### DIFF
--- a/app/src/assets/scss/component/_snackbar.scss
+++ b/app/src/assets/scss/component/_snackbar.scss
@@ -57,7 +57,7 @@
     box-sizing: border-box;
     box-shadow: var(--b3-tooltips-shadow);
     word-break: break-word;
-    max-width: 20vw;
+    width: clamp(20vw, calc(100vw - 60px), 350px);
     text-align: left;
     display: inline-block;
 


### PR DESCRIPTION
改进前，最大 20vw：

![PixPin_2026-01-16_02-33-03](https://github.com/user-attachments/assets/e5e0d9fb-45db-4c9c-a5c5-1797caf420b8)

改进后，最小 20vw，最大 100vw - 60px（右边距是30px，加上一样的左边距就是60px），通常 350px ：

<img width="1206" height="541" alt="image" src="https://github.com/user-attachments/assets/4a7997a7-d2c6-4c95-9f5f-2c4a91f87c66" />
