### PR TITLE
:art: Support Admin Token passthrough in Publish Service proxy

### DIFF
--- a/kernel/model/auth.go
+++ b/kernel/model/auth.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"sync"
 
+	"strings"
+
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/siyuan-note/logging"
@@ -170,4 +172,30 @@ func IsPublishServiceToken(token *jwt.Token) bool {
 		return tokenIssuer == iss
 	}
 	return false
+}
+
+func ParseAPIToken(r *http.Request) (token string, source string) {
+	if authHeader := r.Header.Get("Authorization"); "" != authHeader {
+		if strings.HasPrefix(authHeader, "Token ") {
+			token = strings.TrimPrefix(authHeader, "Token ")
+		} else if strings.HasPrefix(authHeader, "token ") {
+			token = strings.TrimPrefix(authHeader, "token ")
+		} else if strings.HasPrefix(authHeader, "Bearer ") {
+			token = strings.TrimPrefix(authHeader, "Bearer ")
+		} else if strings.HasPrefix(authHeader, "bearer ") {
+			token = strings.TrimPrefix(authHeader, "bearer ")
+		}
+
+		if "" != token {
+			source = "header: Authorization"
+		}
+	}
+
+	if "" == token {
+		token = r.URL.Query().Get("token")
+		if "" != token {
+			source = "query: token"
+		}
+	}
+	return
 }

--- a/kernel/server/proxy/publish.go
+++ b/kernel/server/proxy/publish.go
@@ -129,6 +129,13 @@ func rewrite(r *httputil.ProxyRequest) {
 }
 
 func (PublishServiceTransport) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	// Check Admin Token
+	if token, _ := model.ParseAPIToken(request); "" != token && model.Conf.Api.Token == token {
+		request.Header.Set(model.XAuthTokenKey, token)
+		response, err = http.DefaultTransport.RoundTrip(request)
+		return
+	}
+
 	if model.Conf.Publish.Auth.Enable {
 		// Session Auth
 		sessionIdCookie, cookieErr := request.Cookie(model.SessionIdCookieName)


### PR DESCRIPTION
- Refactor API token parsing logic into [ParseAPIToken](cci:1://file:kernel/model/auth.go:176:0-200:1)
- Allow Admin Token to bypass Publish Service read-only restriction

## Feature or bug? 特性或者缺陷？

If you want to contribute a feature or bug fix, please submit an issue first. After a full discussion in the community, we will decide whether to make the change. Do not submit a contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交一个贡献代码，否则可能会被拒绝。

## Multilingual or copywriting? 多语言或者文案？

Please submit directly, we will evaluate.
请直接提交，我们会进行评估。

## Dev branch!

Any changes should be submitted to the dev branch.
任何改动，请提交到 dev 分支。
