### PR TITLE
Broadcast ws-main setBlockAttrs event after API call

### DIFF
--- a/kernel/model/blockial.go
+++ b/kernel/model/blockial.go
@@ -133,6 +133,7 @@ func BatchSetBlockAttrs(blockAttrs []map[string]interface{}) (err error) {
 
 		cache.PutBlockIAL(node.ID, parse.IAL2Map(node.KramdownIAL))
 		pushBroadcastAttrTransactions(oldAttrs, node)
+		util.PushSetBlockAttrs(node.ID, tree.Root.ID)
 		nodes = append(nodes, node)
 	}
 
@@ -182,6 +183,7 @@ func setNodeAttrs(node *ast.Node, tree *parse.Tree, nameValues map[string]string
 	cache.PutBlockIAL(node.ID, parse.IAL2Map(node.KramdownIAL))
 
 	pushBroadcastAttrTransactions(oldAttrs, node)
+	util.PushSetBlockAttrs(node.ID, tree.Root.ID)
 
 	go func() {
 		sql.FlushQueue()

--- a/kernel/util/websocket.go
+++ b/kernel/util/websocket.go
@@ -285,6 +285,10 @@ func PushReloadDoc(rootID string) {
 	BroadcastByType("main", "reloaddoc", 0, "", rootID)
 }
 
+func PushSetBlockAttrs(id, rootID string) {
+	BroadcastByType("main", "setBlockAttrs", 0, "", map[string]interface{}{"id": id, "rootID": rootID})
+}
+
 func PushSaveDoc(rootID, typ string, sources interface{}) {
 	evt := NewCmdResult("savedoc", 0, PushModeBroadcast)
 	evt.Data = map[string]interface{}{


### PR DESCRIPTION
## Description / 描述

Closes #17179

After a successful `/api/attr/setBlockAttrs` or `/api/attr/batchSetBlockAttrs` call, the kernel now broadcasts a `setBlockAttrs` event to all `ws-main` sessions.

Payload:
```json
{ "id": "<blockID>", "rootID": "<rootDocID>" }
```

Plugins can listen via:
```js
eventBus.on('ws-main', (e) => {
  if (e.detail?.cmd === 'setBlockAttrs') {
    const { id, rootID } = e.detail.data;
    // refresh plugin UI
  }
});
```

This gives plugins a stable, dedicated event for attribute changes — independent of the editor's `transactions` pipeline which is scoped to `ws-protyle` consumers.

## Type of change / 变更类型

- [x] New feature新功能

## Checklist / 检查清单

- [x] I have performed a self-review of my own code我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflictsPR 提交到 `dev` 分支，并且没有合并冲突