### PR TITLE
Make version checking optional

### DIFF
--- a/app/appearance/langs/en_US.json
+++ b/app/appearance/langs/en_US.json
@@ -641,6 +641,8 @@
   "clear": "Clear",
   "autoDownloadUpdatePkg": "Automatically download update installation package",
   "autoDownloadUpdatePkgTip": "When enabled, it will automatically check the version update every two hours. If there is an updated version, it will automatically download the installation package and prompt for installation",
+  "autoUpdateCheck": "Enable automatic update checks",
+  "autoUpdateCheckTip": "Periodically check for new versions, bazaar changes, and announcements in the background.",
   "downloaded": "Downloaded",
   "allOp": "All operations",
   "allNotebooks": "All Notebooks",

--- a/app/appearance/langs/zh_CN.json
+++ b/app/appearance/langs/zh_CN.json
@@ -641,6 +641,8 @@
   "clear": "清空",
   "autoDownloadUpdatePkg": "自动下载更新安装包",
   "autoDownloadUpdatePkgTip": "启用后会每隔两小时自动检查版本更新，如果有更新版本则自动下载安装包并提示安装",
+  "autoUpdateCheck": "启用自动更新检查",
+  "autoUpdateCheckTip": "在后台定期检查新版本、集市变更和公告。",
   "downloaded": "已下载",
   "allOp": "所有操作",
   "allNotebooks": "所有笔记本",

--- a/app/src/config/about.ts
+++ b/app/src/config/about.ts
@@ -18,13 +18,13 @@ import {hasClosestByClassName} from "../protyle/util/hasClosest";
 export const about = {
     element: undefined as Element,
     genHTML: () => {
-        const checkUpdateHTML = window.siyuan.config.system.isMicrosoftStore ? `<div class="fn__flex b3-label config__item">
+        const checkUpdateHTML = window.siyuan.config.system.isMicrosoftStore ? `<div class="fn__flex config__item">
     <div class="fn__flex-1">
         ${window.siyuan.languages.currentVer} v${Constants.SIYUAN_VERSION}
         <span id="isInsider"></span>
         <div class="b3-label__text">${window.siyuan.languages.isMsStoreVerTip}</div>
     </div>
-</div>` : `<div class="fn__flex b3-label config__item">
+</div>` : `<div class="fn__flex config__item">
     <div class="fn__flex-1">
         ${window.siyuan.languages.currentVer} v${Constants.SIYUAN_VERSION}
         <span id="isInsider"></span>
@@ -243,7 +243,17 @@ export const about = {
         <svg><use xlink:href="#iconUpload"></use></svg>${window.siyuan.languages.export}
     </button>
 </div>
-${checkUpdateHTML}
+<div class="b3-label">
+    <label class="fn__flex config__item">
+        <div class="fn__flex-1">
+            ${window.siyuan.languages.autoUpdateCheck}
+            <div class="b3-label__text">${window.siyuan.languages.autoUpdateCheckTip}</div>
+        </div>
+        <div class="fn__space"></div>
+        <input class="b3-switch fn__flex-center" id="autoUpdateCheck" type="checkbox"${window.siyuan.config.system.autoUpdateCheck ? " checked" : ""}>
+    </label>
+    ${checkUpdateHTML}
+</div>
 <div class="fn__flex config__item  b3-label">
     <div class="fn__flex-1">
         ${window.siyuan.languages.about13}
@@ -509,6 +519,12 @@ ${checkUpdateHTML}
         downloadInstallPkgElement.addEventListener("change", () => {
             fetchPost("/api/system/setDownloadInstallPkg", {downloadInstallPkg: downloadInstallPkgElement.checked}, () => {
                 window.siyuan.config.system.downloadInstallPkg = downloadInstallPkgElement.checked;
+            });
+        });
+        const autoUpdateCheckElement = about.element.querySelector("#autoUpdateCheck") as HTMLInputElement;
+        autoUpdateCheckElement.addEventListener("change", () => {
+            fetchPost("/api/system/setAutoUpdateCheck", {autoUpdateCheck: autoUpdateCheckElement.checked}, () => {
+                window.siyuan.config.system.autoUpdateCheck = autoUpdateCheckElement.checked;
             });
         });
         /// #if !BROWSER

--- a/app/src/types/config.d.ts
+++ b/app/src/types/config.d.ts
@@ -1599,6 +1599,10 @@ declare namespace Config {
          */
         downloadInstallPkg: boolean;
         /**
+         * Whether to automatically check for updates in the background
+         */
+        autoUpdateCheck: boolean;
+        /**
          * The absolute path of the user's home directory for the current operating system user
          */
         homeDir: string;

--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -48,6 +48,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/system/importTLSCABundle", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, importTLSCABundle)
 	ginServer.Handle("POST", "/api/system/setAutoLaunch", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setAutoLaunch)
 	ginServer.Handle("POST", "/api/system/setDownloadInstallPkg", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setDownloadInstallPkg)
+	ginServer.Handle("POST", "/api/system/setAutoUpdateCheck", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setAutoUpdateCheck)
 	ginServer.Handle("POST", "/api/system/setNetworkProxy", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setNetworkProxy)
 	ginServer.Handle("POST", "/api/system/setWorkspaceDir", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setWorkspaceDir)
 	ginServer.Handle("POST", "/api/system/getWorkspaces", model.CheckAuth, getWorkspaces)

--- a/kernel/api/system.go
+++ b/kernel/api/system.go
@@ -921,6 +921,20 @@ func setDownloadInstallPkg(c *gin.Context) {
 	model.Conf.Save()
 }
 
+func setAutoUpdateCheck(c *gin.Context) {
+	ret := gulu.Ret.NewResult()
+	defer c.JSON(http.StatusOK, ret)
+
+	arg, ok := util.JsonArg(c, ret)
+	if !ok {
+		return
+	}
+
+	autoUpdateCheck := arg["autoUpdateCheck"].(bool)
+	model.Conf.System.AutoUpdateCheck = autoUpdateCheck
+	model.Conf.Save()
+}
+
 func setNetworkProxy(c *gin.Context) {
 	ret := gulu.Ret.NewResult()
 	defer c.JSON(http.StatusOK, ret)

--- a/kernel/conf/system.go
+++ b/kernel/conf/system.go
@@ -41,7 +41,8 @@ type System struct {
 	NetworkProxy    *NetworkProxy `json:"networkProxy"`
 
 	DownloadInstallPkg bool `json:"downloadInstallPkg"`
-	AutoLaunch2        int  `json:"autoLaunch2"`    // 0：不自动启动，1：自动启动，2：自动启动+隐藏主窗口
+	AutoUpdateCheck    bool `json:"autoUpdateCheck"`
+	AutoLaunch2        int  `json:"autoLaunch2"` // 0：不自动启动，1：自动启动，2：自动启动+隐藏主窗口
 	LockScreenMode     int  `json:"lockScreenMode"` // 0：手动，1：手动+跟随系统 https://github.com/siyuan-note/siyuan/issues/9087
 
 	DisabledFeatures []string `json:"disabledFeatures"`

--- a/kernel/job/cron.go
+++ b/kernel/job/cron.go
@@ -32,7 +32,6 @@ func StartCron() {
 	go every(7*time.Second, task.StatusJob)
 	go every(5*time.Second, model.SyncDataJob)
 	go every(2*time.Hour, model.StatJob)
-	go every(6*time.Hour, util.RefreshRhyResultJob, "RefreshRhyResultJob")
 	go every(2*time.Hour, model.RefreshCheckJob2H)
 	go every(6*time.Hour, model.RefreshCheckJob6H)
 	go every(3*time.Second, model.FlushUpdateRefTextRenameDocJob)

--- a/kernel/model/cloud_service.go
+++ b/kernel/model/cloud_service.go
@@ -217,11 +217,16 @@ var (
 func RefreshCheckJob2H() {
 	go refreshSubscriptionExpirationRemind()
 	go refreshUser()
-	go refreshAnnouncement()
+	if Conf.System.AutoUpdateCheck {
+		go refreshAnnouncement()
+	}
 }
 
 func RefreshCheckJob6H() {
-	go refreshCheckDownloadInstallPkg()
+	if Conf.System.AutoUpdateCheck {
+		go refreshCheckDownloadInstallPkg()
+		go util.RefreshRhyResultJob()
+	}
 }
 
 func refreshSubscriptionExpirationRemind() {

--- a/kernel/model/export.go
+++ b/kernel/model/export.go
@@ -2433,9 +2433,11 @@ func exportTree(tree *parse.Tree, wysiwyg, keepFold, avHiddenCol bool,
 	if 4 == blockRefMode {
 		// 脚注+锚点哈希模式下保持原有的全图递归逻辑
 		depth = 0
-		blockLink2Ref(ret, ret.ID, &depth)
-	} else {
-		// 锚文本块链（2）和仅锚文本（3）模式下，只在当前导出树中将块链接浅转换为块引用，不再做跨文档递归
+		visited := map[string]bool{}
+		blockLink2Ref(ret, ret.ID, &depth, visited)
+	} else if 2 != blockRefMode {
+		// 仅锚文本（3）等模式下，只在当前导出树中将块链接浅转换为块引用，不再做跨文档递归
+		// 锚文本块链（2）模式下块超链接本身已是目标格式，无需转换
 		blockLink2RefShallow(ret)
 	}
 
@@ -3217,7 +3219,12 @@ func resolveFootnotesDefs(refFootnotes *[]*refAsFootnotes, currentTree *parse.Tr
 	return
 }
 
-func blockLink2Ref(currentTree *parse.Tree, id string, depth *int) {
+func blockLink2Ref(currentTree *parse.Tree, id string, depth *int, visited map[string]bool) {
+	if visited[id] {
+		return
+	}
+	visited[id] = true
+
 	*depth++
 	if 4096 < *depth {
 		return
@@ -3237,17 +3244,17 @@ func blockLink2Ref(currentTree *parse.Tree, id string, depth *int) {
 		logging.LogErrorf("not found node [%s] in tree [%s]", b.ID, t.Root.ID)
 		return
 	}
-	blockLink2Ref0(currentTree, node, depth)
+	blockLink2Ref0(currentTree, node, depth, visited)
 	if ast.NodeHeading == node.Type {
 		children := treenode.HeadingChildren(node)
 		for _, c := range children {
-			blockLink2Ref0(currentTree, c, depth)
+			blockLink2Ref0(currentTree, c, depth, visited)
 		}
 	}
 	return
 }
 
-func blockLink2Ref0(currentTree *parse.Tree, node *ast.Node, depth *int) {
+func blockLink2Ref0(currentTree *parse.Tree, node *ast.Node, depth *int, visited map[string]bool) {
 	ast.Walk(node, func(n *ast.Node, entering bool) ast.WalkStatus {
 		if !entering {
 			return ast.WalkContinue
@@ -3258,11 +3265,11 @@ func blockLink2Ref0(currentTree *parse.Tree, node *ast.Node, depth *int) {
 			n.TextMarkBlockRefID = strings.TrimPrefix(n.TextMarkAHref, "siyuan://blocks/")
 			n.TextMarkBlockRefSubtype = "s"
 
-			blockLink2Ref(currentTree, n.TextMarkBlockRefID, depth)
+			blockLink2Ref(currentTree, n.TextMarkBlockRefID, depth, visited)
 			return ast.WalkSkipChildren
 		} else if treenode.IsBlockRef(n) {
 			defID, _, _ := treenode.GetBlockRef(n)
-			blockLink2Ref(currentTree, defID, depth)
+			blockLink2Ref(currentTree, defID, depth, visited)
 		}
 		return ast.WalkContinue
 	})


### PR DESCRIPTION
Add an opt-in toggle in Settings > About to enable background version checks, bazaar refreshes, and announcements. Off by default. No behavior change for existing users unless they turn it on.