### PR TITLE
Support running build script in any directory

### DIFF
--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
-echo 'TIP: This script must be run from the project root directory'
-echo 'Usage: ./scripts/darwin-build.sh [--target=<target>]'
+# 启用错误处理：任何命令失败立即退出，并打印错误信息
+set -e
+trap 'echo "Error occurred at line $LINENO. Command: $BASH_COMMAND"; exit 1' ERR
+
+echo 'Usage: ./darwin-build.sh [--target=<target>]'
 echo 'Options:'
 echo '  --target=<target>  Build target: amd64, arm64, or all (default: all)'
 echo
 
-TARGET='all'
+INITIAL_DIR="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+TARGET='all'
 validate_target() {
     if [[ -z "$1" ]]; then
         echo 'Error: --target option requires a value'
@@ -40,49 +46,60 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-echo 'Building UI'
-cd app || exit
-pnpm install && pnpm run build
-cd .. || exit
-
 echo 'Cleaning Builds'
-rm -rf app/build
-rm -rf app/kernel-darwin
-rm -rf app/kernel-darwin-arm64
+rm -rf "$PROJECT_ROOT/app/build" 2>/dev/null || true
+rm -rf "$PROJECT_ROOT/app/kernel-darwin" 2>/dev/null || true
+rm -rf "$PROJECT_ROOT/app/kernel-darwin-arm64" 2>/dev/null || true
 
+echo
+echo 'Building UI'
+cd "$PROJECT_ROOT/app"
+pnpm install
+pnpm run build
+cd "$PROJECT_ROOT"
+
+echo
 echo 'Building Kernel'
-
-cd kernel || exit
+cd "$PROJECT_ROOT/kernel"
 go version
 export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
 
 if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
+    echo
     echo 'Building Kernel amd64'
     export GOOS=darwin
     export GOARCH=amd64
     go build --tags fts5 -v -o "../app/kernel-darwin/SiYuan-Kernel" -ldflags "-s -w" .
 fi
-
 if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
+    echo
     echo 'Building Kernel arm64'
     export GOOS=darwin
     export GOARCH=arm64
     go build --tags fts5 -v -o "../app/kernel-darwin-arm64/SiYuan-Kernel" -ldflags "-s -w" .
 fi
-cd .. || exit
 
-cd app || exit
-
+echo
+echo 'Building Electron App'
+cd "$PROJECT_ROOT/app"
 if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
+    echo
     echo 'Building Electron App amd64'
     pnpm run dist-darwin
 fi
-
 if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
+    echo
     echo 'Building Electron App arm64'
     pnpm run dist-darwin-arm64
 fi
 
-cd .. || exit
+cd "$PROJECT_ROOT"
+# 尝试返回初始目录
+cd "$INITIAL_DIR" 2>/dev/null || true
+
+echo
+echo '=============================='
+echo '      Build successful!'
+echo '=============================='

--- a/scripts/darwin-build.sh
+++ b/scripts/darwin-build.sh
@@ -56,7 +56,6 @@ echo 'Building UI'
 cd "$PROJECT_ROOT/app"
 pnpm install
 pnpm run build
-cd "$PROJECT_ROOT"
 
 echo
 echo 'Building Kernel'
@@ -65,18 +64,17 @@ go version
 export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
+export GOOS=darwin
 
 if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
     echo
     echo 'Building Kernel amd64'
-    export GOOS=darwin
     export GOARCH=amd64
     go build --tags fts5 -v -o "../app/kernel-darwin/SiYuan-Kernel" -ldflags "-s -w" .
 fi
 if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
     echo
     echo 'Building Kernel arm64'
-    export GOOS=darwin
     export GOARCH=arm64
     go build --tags fts5 -v -o "../app/kernel-darwin-arm64/SiYuan-Kernel" -ldflags "-s -w" .
 fi
@@ -95,11 +93,10 @@ if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
     pnpm run dist-darwin-arm64
 fi
 
-cd "$PROJECT_ROOT"
-# 尝试返回初始目录
-cd "$INITIAL_DIR" 2>/dev/null || true
-
 echo
 echo '=============================='
 echo '      Build successful!'
 echo '=============================='
+
+# 返回初始目录
+cd "$INITIAL_DIR"

--- a/scripts/linux-build.sh
+++ b/scripts/linux-build.sh
@@ -56,7 +56,6 @@ echo 'Building UI'
 cd "$PROJECT_ROOT/app"
 pnpm install
 pnpm run build
-cd "$PROJECT_ROOT"
 
 echo
 echo 'Building Kernel'
@@ -65,11 +64,11 @@ go version
 export GO111MODULE=on
 export GOPROXY=https://mirrors.aliyun.com/goproxy/
 export CGO_ENABLED=1
+export GOOS=linux
 
 if [[ "$TARGET" == 'amd64' || "$TARGET" == 'all' ]]; then
     echo
     echo 'Building Kernel amd64'
-    export GOOS=linux
     export GOARCH=amd64
     export CC=~/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
     go build -buildmode=pie --tags fts5 -v -o "../app/kernel-linux/SiYuan-Kernel" -ldflags "-s -w -extldflags -static-pie" .
@@ -77,7 +76,6 @@ fi
 if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
     echo
     echo 'Building Kernel arm64'
-    export GOOS=linux
     export GOARCH=arm64
     export CC=~/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
     go build -buildmode=pie --tags fts5 -v -o "../app/kernel-linux-arm64/SiYuan-Kernel" -ldflags "-s -w -extldflags -static-pie" .
@@ -97,11 +95,10 @@ if [[ "$TARGET" == 'arm64' || "$TARGET" == 'all' ]]; then
     pnpm run dist-linux-arm64
 fi
 
-cd "$PROJECT_ROOT"
-# 尝试返回初始目录
-cd "$INITIAL_DIR" 2>/dev/null || true
-
 echo
 echo '=============================='
 echo '      Build successful!'
 echo '=============================='
+
+# 返回初始目录
+cd "$INITIAL_DIR"

--- a/scripts/win-build.bat
+++ b/scripts/win-build.bat
@@ -1,10 +1,20 @@
 @echo off
 
-echo TIP: This script must be run from the project root directory
-echo Usage: .\scripts\win-build.bat [--target=^<target^>]
+echo Usage: .\win-build.bat [--target=^<target^>]
 echo Options:
 echo   --target=^<target^>  Build target: amd64, arm64, appx-amd64, appx-arm64, or all (default: all)
 echo.
+
+REM 保存初始目录
+set "INITIAL_DIR=%cd%"
+
+REM 获取脚本所在目录
+set "SCRIPT_DIR=%~dp0"
+REM 移除末尾的反斜杠
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+REM 获取项目根目录（脚本目录的父目录）
+for %%I in ("%SCRIPT_DIR%\..") do set "PROJECT_ROOT=%%~fI"
 
 set "TARGET=all"
 
@@ -50,8 +60,14 @@ if "%TARGET%"=="amd64" (
     set BUILD_APPX_ARM64=1
 )
 
+echo Cleaning Builds
+rmdir /S /Q "%PROJECT_ROOT%\app\build" 1>nul
+rmdir /S /Q "%PROJECT_ROOT%\app\kernel" 1>nul
+rmdir /S /Q "%PROJECT_ROOT%\app\kernel-arm64" 1>nul
+
+echo.
 echo Building UI
-cd app
+cd /d "%PROJECT_ROOT%\app"
 if errorlevel 1 (
     exit /b %errorlevel%
 )
@@ -63,103 +79,115 @@ call pnpm run build
 if errorlevel 1 (
     exit /b %errorlevel%
 )
-cd ..
+
+echo.
+echo Building Kernel
+@REM the C compiler "gcc" is necessary https://sourceforge.net/projects/mingw-w64/files/mingw-w64/
+cd /d "%PROJECT_ROOT%\kernel"
 if errorlevel 1 (
     exit /b %errorlevel%
 )
-
-echo Cleaning Builds
-rmdir /S /Q app\build 1>nul
-rmdir /S /Q app\kernel 1>nul
-rmdir /S /Q app\kernel-arm64 1>nul
-
-echo Building Kernel
-@REM the C compiler "gcc" is necessary https://sourceforge.net/projects/mingw-w64/files/mingw-w64/
 go version
 set GO111MODULE=on
 set GOPROXY=https://mirrors.aliyun.com/goproxy/
 set CGO_ENABLED=1
 set GOOS=windows
 
-cd kernel
-if errorlevel 1 (
-    exit /b %errorlevel%
-)
 @REM you can use `go mod tidy` to update kernel dependency before build
 @REM you can use `go generate` instead (need add something in main.go)
 goversioninfo -platform-specific=true -icon=resource/icon.ico -manifest=resource/goversioninfo.exe.manifest
 
 if defined BUILD_AMD64 (
+    echo.
     echo Building Kernel amd64
     set GOARCH=amd64
-    go build --tags fts5 -v -o "../app/kernel/SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
+    go build --tags fts5 -v -o "%PROJECT_ROOT%\app\kernel\SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
     if errorlevel 1 (
         exit /b %errorlevel%
     )
 )
-
 if defined BUILD_ARM64 (
+    echo.
     echo Building Kernel arm64
     set GOARCH=arm64
     @REM if you want to build arm64, you need to install aarch64-w64-mingw32-gcc
     set CC="D:/Program Files/llvm-mingw-20240518-ucrt-x86_64/bin/aarch64-w64-mingw32-gcc.exe"
-    go build --tags fts5 -v -o "../app/kernel-arm64/SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
+    go build --tags fts5 -v -o "%PROJECT_ROOT%\app\kernel-arm64\SiYuan-Kernel.exe" -ldflags "-s -w -H=windowsgui" .
     if errorlevel 1 (
         exit /b %errorlevel%
     )
 )
-cd ..
+
+if defined BUILD_AMD64 goto electron
+if defined BUILD_ARM64 goto electron
+goto :skipelectron
+:electron
+echo.
+echo Building Electron App
+cd /d "%PROJECT_ROOT%\app"
 if errorlevel 1 (
     exit /b %errorlevel%
 )
-
-cd app
-if errorlevel 1 (
-    exit /b %errorlevel%
-)
-
 if defined BUILD_AMD64 (
+    echo.
     echo Building Electron App amd64
-    copy "elevator\elevator-amd64.exe" "kernel\elevator.exe"
+    copy "%PROJECT_ROOT%\app\elevator\elevator-amd64.exe" "%PROJECT_ROOT%\app\kernel\elevator.exe"
     call pnpm run dist
     if errorlevel 1 (
         exit /b %errorlevel%
     )
 )
-
 if defined BUILD_ARM64 (
+    echo.
     echo Building Electron App arm64
-    copy "elevator\elevator-arm64.exe" "kernel-arm64\elevator.exe"
+    copy "%PROJECT_ROOT%\app\elevator\elevator-arm64.exe" "%PROJECT_ROOT%\app\kernel-arm64\elevator.exe"
     call pnpm run dist-arm64
     if errorlevel 1 (
         exit /b %errorlevel%
     )
 )
-cd ..
+:skipelectron
+
+if defined BUILD_APPX_AMD64 goto appx
+if defined BUILD_APPX_ARM64 goto appx
+goto :skipappx
+:appx
+echo.
+echo Building Appx
+cd /d "%PROJECT_ROOT%"
 if errorlevel 1 (
     exit /b %errorlevel%
 )
-
 if defined BUILD_APPX_AMD64 (
+    echo.
     echo Building Appx amd64
     echo Building Appx amd64 should be disabled if you do not need it. Not configured correctly will lead to build failures
-    cd . > app\build\win-unpacked\resources\ms-store
+    cd . > "%PROJECT_ROOT%\app\build\win-unpacked\resources\ms-store"
     if errorlevel 1 (
         exit /b %errorlevel%
     )
-    call electron-windows-store --input-directory app\build\win-unpacked --output-directory app\build\ --package-version 1.0.0.0 --package-name SiYuan --manifest app\appx\AppxManifest.xml --assets app\appx\assets\ --make-pri true
+    call electron-windows-store --input-directory "%PROJECT_ROOT%\app\build\win-unpacked" --output-directory "%PROJECT_ROOT%\app\build\" --package-version 1.0.0.0 --package-name SiYuan --manifest "%PROJECT_ROOT%\app\appx\AppxManifest.xml" --assets "%PROJECT_ROOT%\app\appx\assets\" --make-pri true
 
-    rmdir /S /Q app\build\pre-appx 1>nul
+    rmdir /S /Q "%PROJECT_ROOT%\app\build\pre-appx" 1>nul
 )
-
 if defined BUILD_APPX_ARM64 (
+    echo.
     echo Building Appx arm64
     echo Building Appx arm64 should be disabled if you do not need it. Not configured correctly will lead to build failures
-    cd . > app\build\win-arm64-unpacked\resources\ms-store
+    cd . > "%PROJECT_ROOT%\app\build\win-arm64-unpacked\resources\ms-store"
     if errorlevel 1 (
         exit /b %errorlevel%
     )
-    call electron-windows-store --input-directory app\build\win-arm64-unpacked --output-directory app\build\ --package-version 1.0.0.0 --package-name SiYuan-arm64 --manifest app\appx\AppxManifest-arm64.xml --assets app\appx\assets\ --make-pri true
+    call electron-windows-store --input-directory "%PROJECT_ROOT%\app\build\win-arm64-unpacked" --output-directory "%PROJECT_ROOT%\app\build\" --package-version 1.0.0.0 --package-name SiYuan-arm64 --manifest "%PROJECT_ROOT%\app\appx\AppxManifest-arm64.xml" --assets "%PROJECT_ROOT%\app\appx\assets\" --make-pri true
 
-    rmdir /S /Q app\build\pre-appx 1>nul
+    rmdir /S /Q "%PROJECT_ROOT%\app\build\pre-appx" 1>nul
 )
+:skipappx
+
+echo.
+echo ==============================
+echo       Build successful!
+echo ==============================
+
+REM 返回初始目录
+cd /d "%INITIAL_DIR%"


### PR DESCRIPTION
- 支持在非项目根目录中执行构建脚本（我没有测试 linux 构建；在我的 Mac 上测试 darwin 构建没问题；在我的 Windows 上测试 win amd64 构建没问题）
- 上次我改 Linux 构建脚本，漏了一行 `export GOOS=linux`，应该会导致使用参数构建的时候出现问题，这次补上