### PR TITLE
Remove the `colspan` and `rowspan` attributes from cell elements after splitting cells

### DIFF
--- a/app/src/menus/protyle.ts
+++ b/app/src/menus/protyle.ts
@@ -64,7 +64,6 @@ import {hideTooltip} from "../dialog/tooltip";
 import {clearSelect} from "../protyle/util/clear";
 import {scrollCenter} from "../util/highlightById";
 import {base64ToURL} from "../util/image";
-import {Dialog} from "../dialog";
 
 const renderAssetList = (element: Element, k: string, position: IPosition, exts: string[] = []) => {
     fetchPost("/api/search/searchAsset", {
@@ -2154,16 +2153,16 @@ export const tableMenu = (protyle: IProtyle, nodeElement: Element, cellElement: 
                     let colSpan = orgColSpan;
                     while (colSpan > 0 && currentCellElement) {
                         currentCellElement.classList.remove("fn__none");
-                        currentCellElement.colSpan = 1;
-                        currentCellElement.rowSpan = 1;
+                        currentCellElement.removeAttribute("colspan");
+                        currentCellElement.removeAttribute("rowspan");
                         currentCellElement = currentCellElement.nextElementSibling as HTMLTableCellElement;
                         colSpan--;
                     }
                     currentRowElement = currentRowElement.nextElementSibling;
                     rowSpan--;
                 }
-                cellElement.rowSpan = 1;
-                cellElement.colSpan = 1;
+                cellElement.removeAttribute("colspan");
+                cellElement.removeAttribute("rowspan");
                 if (cellElement.tagName === "TH") {
                     let prueTrElement: HTMLElement;
                     Array.from(nodeElement.querySelectorAll("thead tr")).find((item: HTMLElement) => {


### PR DESCRIPTION
Fix https://github.com/siyuan-note/siyuan/issues/17050#issue-3943488883

拆分单元格之后移除单元格元素的 `colspan` 和 `rowspan` 属性