### PR TITLE
Improve `/api/attr/setBlockAttrs` and `/api/attr/batchSetBlockAttrs`

### DIFF
--- a/kernel/api/attr.go
+++ b/kernel/api/attr.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/88250/gulu"
@@ -96,7 +97,13 @@ func setBlockAttrs(c *gin.Context) {
 		if nil == value { // API `setBlockAttrs` 中如果存在属性值设置为 `null` 时移除该属性 https://github.com/siyuan-note/siyuan/issues/5577
 			nameValues[name] = ""
 		} else {
-			nameValues[name] = value.(string)
+			strValue, ok := value.(string)
+			if !ok {
+				ret.Code = -1
+				ret.Msg = fmt.Sprintf("the value of attr [%s] must be a string", name)
+				return
+			}
+			nameValues[name] = strValue
 		}
 	}
 	err := model.SetBlockAttrs(id, nameValues)
@@ -131,7 +138,13 @@ func batchSetBlockAttrs(c *gin.Context) {
 			if nil == value {
 				nameValues[name] = ""
 			} else {
-				nameValues[name] = value.(string)
+				strValue, ok := value.(string)
+				if !ok {
+					ret.Code = -1
+					ret.Msg = fmt.Sprintf("the value of attr [%s] must be a string", name)
+					return
+				}
+				nameValues[name] = strValue
 			}
 		}
 
@@ -162,7 +175,17 @@ func resetBlockAttrs(c *gin.Context) {
 	attrs := arg["attrs"].(map[string]interface{})
 	nameValues := map[string]string{}
 	for name, value := range attrs {
-		nameValues[name] = value.(string)
+		if nil == value {
+			// 接口会先清空所有属性，nil 值可忽略
+			continue
+		}
+		strValue, ok := value.(string)
+		if !ok {
+			ret.Code = -1
+			ret.Msg = fmt.Sprintf("the value of attr [%s] must be a string", name)
+			return
+		}
+		nameValues[name] = strValue
 	}
 	err := model.ResetBlockAttrs(id, nameValues)
 	if err != nil {

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -260,7 +260,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/ref/getBackmentionDoc", model.CheckAuth, getBackmentionDoc)
 
 	ginServer.Handle("POST", "/api/attr/getBookmarkLabels", model.CheckAuth, getBookmarkLabels)
-	ginServer.Handle("POST", "/api/attr/resetBlockAttrs", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, resetBlockAttrs)
+	ginServer.Handle("POST", "/api/attr/resetBlockAttrs", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, resetBlockAttrs) // TODO 请使用 /api/attr/setBlockAttrs，该端点计划于 2026 年 6 月 30 日后删除 https://github.com/siyuan-note/siyuan/pull/17027
 	ginServer.Handle("POST", "/api/attr/setBlockAttrs", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setBlockAttrs)
 	ginServer.Handle("POST", "/api/attr/batchSetBlockAttrs", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, batchSetBlockAttrs)
 	ginServer.Handle("POST", "/api/attr/getBlockAttrs", model.CheckAuth, getBlockAttrs)
@@ -471,7 +471,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/av/searchAttributeView", model.CheckAuth, model.CheckReadonly, searchAttributeView)
 	ginServer.Handle("POST", "/api/av/getAttributeView", model.CheckAuth, model.CheckReadonly, getAttributeView)
 	ginServer.Handle("POST", "/api/av/searchAttributeViewRelationKey", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, searchAttributeViewRelationKey)
-	ginServer.Handle("POST", "/api/av/searchAttributeViewNonRelationKey", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, searchAttributeViewNonRelationKey) // 请勿使用，该端点计划于 2026 年 6 月 30 日后删除 https://github.com/siyuan-note/siyuan/issues/15727
+	ginServer.Handle("POST", "/api/av/searchAttributeViewNonRelationKey", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, searchAttributeViewNonRelationKey) // TODO 请勿使用，该端点计划于 2026 年 6 月 30 日后删除 https://github.com/siyuan-note/siyuan/issues/15727
 	ginServer.Handle("POST", "/api/av/searchAttributeViewRollupDestKeys", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, searchAttributeViewRollupDestKeys)
 	ginServer.Handle("POST", "/api/av/getAttributeViewFilterSort", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, getAttributeViewFilterSort)
 	ginServer.Handle("POST", "/api/av/addAttributeViewKey", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, addAttributeViewKey)


### PR DESCRIPTION
## Description / 描述

- setBlockAttrs 相关的三个接口，参数提供的属性值不是字符串时会 panic，我增加了类型验证。

- 调用 ResetBlockAttrs 接口之后文档 DOM 不会更新，我参考 SetBlockAttrs 接口的逻辑进行了修复。

	但该接口仍然存在难以解决的设计缺陷，计划在[下半年](https://github.com/siyuan-note/siyuan/issues/15727)移除该接口。
	
	> ResetBlockAttrs 会调用 node.ClearIALAttrs() 删除所有内置属性和 `custom-` 开头的自定义属性。`abcd` 这种随便命名的属性无法被清空，很多思源内部使用的  `custom-` 开头的不应该直接操作的属性又会被清空。
	>
	> 开发者如果不了解 ResetBlockAttrs 接口的底层实现，很难考虑到使用接口会带来的影响，容易造成 BUG，比如绑定块的数据库角标消失。
	>
	> p.s. 这个接口在思源内部没有使用

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] New feature
      新功能  
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature or bug fix, please submit an issue first. After full community discussion, we will decide whether to implement the change. Do not submit code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突