### PR TITLE
Unreferenced assets files and databases sorted by modification time

### DIFF
--- a/kernel/api/asset.go
+++ b/kernel/api/asset.go
@@ -339,7 +339,7 @@ func getUnusedAssets(c *gin.Context) {
 	ret := gulu.Ret.NewResult()
 	defer c.JSON(http.StatusOK, ret)
 
-	unusedAssets := model.UnusedAssets()
+	unusedAssets := model.UnusedAssets(true)
 	total := len(unusedAssets)
 
 	// List only 512 unreferenced assets https://github.com/siyuan-note/siyuan/issues/13075

--- a/kernel/api/av.go
+++ b/kernel/api/av.go
@@ -58,7 +58,7 @@ func getUnusedAttributeViews(c *gin.Context) {
 	ret := gulu.Ret.NewResult()
 	defer c.JSON(http.StatusOK, ret)
 
-	unusedAttributeViews := model.UnusedAttributeViews()
+	unusedAttributeViews := model.UnusedAttributeViews(true)
 	total := len(unusedAttributeViews)
 
 	const maxUnusedAttributeViews = 512


### PR DESCRIPTION
## Description / 描述

未引用的资源文件现在顺序是随机的不太方便，改成按修改时间排序。

未引用的数据库的一个条件判断写反了，实际上一直在按照创建时间排序，修复并简化了代码。

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [x] New feature
      新功能  
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature or bug fix, please submit an issue first. After full community discussion, we will decide whether to implement the change. Do not submit code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突