### PR TITLE
Fix focus issues on Windows after dialog interactions

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -895,12 +895,14 @@ app.whenReady().then(() => {
             event.sender.send("siyuan-event", "leave-full-screen");
         });
     });
-    ipcMain.on("siyuan-focus-fix", (event) => {
-        const currentWindow = getWindowByContentId(event.sender.id);
-        if (currentWindow && process.platform === "win32") {
-            currentWindow.blur();
-            currentWindow.focus();
-        }
+    ipcMain.on("siyuan-confirm-dialog", (event, options) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        event.returnValue = dialog.showMessageBoxSync(window || BrowserWindow.getFocusedWindow(), options);
+    });
+    ipcMain.on("siyuan-alert-dialog", (event, options) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        dialog.showMessageBoxSync(window || BrowserWindow.getFocusedWindow(), options);
+        event.returnValue = undefined;
     });
     ipcMain.on("siyuan-cmd", (event, data) => {
         let cmd = data;

--- a/app/src/boot/onGetConfig.ts
+++ b/app/src/boot/onGetConfig.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 import {afterExport} from "../protyle/export/util";
 import {onWindowsMsg} from "../window/onWindowsMsg";
-import {initFocusFix} from "../protyle/util/compatibility";
+import {initNativeDialogOverride} from "../protyle/util/compatibility";
 /// #endif
 import {Constants} from "../constants";
 import {appearance} from "../config/appearance";
@@ -70,7 +70,7 @@ export const onGetConfig = (isStart: boolean, app: App) => {
     initStatus();
     initWindow(app);
     /// #if !BROWSER
-    initFocusFix();
+    initNativeDialogOverride();
     /// #endif
     appearance.onSetAppearance(window.siyuan.config.appearance);
     initAssets();


### PR DESCRIPTION
使用 Electron 的弹窗替换 Chromium 的弹窗（应该是？），在 Mac 平台上让 window.alert 和 window.confirm 的取消按钮和确认按钮支持 i18n。

然后发现之前的 Windows 的焦点问题好像顺便就能解决了，关联：

- https://github.com/electron/electron/issues/22923#issuecomment-2731433174
- https://github.com/siyuan-note/siyuan/pull/16073
- https://github.com/siyuan-note/siyuan/issues/16071
- https://github.com/siyuan-note/siyuan/issues/12349