### PR TITLE
Indicates the insertion position when dragging docs or block icon

### DIFF
--- a/app/src/protyle/util/editorCommonEvent.ts
+++ b/app/src/protyle/util/editorCommonEvent.ts
@@ -701,12 +701,15 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             }
             return;
         }
-        const targetElement = editorElement.querySelector(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top");
-        if (targetElement) {
-            targetElement.classList.remove("dragover");
-            targetElement.removeAttribute("select-start");
-            targetElement.removeAttribute("select-end");
-        }
+        const dragoverElements = editorElement.querySelectorAll(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top");
+        const targetElement = dragoverElements[0] as HTMLElement | undefined;
+        const targetClass = targetElement ? targetElement.className.split(" ") : [];
+        // 先清理指示器，否则可能在拖拽完成后或撤回后残留在编辑器内
+        dragoverElements.forEach((el: HTMLElement) => {
+            clearDragoverElement(el);
+            el.removeAttribute("select-start");
+            el.removeAttribute("select-end");
+        });
         if (gutterType) {
             // gutter 或反链面板拖拽
             const sourceElements: Element[] = [];
@@ -738,7 +741,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                 });
                 insertHTML(protyle.lute.SpinBlockDOM(html), protyle, true);
                 blockRender(protyle, protyle.wysiwyg.element);
-            } else if (targetElement && targetElement.className.indexOf("dragover__") > -1) {
+            } else if (targetElement) {
                 let queryClass = "";
                 selectedIds.forEach(item => {
                     queryClass += `[data-node-id="${item}"],`;
@@ -781,9 +784,6 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                 });
 
                 hideElements(["gutter"], protyle);
-
-                const targetClass = targetElement.className.split(" ");
-                targetElement.classList.remove("dragover__bottom", "dragover__top", "dragover__left", "dragover__right");
 
                 if (targetElement.classList.contains("av__cell")) {
                     const blockElement = hasClosestBlock(targetElement);
@@ -1045,7 +1045,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                     }
                 }
                 insertHTML(protyle.lute.Md2BlockDOM(html), protyle);
-            } else if (targetElement && !protyle.options.backlinkData && targetElement.className.indexOf("dragover__") > -1) {
+            } else if (targetElement && !protyle.options.backlinkData) {
                 const scrollTop = protyle.contentElement.scrollTop;
                 if (targetElement.classList.contains("av__row") ||
                     targetElement.classList.contains("av__gallery-item") ||
@@ -1054,9 +1054,9 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                     const blockElement = hasClosestBlock(targetElement);
                     if (blockElement) {
                         let previousID = "";
-                        if (targetElement.classList.contains("dragover__bottom") || targetElement.classList.contains("dragover__right")) {
+                        if (targetClass.includes("dragover__bottom") || targetClass.includes("dragover__right")) {
                             previousID = targetElement.getAttribute("data-id") || "";
-                        } else if (targetElement.classList.contains("dragover__top") || targetElement.classList.contains("dragover__left")) {
+                        } else if (targetClass.includes("dragover__top") || targetClass.includes("dragover__left")) {
                             previousID = targetElement.previousElementSibling?.getAttribute("data-id") || "";
                         }
                         const avID = blockElement.getAttribute("data-av-id");
@@ -1101,7 +1101,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                         blockElement.setAttribute("updated", newUpdated);
                     }
                 } else {
-                    if (targetElement.classList.contains("dragover__bottom")) {
+                    if (targetClass.includes("dragover__bottom")) {
                         for (let i = ids.length - 1; i > -1; i--) {
                             if (ids[i]) {
                                 await fetchSyncPost("/api/filetree/doc2Heading", {
@@ -1145,7 +1145,6 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                         }, Constants.TIMEOUT_LOAD);
                     });
                 }
-                targetElement.classList.remove("dragover__bottom", "dragover__top", "dragover__left", "dragover__right");
             }
         } else if (!window.siyuan.dragElement && (event.dataTransfer.types[0] === "Files" || event.dataTransfer.types.includes("text/html"))) {
             event.preventDefault();
@@ -1191,6 +1190,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
     });
     let dragoverElement: Element;
     let disabledPosition: string;
+    let cursorUpdateRafId = 0;
     editorElement.addEventListener("dragover", (event: DragEvent & { target: HTMLElement }) => {
         if (protyle.disabled || event.dataTransfer.types.includes(Constants.SIYUAN_DROP_EDITOR)) {
             event.preventDefault();
@@ -1240,7 +1240,8 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
         }
         const gutterTypes = gutterType ? gutterType.replace(Constants.SIYUAN_DROP_GUTTER, "").split(Constants.ZWSP) : [];
         const fileTreeIds = (event.dataTransfer.types.includes(Constants.SIYUAN_DROP_FILE) && window.siyuan.dragElement) ? window.siyuan.dragElement.innerText : "";
-        if (event.shiftKey || (event.altKey && fileTreeIds.indexOf("-") === -1)) {
+        // 按住 Alt 拖拽块标时需继续执行后续逻辑以显示光标；按住 Shift 拖拽块标时需继续执行以显示相邻块位置指示
+        if ((event.shiftKey || (event.altKey && fileTreeIds.indexOf("-") === -1)) && !(gutterType && (event.altKey || event.shiftKey))) {
             const targetAssetElement = hasClosestBlock(event.target);
             if (targetAssetElement) {
                 targetAssetElement.classList.remove("dragover__top", "protyle-wysiwyg--select", "dragover__bottom", "dragover__left", "dragover__right");
@@ -1395,6 +1396,28 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             !targetElement.classList.contains("av__row--util") &&
             !targetElement.classList.contains("av__gallery-item") &&
             !targetElement.classList.contains("av__gallery-add");
+        if (targetElement && isNotAvItem) {
+            if (((fileTreeIds && !event.altKey) || (gutterType && event.altKey))) {
+                // 文档树拖拽文档，或按住 Alt 拖拽块标时，是插入块引用，需在拖拽过程中显示光标
+                if (!cursorUpdateRafId) {
+                    cursorUpdateRafId = requestAnimationFrame(() => {
+                        cursorUpdateRafId = 0;
+                        const range = getRangeByPoint(event.clientX, event.clientY);
+                        if (range && protyle.wysiwyg.element.contains(range.startContainer)) {
+                            focusByRange(range);
+                        }
+                    });
+                }
+                editorElement.querySelectorAll(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top, .dragover").forEach((item: HTMLElement) => {
+                    item.classList.remove("dragover__top", "dragover__bottom", "dragover__left", "dragover__right", "dragover");
+                });
+                dragoverElement = undefined;
+                return;
+            } else if (((fileTreeIds && event.altKey) || (gutterType && !event.altKey))) {
+                // 文档树按住 Alt 拖拽文档，或拖拽块标时，是移动块，需清除此前显示的光标
+                getSelection().removeAllRanges();
+            }
+        }
         if (targetElement && dragoverElement && targetElement === dragoverElement) {
             // 性能优化，目标为同一个元素不再进行校验
             const nodeRect = targetElement.getBoundingClientRect();
@@ -1591,6 +1614,10 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                 item.classList.remove("dragover__top", "dragover__bottom", "dragover__left", "dragover__right", "dragover");
             });
             dragoverElement = undefined;
+            if (cursorUpdateRafId) {
+                cancelAnimationFrame(cursorUpdateRafId);
+                cursorUpdateRafId = 0;
+            }
         }
     });
     editorElement.addEventListener("dragenter", (event) => {
@@ -1598,6 +1625,10 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
         counter++;
     });
     editorElement.addEventListener("dragend", () => {
+        if (cursorUpdateRafId) {
+            cancelAnimationFrame(cursorUpdateRafId);
+            cursorUpdateRafId = 0;
+        }
         if (window.siyuan.dragElement) {
             window.siyuan.dragElement.style.opacity = "";
             window.siyuan.dragElement = undefined;

--- a/app/src/protyle/util/editorCommonEvent.ts
+++ b/app/src/protyle/util/editorCommonEvent.ts
@@ -1388,7 +1388,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
 
         if (!targetElement) {
             editorElement.querySelectorAll(".dragover__bottom, .dragover__top, .dragover, .dragover__left, .dragover__right").forEach((item: HTMLElement) => {
-                item.classList.remove("dragover__top", "dragover__bottom", "dragover", "dragover__left", "dragover__right");
+                clearDragoverElement(item);
             });
             return;
         }
@@ -1409,7 +1409,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
                     });
                 }
                 editorElement.querySelectorAll(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top, .dragover").forEach((item: HTMLElement) => {
-                    item.classList.remove("dragover__top", "dragover__bottom", "dragover__left", "dragover__right", "dragover");
+                    clearDragoverElement(item);
                 });
                 dragoverElement = undefined;
                 return;
@@ -1422,7 +1422,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             // 性能优化，目标为同一个元素不再进行校验
             const nodeRect = targetElement.getBoundingClientRect();
             editorElement.querySelectorAll(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top, .dragover").forEach((item: HTMLElement) => {
-                item.classList.remove("dragover__top", "dragover__bottom", "dragover__left", "dragover__right", "dragover");
+                clearDragoverElement(item);
                 item.removeAttribute("select-start");
                 item.removeAttribute("select-end");
             });
@@ -1525,7 +1525,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
             if (fileTreeIds.split(",").includes(protyle.block.rootID) && isNotAvItem && event.altKey) {
                 dragoverElement = undefined;
                 editorElement.querySelectorAll(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top, .dragover").forEach((item: HTMLElement) => {
-                    item.classList.remove("dragover__top", "dragover__bottom", "dragover__left", "dragover__right", "dragover");
+                    clearDragoverElement(item);
                     item.removeAttribute("select-start");
                     item.removeAttribute("select-end");
                 });
@@ -1611,7 +1611,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
         counter--;
         if (counter === 0) {
             editorElement.querySelectorAll(".dragover__left, .dragover__right, .dragover__bottom, .dragover__top, .dragover").forEach((item: HTMLElement) => {
-                item.classList.remove("dragover__top", "dragover__bottom", "dragover__left", "dragover__right", "dragover");
+                clearDragoverElement(item);
             });
             dragoverElement = undefined;
             if (cursorUpdateRafId) {

--- a/app/src/protyle/util/editorCommonEvent.ts
+++ b/app/src/protyle/util/editorCommonEvent.ts
@@ -1240,7 +1240,7 @@ export const dropEvent = (protyle: IProtyle, editorElement: HTMLElement) => {
         }
         const gutterTypes = gutterType ? gutterType.replace(Constants.SIYUAN_DROP_GUTTER, "").split(Constants.ZWSP) : [];
         const fileTreeIds = (event.dataTransfer.types.includes(Constants.SIYUAN_DROP_FILE) && window.siyuan.dragElement) ? window.siyuan.dragElement.innerText : "";
-        // 按住 Alt 拖拽块标时需继续执行后续逻辑以显示光标；按住 Shift 拖拽块标时需继续执行以显示相邻块位置指示
+        // 按住 Alt 拖拽块标时需继续执行后续逻辑以显示光标；按住 Shift 拖拽块标时需继续执行以显示指示器
         if ((event.shiftKey || (event.altKey && fileTreeIds.indexOf("-") === -1)) && !(gutterType && (event.altKey || event.shiftKey))) {
             const targetAssetElement = hasClosestBlock(event.target);
             if (targetAssetElement) {


### PR DESCRIPTION
## Description / 描述

Fix https://github.com/siyuan-note/siyuan/issues/16882

目前存在的问题：

- 在文档树拖拽文档到编辑器里，不能插入光标
- 拖拽块标到其他块上面，按住 Alt 时（插入块引用）不能插入光标、按住 Shift 时（插入嵌入块）不能插入指示器

[video.webm](https://github.com/user-attachments/assets/5d9467ee-a5f2-488a-897c-4b23218ddd63)

本 PR 进行改进，增加了以下逻辑：

- 在文档树拖拽文档到编辑器里（插入块引用），插入光标；按住 Alt 时（移动块）则移除光标
- 拖拽块标到其他块上面（移动块），移除光标；按住 Alt 时（插入块引用）则插入光标；按住 Shift 时（插入嵌入块）则插入指示器

[video.webm](https://github.com/user-attachments/assets/72e9600e-9efc-43aa-95dc-ef1446e3cb19)

但是本 PR 仍然存在我无法解决的缺陷，需要帮助：

- [ ] 按住 Shift 时（插入嵌入块）插入了指示器，但松手之后不会按照指示器的方位来插入，只会插入到段落块的后面。因为这个嵌入块是通过 `insertHTML(protyle.lute.SpinBlockDOM(html), protyle, true)` 插入的，我不懂怎么更换为其他方式。

	[video.webm](https://github.com/user-attachments/assets/9a5de7b2-9c9e-49aa-90fa-5355e6fdaf7c)

- [ ] 本来还想试试能不能按照指示器位置插入外部拖拽进来的[视频文件](https://github.com/siyuan-note/siyuan/issues/12857#issuecomment-2436865200)，但感觉应该会遇到跟前面相同的问题，所以先搁置了

## Type of change / 变更类型

- [ ] Bug fix
      缺陷修复
- [x] New feature
      新功能  
- [ ] Text updates or new language additions
      修改文案或增加新语言

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突