### PR TITLE
Improve the database assets field file opening

### DIFF
--- a/app/src/protyle/render/av/blockAttr.ts
+++ b/app/src/protyle/render/av/blockAttr.ts
@@ -16,7 +16,7 @@ import {webUtils} from "electron";
 /// #endif
 import {isBrowser} from "../../../util/functions";
 import {Constants} from "../../../constants";
-import {getCompressURL} from "../../../util/image";
+import {getCompressURL, removeCompressURL} from "../../../util/image";
 
 const genAVRollupHTML = (value: IAVCellValue) => {
     let html = "";
@@ -502,7 +502,7 @@ const openEdit = (protyle: IProtyle, element: HTMLElement, event: MouseEvent) =>
                 });
             } else {
                 if (target.tagName === "IMG") {
-                    previewImages([target.getAttribute("src")]);
+                    previewImages([removeCompressURL(target.getAttribute("src"))]);
                 } else {
                     openLink(protyle, target.dataset.url, event, event.ctrlKey || event.metaKey);
                 }

--- a/app/src/protyle/render/av/openMenuPanel.ts
+++ b/app/src/protyle/render/av/openMenuPanel.ts
@@ -21,12 +21,10 @@ import {updateAttrViewCellAnimation} from "./action";
 import {addAssetLink, bindAssetEvent, editAssetItem, getAssetHTML, updateAssetCell} from "./asset";
 import {Constants} from "../../../constants";
 import {hideElements} from "../../ui/hideElements";
-import {isLocalPath, pathPosix} from "../../../util/pathName";
+import {pathPosix} from "../../../util/pathName";
 import {openEmojiPanel, unicode2Emoji} from "../../../emoji";
-import {getSearch, isMobile} from "../../../util/functions";
-/// #if !MOBILE
-import {openAsset} from "../../../editor/util";
-/// #endif
+import {isMobile} from "../../../util/functions";
+import {openLink} from "../../../editor/openLink";
 import {previewAttrViewImages} from "../../preview/image";
 import {assetMenu} from "../../../menus/protyle";
 import {
@@ -1358,29 +1356,13 @@ export const openMenuPanel = (options: {
                     event.stopPropagation();
                     break;
                 } else if (type === "openAssetItem") {
-                    const assetType = target.parentElement.dataset.type;
                     const assetLink = target.parentElement.dataset.content;
-                    /// #if !MOBILE
-                    const suffix = pathPosix().extname(assetLink);
-                    if (assetType === "image") {
-                        previewAttrViewImages(assetLink, avID, options.blockElement.getAttribute(Constants.CUSTOM_SY_AV_VIEW),
-                            options.blockElement.querySelector('[data-type="av-search"]')?.textContent.trim() || "");
-                    } else if (isLocalPath(assetLink) && assetType === "file" && (
-                        (suffix === ".pdf" && !assetLink.startsWith("file://")) ||
-                        Constants.SIYUAN_ASSETS_AUDIO.concat(Constants.SIYUAN_ASSETS_VIDEO, Constants.SIYUAN_ASSETS_IMAGE).includes(suffix)
-                    )) {
-                        openAsset(options.protyle.app, assetLink.trim(), parseInt(getSearch("page", assetLink)), "right");
-                    } else {
-                        window.open(assetLink);
-                    }
-                    /// #else
-                    if (assetType === "image") {
+                    if (target.parentElement.dataset.type === "image") {
                         previewAttrViewImages(assetLink, avID, options.blockElement.getAttribute(Constants.CUSTOM_SY_AV_VIEW),
                             options.blockElement.querySelector('[data-type="av-search"]')?.textContent.trim() || "");
                     } else {
-                        window.open(assetLink);
+                        openLink(options.protyle, assetLink, event, event.ctrlKey || event.metaKey);
                     }
-                    /// #endif
                     event.preventDefault();
                     event.stopPropagation();
                     break;


### PR DESCRIPTION
## Description / 描述

修复问题：

- 在资源字段单元格菜单里点击资源文件，会打开浏览器下载而不是使用默认应用打开

	→ 使用 openLink 函数，将「在菜单里点击文件」的效果与「在单元格里点击文件」统一

- 在属性面板点击资源字段里的图片，预览时没有去掉末尾的 `?style=thumb`

	→ 使用 removeCompressURL 函数

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] New feature
      新功能  
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature or bug fix, please submit an issue first. After full community discussion, we will decide whether to implement the change. Do not submit code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突