### PR TITLE
Add kernel API `/api/setting/setTheme`

### DIFF
--- a/kernel/api/router.go
+++ b/kernel/api/router.go
@@ -374,6 +374,7 @@ func ServeAPI(ginServer *gin.Engine) {
 	ginServer.Handle("POST", "/api/setting/setSearch", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setSearch)
 	ginServer.Handle("POST", "/api/setting/setKeymap", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setKeymap)
 	ginServer.Handle("POST", "/api/setting/setAppearance", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setAppearance)
+	ginServer.Handle("POST", "/api/setting/setTheme", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, setTheme)
 	ginServer.Handle("POST", "/api/setting/getCloudUser", model.CheckAuth, getCloudUser)
 	ginServer.Handle("POST", "/api/setting/logoutCloudUser", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, logoutCloudUser)
 	ginServer.Handle("POST", "/api/setting/login2faCloudUser", model.CheckAuth, model.CheckAdminRole, model.CheckReadonly, login2faCloudUser)

--- a/kernel/api/setting.go
+++ b/kernel/api/setting.go
@@ -561,6 +561,61 @@ func setAppearance(c *gin.Context) {
 	util.BroadcastByType("main", "setAppearance", 0, "", model.Conf.Appearance)
 }
 
+func setTheme(c *gin.Context) {
+	ret := gulu.Ret.NewResult()
+	defer c.JSON(http.StatusOK, ret)
+
+	arg, ok := util.JsonArg(c, ret)
+	if !ok {
+		return
+	}
+
+	themeName, ok := arg["theme"].(string)
+	if !ok || themeName == "" {
+		ret.Code = -1
+		ret.Msg = "theme is required"
+		return
+	}
+
+	modesRaw, ok := arg["modes"].([]interface{})
+	if !ok || len(modesRaw) == 0 {
+		ret.Code = -1
+		ret.Msg = "modes is required ([0] for light, [1] for dark, [0,1] for both)"
+		return
+	}
+
+	var modes []int
+	seen := map[int]bool{}
+	for _, m := range modesRaw {
+		mf, isMf := m.(float64)
+		if !isMf {
+			ret.Code = -1
+			ret.Msg = "modes values must be integers"
+			return
+		}
+		mi := int(mf)
+		if mi != 0 && mi != 1 {
+			ret.Code = -1
+			ret.Msg = "modes values must be 0 (light) or 1 (dark)"
+			return
+		}
+		if !seen[mi] {
+			modes = append(modes, mi)
+			seen[mi] = true
+		}
+	}
+
+	if errMsg := model.SetTheme(themeName, modes); errMsg != "" {
+		ret.Code = -1
+		ret.Msg = errMsg
+		return
+	}
+
+	model.InitAppearance()
+	ret.Data = model.Conf.Appearance
+	util.BroadcastByType("main", "setAppearance", 0, "", model.Conf.Appearance)
+}
+
 func setPublish(c *gin.Context) {
 	ret := gulu.Ret.NewResult()
 	defer c.JSON(http.StatusOK, ret)

--- a/kernel/model/appearance.go
+++ b/kernel/model/appearance.go
@@ -68,6 +68,40 @@ func InitAppearance() {
 	util.InitEmojiChars()
 }
 
+// SetTheme applies themeName to the slot(s) identified by modes (0 = light, 1 = dark).
+// It validates that the theme is available for each requested mode using the already-loaded
+// theme lists, then updates Conf. Call InitAppearance() after to persist and broadcast.
+// Returns a non-empty error message on failure.
+func SetTheme(themeName string, modes []int) string {
+	Conf.m.Lock()
+	defer Conf.m.Unlock()
+
+	for _, mode := range modes {
+		if mode == 0 {
+			if !containTheme(themeName, Conf.Appearance.LightThemes) {
+				return "theme not available for light mode: " + themeName
+			}
+		} else {
+			if !containTheme(themeName, Conf.Appearance.DarkThemes) {
+				return "theme not available for dark mode: " + themeName
+			}
+		}
+	}
+
+	for _, mode := range modes {
+		if mode == 0 {
+			Conf.Appearance.ThemeLight = themeName
+		} else {
+			Conf.Appearance.ThemeDark = themeName
+		}
+	}
+	// Only switch the active mode when targeting a single slot
+	if len(modes) == 1 {
+		Conf.Appearance.Mode = modes[0]
+	}
+	return ""
+}
+
 func containTheme(name string, themes []*conf.AppearanceTheme) bool {
 	for _, t := range themes {
 		if t.Name == name {


### PR DESCRIPTION
## Summary

Adds `POST /api/setting/setTheme` — a minimal endpoint for activating a theme by name and mode, without requiring the caller to fetch and re-POST the entire appearance config blob.

## Request

```json
POST /api/setting/setTheme
{ "theme": "<theme-dir-name>", "mode": 0 }
```

| Field | Type | Description |
|-------|------|-------------|
| `theme` | string | Theme directory name (e.g. `"midnight"`, `"my-theme"`) |
| `mode` | int | `0` = light, `1` = dark |

## Response

Returns the full `Appearance` config (same shape as `/api/setting/setAppearance`), `code: 0` on success.

## Behaviour

1. Sets both `ThemeLight` **and** `ThemeDark` to the supplied theme name
2. Sets `Mode`
3. Calls `InitAppearance()` — validates the theme exists, reads `themeVer` from `theme.json`
4. Saves `conf.json`
5. Broadcasts `setAppearance` WebSocket event → all open windows reload the theme CSS with the new `?v=<themeVer>` cache-buster

## Motivation

External tools (OS-level theme switchers, scripts, plugins) that want to activate a theme currently must:

1. `GET /api/system/getConf` to fetch the full appearance blob
2. Patch `themeLight`, `themeDark`, `mode` fields
3. `POST /api/setting/setAppearance` the entire mutated blob

This endpoint reduces that to a single self-contained call with no `jq` or JSON manipulation required.