### PR TITLE
feat: enable Local File System sync provider on Android

### DIFF
--- a/app/src/config/repos.ts
+++ b/app/src/config/repos.ts
@@ -185,11 +185,9 @@ const renderProvider = (provider: number) => {
     </button>
 </div>`;
     } else if (provider === 4) {
+        const isUnsupportedMobile = ["ios", "harmony"].includes(window.siyuan.config.system.container);
         return `<div class="b3-label b3-label--inner">
-    <div class="ft__error">
-        ${window.siyuan.languages.mobileNotSupport}
-    </div>
-    <div class="fn__hr"></div>
+    ${isUnsupportedMobile ? `<div class="ft__error">${window.siyuan.languages.mobileNotSupport}</div><div class="fn__hr"></div>` : ""}
     ${window.siyuan.languages.syncThirdPartyProviderLocalIntro}
     <div class="fn__hr"></div>
     <em>${window.siyuan.languages.proFeature}</em>
@@ -424,7 +422,7 @@ export const repos = {
         <option value="0" ${window.siyuan.config.sync.provider === 0 ? "selected" : ""}>SiYuan</option>
         <option value="2" ${window.siyuan.config.sync.provider === 2 ? "selected" : ""}>S3</option>
         <option value="3" ${window.siyuan.config.sync.provider === 3 ? "selected" : ""}>WebDAV</option>
-        <option class="${!["std", "docker"].includes(window.siyuan.config.system.container) ? "fn__none" : ""}" value="4" ${window.siyuan.config.sync.provider === 4 ? "selected" : ""}>${window.siyuan.languages.localFileSystem}</option>
+        <option class="${["ios", "harmony"].includes(window.siyuan.config.system.container) ? "fn__none" : ""}" value="4" ${window.siyuan.config.sync.provider === 4 ? "selected" : ""}>${window.siyuan.languages.localFileSystem}</option>
     </select>
 </div>
 <div id="syncProviderPanel" class="b3-label">


### PR DESCRIPTION
## Problem

The `Local File System` sync provider option (`provider: 4`) is hidden on all non-`std`/`docker` containers via `fn__none`, blocking Android users from selecting it. The kernel-side `SetSyncProviderLocal` has **no platform restrictions** — it only validates that the endpoint path exists and is not inside the workspace.

Additionally, the provider 4 config panel unconditionally rendered a `ft__error` `mobileNotSupport` banner on **all** platforms including desktop, which is a separate bug.

## Why Android should have access

Android exposes a real, writable filesystem hierarchy. Paths like:
- `/storage/emulated/0/SiYuan-sync/` — internal storage
- `/storage/<USB-OTG-uuid>/SiYuan-sync/` — USB-OTG drive

…are valid and accessible. This makes Local provider genuinely useful for:
- **Manual USB sync** between an Android device and a Linux/Windows machine — plug in USB, trigger sync on each end, no cloud required.
- Pointing both devices at the same NAS-mounted or Syncthing-managed folder without needing S3/WebDAV credentials.

iOS and HarmonyOS lack accessible external filesystem mount points in the same way, so they remain restricted.

## Changes

### `app/src/config/repos.ts`

**1. Dropdown option** — was hidden on all non-std/docker (including Android), now only hidden on ios/harmony:

```diff
- class="${!["std", "docker"].includes(window.siyuan.config.system.container) ? "fn__none" : ""}"
+ class="${["ios", "harmony"].includes(window.siyuan.config.system.container) ? "fn__none" : ""}"
```

**2. Provider 4 config panel** — `mobileNotSupport` error banner is now conditional on ios/harmony only (also fixes it appearing on desktop):

```diff
- <div class="ft__error">
-     ${window.siyuan.languages.mobileNotSupport}
- </div>
- <div class="fn__hr"></div>
+ ${isUnsupportedMobile ? `<div class="ft__error">${window.siyuan.languages.mobileNotSupport}</div><div class="fn__hr"></div>` : ""}
```

No kernel changes required.
