### PR TITLE
Streamline comment output for the target-branch workflow and add Chinese

### DIFF
--- a/.github/workflows/target-branch.yml
+++ b/.github/workflows/target-branch.yml
@@ -7,8 +7,10 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: Vankka/pr-target-branch-action@v2
+      - uses: Vankka/pr-target-branch-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -16,5 +18,5 @@ jobs:
           exclude: dev
           change-to: dev
           comment: |
-              Your PR was set to target `master`, PRs should be target `dev`
-              The base branch of this PR has been automatically changed to `dev`, please check that there are no merge conflicts
+              The base branch of this PR has been automatically changed to `dev`, please check that there are no merge conflicts.
+              此 PR 的基础分支已自动更改为 `dev`，请检查是否存在合并冲突。


### PR DESCRIPTION
工作流：

- 更新到 Vankka/pr-target-branch-action@v3
- 删除描述 "Your PR was set to target `master`, PRs should be target `dev`"，因为其与 PR 模板中的描述重复，并且产生过歧义，导致贡献者关闭了 PR 重新 PR 到 dev 分支
- 增加中文描述 "此 PR 的基础分支已自动更改为 `dev`，请检查是否存在合并冲突。"