### PR TITLE
kernel: Fix network serving TLS on mobile devices

### DIFF
--- a/kernel/server/proxy/fixedport.go
+++ b/kernel/server/proxy/fixedport.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"crypto/tls"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -51,39 +52,10 @@ func InitFixedPortService(host string, useTLS bool, certPath, keyPath string) {
 				return
 			}
 
-			m := cmux.New(ln)
-
-			// Match TLS connections (first byte 0x16 indicates TLS handshake)
-			tlsL := m.Match(cmux.TLS())
-			// Match HTTP (anything else)
-			httpL := m.Match(cmux.Any())
-
-			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
-			if err != nil {
-				logging.LogWarnf("failed to load TLS cert for fixed port service: %s", err)
-				ln.Close()
-				return
-			}
-			tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
-
-			tlsListener := tls.NewListener(tlsL, tlsConfig)
-
-			go func() {
-				httpServer := &http.Server{Handler: proxy}
-				if err := httpServer.Serve(httpL); err != nil && err != cmux.ErrListenerClosed {
-					logging.LogWarnf("fixed port HTTP server error: %s", err)
+			if serveErr := util.ServeMultiplexed(ln, proxy, certPath, keyPath, nil); serveErr != nil {
+				if serveErr != cmux.ErrListenerClosed && !errors.Is(serveErr, http.ErrServerClosed) {
+					logging.LogWarnf("fixed port cmux serve error: %s", serveErr)
 				}
-			}()
-
-			go func() {
-				httpsServer := &http.Server{Handler: proxy}
-				if err := httpsServer.Serve(tlsListener); err != nil && err != cmux.ErrListenerClosed {
-					logging.LogWarnf("fixed port HTTPS server error: %s", err)
-				}
-			}()
-
-			if err := m.Serve(); err != nil && err != cmux.ErrListenerClosed {
-				logging.LogWarnf("fixed port cmux serve error: %s", err)
 			}
 		} else {
 			logging.LogInfof("fixed port service [%s] is running", addr)

--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -47,6 +47,7 @@ import (
 	"github.com/siyuan-note/siyuan/kernel/model"
 	"github.com/siyuan-note/siyuan/kernel/server/proxy"
 	"github.com/siyuan-note/siyuan/kernel/util"
+	"github.com/soheilhy/cmux"
 	"golang.org/x/net/webdav"
 )
 
@@ -242,6 +243,20 @@ func Serve(fastMode bool, cookieKey string) {
 
 	util.HttpServer = &http.Server{
 		Handler: ginServer,
+	}
+
+	if useTLS && (util.FixedPort == util.ServerPort || util.IsPortOpen(util.FixedPort)) {
+		if err = util.ServeMultiplexed(ln, ginServer, certPath, keyPath, util.HttpServer); err != nil {
+			if errors.Is(err, http.ErrServerClosed) || err == cmux.ErrListenerClosed {
+				return
+			}
+
+			if !fastMode {
+				logging.LogErrorf("boot kernel failed: %s", err)
+				os.Exit(logging.ExitCodeUnavailablePort)
+			}
+		}
+		return
 	}
 
 	if err = util.HttpServer.Serve(ln); err != nil {

--- a/kernel/util/cmux.go
+++ b/kernel/util/cmux.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/siyuan-note/logging"
+	"github.com/soheilhy/cmux"
+)
+
+func ServeMultiplexed(ln net.Listener, handler http.Handler, certPath, keyPath string, httpServer *http.Server) error {
+	m := cmux.New(ln)
+
+	tlsL := m.Match(cmux.TLS())
+	httpL := m.Match(cmux.Any())
+
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		logging.LogErrorf("failed to load TLS cert for multiplexing: %s", err)
+		return err
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	tlsListener := tls.NewListener(tlsL, tlsConfig)
+
+	if httpServer == nil {
+		httpServer = &http.Server{Handler: handler}
+	} else {
+		httpServer.Handler = handler
+	}
+
+	httpsServer := &http.Server{Handler: handler}
+
+	go func() {
+		if serveErr := httpServer.Serve(httpL); serveErr != nil && serveErr != cmux.ErrListenerClosed && !errors.Is(serveErr, http.ErrServerClosed) {
+			logging.LogErrorf("multiplexed HTTP server error: %s", serveErr)
+		}
+	}()
+
+	go func() {
+		if serveErr := httpsServer.Serve(tlsListener); serveErr != nil && serveErr != cmux.ErrListenerClosed && !errors.Is(serveErr, http.ErrServerClosed) {
+			logging.LogErrorf("multiplexed HTTPS server error: %s", serveErr)
+		}
+	}()
+
+	return m.Serve()
+}


### PR DESCRIPTION
 * Until now, the TLS would only work via the fixed port proxy, which isn't used on mobile devices.
 * Move the logic for the multiplexer out of the fixed port logic
 * Use the newly moved multiplexer logic for the regular server as well, whenever the fixed port and the server port match.

## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] New feature
      新功能  
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature or bug fix, please submit an issue first. After full community discussion, we will decide whether to implement the change. Do not submit code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突