### PR TITLE
Improve input method compatibility

### DIFF
--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -1942,15 +1942,20 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                     range.setEndAfter(inlineElement);
                     range.collapse(false);
                 }
-                const wbrElement = document.createElement("wbr");
-                range.insertNode(wbrElement);
-                const oldHTML = nodeElement.outerHTML;
-                range.extractContents();
-                range.insertNode(document.createTextNode(tabSpace));
-                range.collapse(false);
-                focusByRange(range);
-                wbrElement.remove();
-                updateTransaction(protyle, nodeElement.getAttribute("data-node-id"), nodeElement.outerHTML, oldHTML);
+                if (range.startContainer.nodeType === 3) {
+                    // Mac 简体拼音输入法按 Tab 之后继续输入中文会直接写入首字母 https://ld246.com/article/1749558626317
+                    document.execCommand("insertText", false, tabSpace);
+                } else {
+                    const wbrElement = document.createElement("wbr");
+                    range.insertNode(wbrElement);
+                    const oldHTML = nodeElement.outerHTML;
+                    range.extractContents();
+                    range.insertNode(document.createTextNode(tabSpace));
+                    range.collapse(false);
+                    focusByRange(range);
+                    wbrElement.remove();
+                    updateTransaction(protyle, nodeElement.getAttribute("data-node-id"), nodeElement.outerHTML, oldHTML);
+                }
                 return true;
             }
         }


### PR DESCRIPTION
Fix https://ld246.com/article/1749558626317

解决 Mac 简体拼音输入法按 Tab 之后继续输入中文会直接写入首字母。

改进前：


https://github.com/user-attachments/assets/dbace49d-64f0-4cf5-a33e-0c6b83a3a4e3

改进后：


https://github.com/user-attachments/assets/5a0437ff-78bb-4543-8035-d3f7d05479b8



改进后在以下环境测试没问题：

- Mac、简体拼音输入法
- Mac、搜狗拼音输入法
- Windows、微软拼音输入法
- Windows、搜狗拼音输入法