### PR TITLE
Support copying file in the asset menu on Windows and macOS 2

### DIFF
--- a/app/src/menus/util.ts
+++ b/app/src/menus/util.ts
@@ -42,7 +42,7 @@ export const exportAsset = (src: string) => {
 // 复制资源文件到系统剪贴板，在文件资源管理器中可粘贴为文件（仅 Windows、macOS 桌面端支持）
 export const copyAsset = (src: string) => {
     return {
-        id: "copy",
+        id: "copyFile",
         label: window.siyuan.languages.copyFile,
         icon: "iconCopy",
         click: () => {

--- a/app/src/protyle/render/av/asset.ts
+++ b/app/src/protyle/render/av/asset.ts
@@ -7,7 +7,7 @@ import {uploadFiles} from "../../upload";
 import {pathPosix} from "../../../util/pathName";
 import {openMenu} from "../../../menus/commonMenuItem";
 import {MenuItem} from "../../../menus/Menu";
-import {copyPNGByLink, exportAsset} from "../../../menus/util";
+import {copyAsset, copyPNGByLink, exportAsset} from "../../../menus/util";
 import {setPosition} from "../../../util/setPosition";
 import {previewAttrViewImages} from "../../preview/image";
 import {genAVValueHTML} from "./blockAttr";
@@ -367,6 +367,11 @@ export const editAssetItem = (options: {
     }
     if (linkAddress?.startsWith("assets/")) {
         window.siyuan.menus.menu.append(new MenuItem(exportAsset(linkAddress)).element);
+        /// #if !BROWSER
+        if (["windows", "darwin"].includes(window.siyuan.config.system.os)) {
+            window.siyuan.menus.menu.append(new MenuItem(copyAsset(linkAddress)).element);
+        }
+        /// #endif
     }
     const rect = options.rect;
     /// #if MOBILE


### PR DESCRIPTION
继续改进 https://github.com/siyuan-note/siyuan/pull/17049

- 补充数据库资源字段的菜单
- 选项 id 跟另一个重复了，修改一下