### PR TITLE
Fix infinite recursion and redundant conversion in blockLink2Ref

### DIFF
--- a/kernel/model/export.go
+++ b/kernel/model/export.go
@@ -2433,9 +2433,11 @@ func exportTree(tree *parse.Tree, wysiwyg, keepFold, avHiddenCol bool,
 	if 4 == blockRefMode {
 		// 脚注+锚点哈希模式下保持原有的全图递归逻辑
 		depth = 0
-		blockLink2Ref(ret, ret.ID, &depth)
-	} else {
-		// 锚文本块链（2）和仅锚文本（3）模式下，只在当前导出树中将块链接浅转换为块引用，不再做跨文档递归
+		visited := map[string]bool{}
+		blockLink2Ref(ret, ret.ID, &depth, visited)
+	} else if 2 != blockRefMode {
+		// 仅锚文本（3）等模式下，只在当前导出树中将块链接浅转换为块引用，不再做跨文档递归
+		// 锚文本块链（2）模式下块超链接本身已是目标格式，无需转换
 		blockLink2RefShallow(ret)
 	}
 
@@ -3217,7 +3219,12 @@ func resolveFootnotesDefs(refFootnotes *[]*refAsFootnotes, currentTree *parse.Tr
 	return
 }
 
-func blockLink2Ref(currentTree *parse.Tree, id string, depth *int) {
+func blockLink2Ref(currentTree *parse.Tree, id string, depth *int, visited map[string]bool) {
+	if visited[id] {
+		return
+	}
+	visited[id] = true
+
 	*depth++
 	if 4096 < *depth {
 		return
@@ -3237,17 +3244,17 @@ func blockLink2Ref(currentTree *parse.Tree, id string, depth *int) {
 		logging.LogErrorf("not found node [%s] in tree [%s]", b.ID, t.Root.ID)
 		return
 	}
-	blockLink2Ref0(currentTree, node, depth)
+	blockLink2Ref0(currentTree, node, depth, visited)
 	if ast.NodeHeading == node.Type {
 		children := treenode.HeadingChildren(node)
 		for _, c := range children {
-			blockLink2Ref0(currentTree, c, depth)
+			blockLink2Ref0(currentTree, c, depth, visited)
 		}
 	}
 	return
 }
 
-func blockLink2Ref0(currentTree *parse.Tree, node *ast.Node, depth *int) {
+func blockLink2Ref0(currentTree *parse.Tree, node *ast.Node, depth *int, visited map[string]bool) {
 	ast.Walk(node, func(n *ast.Node, entering bool) ast.WalkStatus {
 		if !entering {
 			return ast.WalkContinue
@@ -3258,11 +3265,11 @@ func blockLink2Ref0(currentTree *parse.Tree, node *ast.Node, depth *int) {
 			n.TextMarkBlockRefID = strings.TrimPrefix(n.TextMarkAHref, "siyuan://blocks/")
 			n.TextMarkBlockRefSubtype = "s"
 
-			blockLink2Ref(currentTree, n.TextMarkBlockRefID, depth)
+			blockLink2Ref(currentTree, n.TextMarkBlockRefID, depth, visited)
 			return ast.WalkSkipChildren
 		} else if treenode.IsBlockRef(n) {
 			defID, _, _ := treenode.GetBlockRef(n)
-			blockLink2Ref(currentTree, defID, depth)
+			blockLink2Ref(currentTree, defID, depth, visited)
 		}
 		return ast.WalkContinue
 	})


### PR DESCRIPTION
## Description / 描述

Fixes two bugs in `blockLink2Ref` (used in footnote+anchor hash export mode, `blockRefMode=4`).

**1. Infinite / exponential recursion across documents**
`blockLink2Ref` recursively follows every block ref and block link across documents. With circular references (doc A → doc B → doc A), the only guard was a depth counter capped at 4096, causing O(4096) wasted iterations for every cycle. The traversal was also re-processing the same blocks many times in non-cyclic graphs.

Fix: add a `visited map[string]bool` per export call. Each block ID is processed at most once, making the traversal linear in the number of unique referenced blocks.

**2. Redundant round-trip for `blockRefMode=2` (anchor text block link)**
`blockLink2RefShallow` converted block hyperlinks → block refs, then the main walk's `case 2` immediately converted all block refs back → block hyperlinks. A full round-trip with no net effect.

Fix: skip `blockLink2RefShallow` for `blockRefMode=2`. Block hyperlinks are already in the target format and pass through the main walk unchanged.

Closes #17193
Related to #17178

## Type of change / 变更类型

- [x] Bug fix缺陷修复
- [x] Refactoring代码重构

## Checklist / 检查清单

- [x] I have performed a self-review of my own code我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflictsPR 提交到 `dev` 分支，并且没有合并冲突