### PR TITLE
Improve cleaning up unreferenced databases

### DIFF
--- a/app/src/config/image.ts
+++ b/app/src/config/image.ts
@@ -168,7 +168,7 @@ export const image = {
                             code: 0
                         },
                         protyle: editor.protyle,
-                        action: [Constants.CB_GET_HISTORY, Constants.CB_GET_HTML],
+                        action: [Constants.CB_GET_HISTORY, Constants.CB_GET_HTML, Constants.CB_GET_AV_NO_CREATE],
                     });
                     event.preventDefault();
                     event.stopPropagation();
@@ -198,27 +198,30 @@ export const image = {
                     const liElement = target.parentElement;
                     confirmDialog(window.siyuan.languages.deleteOpConfirm, `${window.siyuan.languages.delete} <b>${liElement.querySelector(".b3-list-item__text").textContent}</b>`, () => {
                         if (liElement.getAttribute("data-tab-type") === "unRefAV") {
+                            const id = liElement.getAttribute("data-item");
                             fetchPost("/api/av/removeUnusedAttributeView", {
-                                id: liElement.getAttribute("data-item"),
+                                id,
                             }, () => {
                                 if (liElement.parentElement.querySelectorAll("li").length === 1) {
                                     liElement.parentElement.innerHTML = `<li class="b3-list--empty">${window.siyuan.languages.emptyContent}</li>`;
                                 } else {
                                     liElement.remove();
                                 }
-                                onGet({
-                                    data: {
+                                if (editor.protyle.element.querySelector(`.av[data-av-id="${id}"]`)) {
+                                    onGet({
                                         data: {
-                                            content: "",
-                                            id: Lute.NewNodeID(),
-                                            rootID: Lute.NewNodeID(),
+                                            data: {
+                                                content: "",
+                                                id: Lute.NewNodeID(),
+                                                rootID: Lute.NewNodeID(),
+                                            },
+                                            msg: "",
+                                            code: 0
                                         },
-                                        msg: "",
-                                        code: 0
-                                    },
-                                    protyle: editor.protyle,
-                                    action: [Constants.CB_GET_HISTORY, Constants.CB_GET_HTML],
-                                });
+                                        protyle: editor.protyle,
+                                        action: [Constants.CB_GET_HISTORY, Constants.CB_GET_HTML],
+                                    });
+                                }
                             });
                         } else {
                             fetchPost("/api/asset/removeUnusedAsset", {
@@ -281,7 +284,7 @@ export const image = {
         data.forEach((item) => {
             html += `<li data-tab-type="${type}" data-item="${item.item}"  class="b3-list-item${isM ? "" : " b3-list-item--hide-action"}">
     <span class="b3-list-item__text">${escapeHtml(item.name || item.item)}</span>
-    <span data-type="copy" class="ariaLabel b3-list-item__action" aria-label="${window.siyuan.languages[type === "unRefAV" ? "copyMirror" : "copy"]}">
+    <span data-type="copy" class="ariaLabel b3-list-item__action" aria-label="${type === "unRefAV" ? window.siyuan.languages.copyMirror : window.siyuan.languages.copy}">
         <svg><use xlink:href="#iconCopy"></use></svg>
     </span>
     ${boxOpenHTML}

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -139,6 +139,7 @@ export abstract class Constants {
     public static readonly CB_GET_HTML = "cb-get-html"; // 直接渲染，不需要再 /api/block/getDocInfo，否则搜索表格无法定位
     public static readonly CB_GET_HISTORY = "cb-get-history"; // 历史渲染
     public static readonly CB_GET_OPENNEW = "cb-get-opennew"; // 编辑器只读后新建文件需为临时解锁状态 & https://github.com/siyuan-note/siyuan/issues/12197
+    public static readonly CB_GET_AV_NO_CREATE = "cb-get-av-no-create"; // 属性视图不自动创建
 
     // localstorage
     public static readonly LOCAL_ZOOM = "local-zoom";

--- a/app/src/protyle/render/av/render.ts
+++ b/app/src/protyle/render/av/render.ts
@@ -569,6 +569,7 @@ export const avRender = async (element: Element, protyle: IProtyle, cb?: (data: 
                 viewID: e.getAttribute(Constants.CUSTOM_SY_AV_VIEW) || "",
                 query: resetData.query.trim(),
                 blockID: e.getAttribute("data-node-id"),
+                createIfNotExist: !protyle.block.action?.includes(Constants.CB_GET_AV_NO_CREATE),
             });
             data = response.data;
         } else {

--- a/app/src/types/protyle.d.ts
+++ b/app/src/types/protyle.d.ts
@@ -39,7 +39,8 @@ type TProtyleAction = "cb-get-append" | // 向下滚动加载
     "cb-get-rootscroll" | // 如果为 rootID 就滚动到指定位置，必有 rootID
     "cb-get-html" | // 直接渲染，不需要再 /api/block/getDocInfo，否则搜索表格无法定位
     "cb-get-history" | // 历史渲染
-    "cb-get-opennew"  // 编辑器只读后新建文件需为临时解锁状态 & https://github.com/siyuan-note/siyuan/issues/12197
+    "cb-get-opennew" | // 编辑器只读后新建文件需为临时解锁状态 & https://github.com/siyuan-note/siyuan/issues/12197
+    "cb-get-av-no-create"  // 属性视图不自动创建
 
 /** @link https://ld246.com/article/1588412297062 */
 interface ILuteRender {


### PR DESCRIPTION


## Description / 描述

Fix https://github.com/siyuan-note/siyuan/issues/11569#issuecomment-3884008188

- 只有删除当前预览的数据库时才清空预览区
- 渲染数据库始终不创建新的 JSON 文件

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] New feature
      新功能  
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature or bug fix, please submit an issue first. After full community discussion, we will decide whether to implement the change. Do not submit code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突