### PR TITLE
Improve the latency of marketplace requests when offline

### DIFF
--- a/kernel/model/bazzar.go
+++ b/kernel/model/bazzar.go
@@ -214,8 +214,11 @@ func BazaarPlugins(frontend, keyword string) (plugins []*bazaar.Plugin) {
 }
 
 func filterPlugins(plugins []*bazaar.Plugin, keyword string) (ret []*bazaar.Plugin) {
-	ret = []*bazaar.Plugin{}
 	keywords := getSearchKeywords(keyword)
+	if 0 == len(keywords) {
+		return plugins
+	}
+	ret = []*bazaar.Plugin{}
 	for _, plugin := range plugins {
 		if matchPackage(keywords, plugin.Package) {
 			ret = append(ret, plugin)
@@ -285,8 +288,11 @@ func BazaarWidgets(keyword string) (widgets []*bazaar.Widget) {
 }
 
 func filterWidgets(widgets []*bazaar.Widget, keyword string) (ret []*bazaar.Widget) {
-	ret = []*bazaar.Widget{}
 	keywords := getSearchKeywords(keyword)
+	if 0 == len(keywords) {
+		return widgets
+	}
+	ret = []*bazaar.Widget{}
 	for _, w := range widgets {
 		if matchPackage(keywords, w.Package) {
 			ret = append(ret, w)
@@ -337,8 +343,11 @@ func BazaarIcons(keyword string) (icons []*bazaar.Icon) {
 }
 
 func filterIcons(icons []*bazaar.Icon, keyword string) (ret []*bazaar.Icon) {
-	ret = []*bazaar.Icon{}
 	keywords := getSearchKeywords(keyword)
+	if 0 == len(keywords) {
+		return icons
+	}
+	ret = []*bazaar.Icon{}
 	for _, i := range icons {
 		if matchPackage(keywords, i.Package) {
 			ret = append(ret, i)
@@ -400,8 +409,11 @@ func BazaarThemes(keyword string) (ret []*bazaar.Theme) {
 }
 
 func filterThemes(themes []*bazaar.Theme, keyword string) (ret []*bazaar.Theme) {
-	ret = []*bazaar.Theme{}
 	keywords := getSearchKeywords(keyword)
+	if 0 == len(keywords) {
+		return themes
+	}
+	ret = []*bazaar.Theme{}
 	for _, t := range themes {
 		if matchPackage(keywords, t.Package) {
 			ret = append(ret, t)
@@ -475,8 +487,11 @@ func BazaarTemplates(keyword string) (templates []*bazaar.Template) {
 }
 
 func filterTemplates(templates []*bazaar.Template, keyword string) (ret []*bazaar.Template) {
-	ret = []*bazaar.Template{}
 	keywords := getSearchKeywords(keyword)
+	if 0 == len(keywords) {
+		return templates
+	}
+	ret = []*bazaar.Template{}
 	for _, t := range templates {
 		if matchPackage(keywords, t.Package) {
 			ret = append(ret, t)

--- a/kernel/model/updater.go
+++ b/kernel/model/updater.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -120,7 +121,7 @@ func checkDownloadInstallPkg() {
 
 func getUpdatePkg() (downloadPkgURLs []string, checksum string, err error) {
 	defer logging.Recover()
-	result, err := util.GetRhyResult(false)
+	result, err := util.GetRhyResult(context.TODO(), false)
 	if err != nil {
 		return
 	}
@@ -246,7 +247,7 @@ type Announcement struct {
 }
 
 func getAnnouncements() (ret []*Announcement) {
-	result, err := util.GetRhyResult(false)
+	result, err := util.GetRhyResult(context.TODO(), false)
 	if err != nil {
 		logging.LogErrorf("get announcement failed: %s", err)
 		return
@@ -278,7 +279,7 @@ func CheckUpdate(showMsg bool) {
 		return
 	}
 
-	result, err := util.GetRhyResult(showMsg)
+	result, err := util.GetRhyResult(context.TODO(), showMsg)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
- 离线时，特定情况下（在[sy-theme-change](https://github.com/frostime/sy-theme-change)插件启用的同时打开集市）连续 GetRhyResult 会导致集市请求耗时很长，对此进行优化（15s → 6s）
- 避免搜索关键词为空时的不必要开销