### PR TITLE
Support setting document title to empty

### DIFF
--- a/app/src/boot/globalEvent/keydown.ts
+++ b/app/src/boot/globalEvent/keydown.ts
@@ -658,12 +658,26 @@ const fileTreeKeydown = (app: App, event: KeyboardEvent) => {
 
     if (matchHotKey(window.siyuan.config.keymap.editor.general.rename.custom, event)) {
         window.siyuan.menus.menu.remove();
-        rename({
-            notebookId,
-            path: pathString,
-            name: isFile ? getDisplayName(liElements[0].getAttribute("data-name"), false, true) : getNotebookName(notebookId),
-            type: isFile ? "file" : "notebook",
-        });
+        if (isFile) {
+            fetchPost("/api/block/getDocInfo", {
+                id: liElements[0].getAttribute("data-node-id")
+            }, (response) => {
+                rename({
+                    notebookId,
+                    path: pathString,
+                    name: response.data.ial.title,
+                    empty: response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true",
+                    type: "file",
+                });
+            });
+        } else {
+            rename({
+                notebookId,
+                path: pathString,
+                name: getNotebookName(notebookId),
+                type: "notebook",
+            });
+        }
         event.preventDefault();
         return true;
     }

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -61,11 +61,12 @@ export abstract class Constants {
     public static readonly SIYUAN_SHOW_WINDOW: string = "siyuan-show-window";
 
     // custom
+    public static readonly CUSTOM_REMINDER_WECHAT: string = "custom-reminder-wechat";
+    public static readonly CUSTOM_RIFF_DECKS: string = "custom-riff-decks";
     public static readonly CUSTOM_SY_READONLY: string = "custom-sy-readonly";
     public static readonly CUSTOM_SY_FULLWIDTH: string = "custom-sy-fullwidth";
     public static readonly CUSTOM_SY_AV_VIEW: string = "custom-sy-av-view";
-    public static readonly CUSTOM_REMINDER_WECHAT: string = "custom-reminder-wechat";
-    public static readonly CUSTOM_RIFF_DECKS: string = "custom-riff-decks";
+    public static readonly CUSTOM_SY_TITLE_EMPTY: string = "custom-sy-title-empty";
 
     // size
     public static readonly SIZE_DATABASE_MAZ_SIZE: number = 102400;

--- a/app/src/dialog/processSystem.ts
+++ b/app/src/dialog/processSystem.ts
@@ -515,10 +515,10 @@ export const bootSync = () => {
     });
 };
 
-export const setTitle = (title: string) => {
+export const setTitle = (title: string, showVersionTitle = false) => {
     const dragElement = document.getElementById("drag");
     const workspaceName = getWorkspaceName();
-    if (title === window.siyuan.languages.siyuanNote) {
+    if (showVersionTitle) {
         const versionTitle = `${workspaceName} - ${window.siyuan.languages.siyuanNote} v${Constants.SIYUAN_VERSION}`;
         document.title = versionTitle;
         if (dragElement) {
@@ -526,7 +526,7 @@ export const setTitle = (title: string) => {
             dragElement.setAttribute("title", versionTitle);
         }
     } else {
-        title = title || window.siyuan.languages.untitled;
+        title = title.trim() || window.siyuan.languages["_kernel"][16];
         document.title = `${title} - ${workspaceName} - ${window.siyuan.languages.siyuanNote} v${Constants.SIYUAN_VERSION}`;
         if (!dragElement) {
             return;

--- a/app/src/dialog/processSystem.ts
+++ b/app/src/dialog/processSystem.ts
@@ -32,7 +32,7 @@ const updateTitle = (rootID: string, tab: Tab, protyle?: IProtyle) => {
     }, (response) => {
         tab.updateTitle(response.data.name);
         if (protyle && protyle.title) {
-            protyle.title.setTitle(response.data.name);
+            protyle.title.setTitle(response.data.name, response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true");
         }
     });
 };
@@ -66,7 +66,7 @@ export const reloadSync = (
                 id: window.siyuan.mobile.editor.protyle.block.rootID
             }, (response) => {
                 setTitle(response.data.name);
-                window.siyuan.mobile.editor.protyle.title.setTitle(response.data.name);
+                window.siyuan.mobile.editor.protyle.title.setTitle(response.data.name, response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true");
             });
         }
     }

--- a/app/src/editor/rename.ts
+++ b/app/src/editor/rename.ts
@@ -50,10 +50,14 @@ export const rename = (options: {
     notebookId: string
     name: string,
     type: "notebook" | "file"
+    empty?: boolean
     range?: Range,
 }) => {
     if (window.siyuan.config.readonly) {
         return;
+    }
+    if (options.empty) {
+        options.name = "";
     }
     const dialog = new Dialog({
         title: window.siyuan.languages.rename,
@@ -85,27 +89,27 @@ export const rename = (options: {
         if (!validateName(inputElement.value)) {
             return false;
         }
-        if (inputElement.value === options.name) {
+        let name = inputElement.value.trim();
+        if (name === options.name) {
             dialog.destroy();
             return false;
         }
-        if (inputElement.value.trim() === "") {
-            inputElement.value = window.siyuan.languages.untitled;
-        } else {
-            inputElement.value = replaceFileName(inputElement.value);
-        }
+        name = replaceFileName(name);
         if (options.type === "notebook") {
+            if (!name) {
+                name = window.siyuan.languages.untitled;
+            }
             fetchPost("/api/notebook/renameNotebook", {
                 notebook: options.notebookId,
-                name: inputElement.value
+                name,
             }, () => {
-                setNotebookName(options.notebookId, inputElement.value);
+                setNotebookName(options.notebookId, name);
             });
         } else {
             fetchPost("/api/filetree/renameDoc", {
                 notebook: options.notebookId,
                 path: options.path,
-                title: inputElement.value,
+                title: name,
             });
         }
         dialog.destroy();

--- a/app/src/editor/rename.ts
+++ b/app/src/editor/rename.ts
@@ -77,7 +77,7 @@ export const rename = (options: {
     dialog.bindInput(inputElement, () => {
         (btnsElement[1] as HTMLButtonElement).click();
     });
-    inputElement.value = Lute.UnEscapeHTMLStr(initialName);
+    inputElement.value = initialName;
     inputElement.focus();
     inputElement.select();
     btnsElement[0].addEventListener("click", () => {

--- a/app/src/editor/rename.ts
+++ b/app/src/editor/rename.ts
@@ -56,9 +56,7 @@ export const rename = (options: {
     if (window.siyuan.config.readonly) {
         return;
     }
-    if (options.empty) {
-        options.name = "";
-    }
+    const initialName = options.empty ? "" : options.name;
     const dialog = new Dialog({
         title: window.siyuan.languages.rename,
         content: `<div class="b3-dialog__content"><input class="b3-text-field fn__block" value=""></div>
@@ -79,7 +77,7 @@ export const rename = (options: {
     dialog.bindInput(inputElement, () => {
         (btnsElement[1] as HTMLButtonElement).click();
     });
-    inputElement.value = Lute.UnEscapeHTMLStr(options.name);
+    inputElement.value = Lute.UnEscapeHTMLStr(initialName);
     inputElement.focus();
     inputElement.select();
     btnsElement[0].addEventListener("click", () => {
@@ -90,7 +88,7 @@ export const rename = (options: {
             return false;
         }
         let name = inputElement.value.trim();
-        if (name === options.name) {
+        if (name === initialName) {
             dialog.destroy();
             return false;
         }

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -217,7 +217,7 @@ export class App {
                         window.siyuan.user = userResponse.data;
                         onGetConfig(response.data.start, this);
                         account.onSetaccount();
-                        setTitle(window.siyuan.languages.siyuanNote);
+                        setTitle("", true);
                         initMessage();
                         /// #if BROWSER && !MOBILE
                         if (!isInMobileApp() && !window.siyuan.config.readonly && !window.siyuan.isPublish && !isChromeBrowser()) {

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -881,7 +881,7 @@ export class Wnd {
                 const wnd = new Wnd(this.app);
                 window.siyuan.layout.centerLayout.addWnd(wnd);
                 wnd.addTab(newCenterEmptyTab(this.app), false, false);
-                setTitle(window.siyuan.languages.siyuanNote);
+                setTitle("", true);
             }
         }
         if (isSaveLayout) {

--- a/app/src/layout/util.ts
+++ b/app/src/layout/util.ts
@@ -36,7 +36,7 @@ import {setStorageVal} from "../protyle/util/compatibility";
 
 export const setPanelFocus = (element: Element, isSaveLayout = true) => {
     if (element.getAttribute("data-type") === "wnd") {
-        setTitle(element.querySelector('.layout-tab-bar .item--focus[data-type="tab-header"] .item__text')?.textContent || window.siyuan.languages.siyuanNote);
+        setTitle(element.querySelector('.layout-tab-bar .item--focus[data-type="tab-header"] .item__text')?.textContent || "");
     }
     if (element.classList.contains("layout__tab--active") || element.classList.contains("layout__wnd--active")) {
         return;

--- a/app/src/menus/commonMenuItem.ts
+++ b/app/src/menus/commonMenuItem.ts
@@ -967,6 +967,7 @@ export const renameMenu = (options: {
     notebookId: string
     name: string,
     type: "notebook" | "file"
+    docId?: string | null
 }) => {
     return new MenuItem({
         id: "rename",
@@ -974,7 +975,18 @@ export const renameMenu = (options: {
         icon: "iconEdit",
         label: window.siyuan.languages.rename,
         click: () => {
-            rename(options);
+            if (options.type === "file" && options.docId) {
+                fetchPost("/api/block/getDocInfo", {
+                    id: options.docId
+                }, (response) => {
+                    rename({
+                        ...options,
+                        empty: response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true",
+                    });
+                });
+            } else {
+                rename(options);
+            }
         }
     }).element;
 };

--- a/app/src/menus/commonMenuItem.ts
+++ b/app/src/menus/commonMenuItem.ts
@@ -981,6 +981,7 @@ export const renameMenu = (options: {
                 }, (response) => {
                     rename({
                         ...options,
+                        name: response.data.ial.title,
                         empty: response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true",
                     });
                 });

--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -549,7 +549,8 @@ export const initFileMenu = (app: App, notebookId: string, pathString: string, l
             path: pathString,
             notebookId,
             name,
-            type: "file"
+            type: "file",
+            docId: id,
         }));
         window.siyuan.menus.menu.append(new MenuItem({
             id: "attr",

--- a/app/src/mobile/util/MobileBackFoward.ts
+++ b/app/src/mobile/util/MobileBackFoward.ts
@@ -47,7 +47,7 @@ const focusStack = (backStack: IBackStack) => {
             id: backStack.id,
         }, (response) => {
             setTitle(response.data.name);
-            protyle.title.setTitle(response.data.name);
+            protyle.title.setTitle(response.data.name, response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true");
             protyle.background.render(response.data.ial, protyle.block.rootID);
             protyle.wysiwyg.renderCustom(response.data.ial);
         });

--- a/app/src/mobile/util/setEmpty.ts
+++ b/app/src/mobile/util/setEmpty.ts
@@ -9,7 +9,7 @@ import {setTitle} from "../../dialog/processSystem";
 import {isIPhone} from "../../protyle/util/compatibility";
 
 export const setEmpty = (app: App) => {
-    setTitle(window.siyuan.languages.siyuanNote);
+    setTitle("", true);
     document.getElementById("toolbarName").classList.add("fn__hidden");
     document.getElementById("editor").classList.add("fn__none");
     const emptyElement = document.getElementById("empty");

--- a/app/src/protyle/header/Title.ts
+++ b/app/src/protyle/header/Title.ts
@@ -339,21 +339,21 @@ export class Title {
         }, Constants.TIMEOUT_INPUT);
     }
 
-    public setTitle(title: string) {
+    public setTitle(title: string, empty?: boolean) {
         /// #if MOBILE
         if (this.editElement) {
             if (nbsp2space(title) !== nbsp2space(this.editElement.textContent)) {
-                this.editElement.textContent = title === window.siyuan.languages.untitled ? "" : title;
+                this.editElement.textContent = empty ? "" : title;
             }
         } else {
             const inputElement = document.getElementById("toolbarName") as HTMLInputElement;
             if (nbsp2space(title) !== nbsp2space(inputElement.value)) {
-                inputElement.value = title === window.siyuan.languages.untitled ? "" : title;
+                inputElement.value = empty ? "" : title;
             }
         }
         /// #else
         if (nbsp2space(title) !== nbsp2space(this.editElement.textContent)) {
-            this.editElement.textContent = title === window.siyuan.languages.untitled ? "" : title;
+            this.editElement.textContent = empty ? "" : title;
         }
         /// #endif
     }
@@ -376,7 +376,7 @@ export class Title {
         protyle.background?.render(response.data.ial, protyle.block.rootID);
         protyle.wysiwyg.renderCustom(response.data.ial);
         this.element.setAttribute("data-render", "true");
-        this.setTitle(response.data.ial.title);
+        this.setTitle(response.data.ial.title, response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true");
         let nodeAttrHTML = "";
         if (response.data.ial.bookmark) {
             nodeAttrHTML += `<div class="protyle-attr--bookmark">${Lute.EscapeHTMLStr(response.data.ial.bookmark)}</div>`;

--- a/app/src/protyle/header/Title.ts
+++ b/app/src/protyle/header/Title.ts
@@ -339,7 +339,7 @@ export class Title {
         }, Constants.TIMEOUT_INPUT);
     }
 
-    public setTitle(title: string, empty?: boolean) {
+    public setTitle(title: string, empty: boolean = false) {
         /// #if MOBILE
         if (this.editElement) {
             if (nbsp2space(title) !== nbsp2space(this.editElement.textContent)) {

--- a/app/src/protyle/index.ts
+++ b/app/src/protyle/index.ts
@@ -212,7 +212,7 @@ export class Protyle {
                                     this.protyle.title.editElement?.contains(getSelection().getRangeAt(0).startContainer)) {
                                     // 标题编辑中的不用更新 https://github.com/siyuan-note/siyuan/issues/6565
                                 } else {
-                                    this.protyle.title.setTitle(data.data.title);
+                                    this.protyle.title.setTitle(data.data.title, data.data.empty === "true");
                                 }
                             }
                             // update ref

--- a/app/src/protyle/index.ts
+++ b/app/src/protyle/index.ts
@@ -212,7 +212,7 @@ export class Protyle {
                                     this.protyle.title.editElement?.contains(getSelection().getRangeAt(0).startContainer)) {
                                     // 标题编辑中的不用更新 https://github.com/siyuan-note/siyuan/issues/6565
                                 } else {
-                                    this.protyle.title.setTitle(data.data.title, data.data.empty === "true");
+                                    this.protyle.title.setTitle(data.data.title, !!data.data.empty);
                                 }
                             }
                             // update ref

--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -1221,6 +1221,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                         notebookId: protyle.notebookId,
                         path: protyle.path,
                         name: response.data.ial.title,
+                        empty: response.data.ial[Constants.CUSTOM_SY_TITLE_EMPTY] === "true",
                         range,
                         type: "file",
                     });

--- a/app/src/window/index.ts
+++ b/app/src/window/index.ts
@@ -180,7 +180,7 @@ class App {
                     fetchPost("/api/setting/getCloudUser", {}, userResponse => {
                         window.siyuan.user = userResponse.data;
                         init(this);
-                        setTitle(window.siyuan.languages.siyuanNote);
+                        setTitle("", true);
                         initMessage();
                     });
                 });

--- a/kernel/model/file.go
+++ b/kernel/model/file.go
@@ -1675,35 +1675,36 @@ func RenameDoc(boxID, p, title string) (err error) {
 	}
 
 	oldTitle := tree.Root.IALAttr("title")
-	var titleChanged, markCleared bool
 
-	// 标题改变
-	if oldTitle != title {
-		var isEmpty bool
-		if "" == title {
-			title = Conf.language(16)
-			isEmpty = true
-		}
-		title = strings.ReplaceAll(title, "/", "")
+	// 先规范化输入得到实际会存储的标题，再与旧标题比较，避免 title=="" 被误判为标题变更
+	newTitle := strings.ReplaceAll(title, "/", "")
+	var isEmpty bool
+	if "" == newTitle {
+		newTitle = Conf.language(16)
+		isEmpty = true
+	}
+	titleChanged := oldTitle != newTitle
 
-		tree.HPath = path.Join(path.Dir(tree.HPath), title)
-		tree.Root.SetIALAttr("title", title)
+	var emptyAttrUpdated bool
+	if titleChanged {
+		tree.HPath = path.Join(path.Dir(tree.HPath), newTitle)
+		tree.Root.SetIALAttr("title", newTitle)
+	}
+
+	// 按需同步“无标题”标记（仅更新 IAL，不触发子树重命名等）
+	isTitleEmpty := "" != tree.Root.IALAttr(NodeAttrTitleEmpty)
+	if isTitleEmpty != isEmpty {
 		if isEmpty {
 			tree.Root.SetIALAttr(NodeAttrTitleEmpty, "true")
+			isTitleEmpty = true
 		} else {
 			tree.Root.RemoveIALAttr(NodeAttrTitleEmpty)
-			markCleared = true
+			isTitleEmpty = false
 		}
-		titleChanged = true
+		emptyAttrUpdated = true
 	}
 
-	// 标题没变但需要清除标记
-	if !titleChanged && "" != title && "" != tree.Root.IALAttr(NodeAttrTitleEmpty) {
-		tree.Root.RemoveIALAttr(NodeAttrTitleEmpty)
-		markCleared = true
-	}
-
-	if titleChanged || markCleared {
+	if titleChanged || emptyAttrUpdated {
 		tree.Root.SetIALAttr("updated", util.CurrentTimeSecondsStr())
 		if err = renameWriteJSONQueue(tree); err != nil {
 			return
@@ -1715,8 +1716,8 @@ func RenameDoc(boxID, p, title string) (err error) {
 			"box":     boxID,
 			"id":      tree.Root.ID,
 			"path":    p,
-			"title":   title,
-			"empty":   tree.Root.IALAttr(NodeAttrTitleEmpty),
+			"title":   newTitle,
+			"empty":   isTitleEmpty,
 			"refText": refText,
 		}
 		util.PushEvent(evt)
@@ -1725,7 +1726,7 @@ func RenameDoc(boxID, p, title string) (err error) {
 		box.renameSubTrees(tree)
 		updateRefTextRenameDoc(tree)
 	}
-	if titleChanged || markCleared {
+	if titleChanged || emptyAttrUpdated {
 		IncSync()
 	}
 	return

--- a/kernel/model/file.go
+++ b/kernel/model/file.go
@@ -1668,27 +1668,24 @@ func RenameDoc(boxID, p, title string) (err error) {
 		return
 	}
 
-	title = removeInvisibleCharsInTitle(title)
+	title = normalizeDocTitle(title)
 	if 512 < utf8.RuneCountInString(title) {
 		// 限制笔记本名和文档名最大长度为 `512` https://github.com/siyuan-note/siyuan/issues/6299
 		return errors.New(Conf.Language(106))
 	}
 
-	oldTitle := tree.Root.IALAttr("title")
-
-	// 先规范化输入得到实际会存储的标题，再与旧标题比较，避免 title=="" 被误判为标题变更
-	newTitle := strings.ReplaceAll(title, "/", "")
 	var isEmpty bool
-	if "" == newTitle {
-		newTitle = Conf.language(16)
+	if "" == title {
+		title = Conf.language(16)
 		isEmpty = true
 	}
-	titleChanged := oldTitle != newTitle
+	// 先规范化输入得到实际会存储的标题，再与旧标题比较
+	titleChanged := tree.Root.IALAttr("title") != title
 
 	var emptyAttrUpdated bool
 	if titleChanged {
-		tree.HPath = path.Join(path.Dir(tree.HPath), newTitle)
-		tree.Root.SetIALAttr("title", newTitle)
+		tree.HPath = path.Join(path.Dir(tree.HPath), title)
+		tree.Root.SetIALAttr("title", title)
 	}
 
 	// 按需同步“无标题”标记（仅更新 IAL，不触发子树重命名等）
@@ -1716,7 +1713,7 @@ func RenameDoc(boxID, p, title string) (err error) {
 			"box":     boxID,
 			"id":      tree.Root.ID,
 			"path":    p,
-			"title":   newTitle,
+			"title":   title,
 			"empty":   isTitleEmpty,
 			"refText": refText,
 		}
@@ -1733,14 +1730,12 @@ func RenameDoc(boxID, p, title string) (err error) {
 }
 
 func createDoc(boxID, p, title, dom string) (tree *parse.Tree, err error) {
-	title = removeInvisibleCharsInTitle(title)
+	title = normalizeDocTitle(title)
 	if 512 < utf8.RuneCountInString(title) {
 		// 限制笔记本名和文档名最大长度为 `512` https://github.com/siyuan-note/siyuan/issues/6299
 		err = errors.New(Conf.Language(106))
 		return
 	}
-	title = strings.ReplaceAll(title, "/", "")
-	title = strings.TrimSpace(title)
 	var isEmpty bool
 	if "" == title {
 		title = Conf.Language(16)
@@ -1851,7 +1846,8 @@ func createDoc(boxID, p, title, dom string) (tree *parse.Tree, err error) {
 	return
 }
 
-func removeInvisibleCharsInTitle(title string) string {
+func normalizeDocTitle(title string) string {
+	title = strings.ReplaceAll(title, "/", "")
 	// 不要踢掉 零宽连字符，否则有的 Emoji 会变形 https://github.com/siyuan-note/siyuan/issues/11480
 	title = strings.ReplaceAll(title, string(gulu.ZWJ), "__@ZWJ@__")
 	title = util.RemoveInvalid(title)

--- a/kernel/model/history.go
+++ b/kernel/model/history.go
@@ -346,6 +346,7 @@ func RollbackDocHistory(boxID, historyPath string) (err error) {
 			"id":      tree.Root.ID,
 			"path":    tree.Path,
 			"title":   tree.Root.IALAttr("title"),
+			"empty":   "" != tree.Root.IALAttr(NodeAttrTitleEmpty),
 			"refText": refText,
 		}
 		util.PushEvent(evt)


### PR DESCRIPTION
## Description / 描述

目前如果使用中文界面，刷新文档之后就会在空文档标题填入“未命名文档”；如果使用英文界面，刷新文档之后不会填入标题，而是显示占位符“Untitled”。这是因为前端目前是根据文档名字符串是否等于 window.siyuan.languages.untitled 来判断文档是否未命名的，完全不准确，所以我添加了 custom-sy-title-empty 属性作为标记。

本 PR：前端清空文档标题之后，内核会将 Conf.language(16)（“未命名文档”）写入文档标题，同时给文档添加一个 custom-sy-title-empty=true 属性。前端打开空标题的文档时可以只显示占位符，不像目前这样清空标题之后一刷新文档就把文档标题变成“未命名文档”。

最后的效果就是能支持将文档标题设置为空。

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] New feature
      新功能  
- [ ] Text updates or new language additions
      修改文案或增加新语言

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突