### PR TITLE
Use the did-finish-load event as a fallback for when the ready-to-show event fails to trigger

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -482,26 +482,13 @@ const initMainWindow = () => {
         cb({responseHeaders: details.responseHeaders});
     });
 
-    currentWindow.webContents.on("did-finish-load", () => {
-        let siyuanOpenURL = process.argv.find((arg) => arg.startsWith("siyuan://"));
-        if (siyuanOpenURL) {
-            if (currentWindow.isMinimized()) {
-                currentWindow.restore();
-            }
-            currentWindow.show();
-            setTimeout(() => { // 等待界面js执行完毕
-                writeLog(siyuanOpenURL);
-                currentWindow.webContents.send("siyuan-open-url", siyuanOpenURL);
-            }, 2000);
+    let mainShown = false;
+    const showMainWindowOnce = (reason) => {
+        if (mainShown || !currentWindow || currentWindow.isDestroyed()) {
+            return;
         }
-    });
-
-    if (windowState.isDevToolsOpened) {
-        currentWindow.webContents.openDevTools({mode: "bottom"});
-    }
-
-    // 主界面事件监听
-    currentWindow.once("ready-to-show", () => {
+        mainShown = true;
+        writeLog("show main window [" + reason + "]");
         if (isOpenAsHidden()) {
             currentWindow.minimize();
         } else {
@@ -514,7 +501,44 @@ const initMainWindow = () => {
         }
         if (bootWindow && !bootWindow.isDestroyed()) {
             bootWindow.destroy();
+            writeLog("destroy boot window");
         }
+    };
+
+    currentWindow.webContents.on("did-finish-load", () => {
+        let siyuanOpenURL = process.argv.find((arg) => arg.startsWith("siyuan://"));
+        if (siyuanOpenURL) {
+            if (currentWindow.isMinimized()) {
+                currentWindow.restore();
+            }
+            currentWindow.show();
+            setTimeout(() => { // 等待界面js执行完毕
+                writeLog(siyuanOpenURL);
+                currentWindow.webContents.send("siyuan-open-url", siyuanOpenURL);
+            }, 2000);
+        }
+
+        if (!mainShown) {
+            // 页面已经加载完成，但 ready-to-show 事件无法触发、未显示主窗口 https://github.com/siyuan-note/siyuan/issues/17212
+            setTimeout(() => {
+                if (currentWindow && !currentWindow.isDestroyed() && !currentWindow.isVisible()) {
+                    showMainWindowOnce("did-finish-load");
+                }
+            }, 1000);
+        }
+    });
+
+    currentWindow.webContents.on("did-fail-load", (_event, errorCode, errorDesc, url) => {
+        writeLog("main window did-fail-load, code=" + errorCode + ", desc=" + errorDesc + ", url=" + url);
+    });
+
+    if (windowState.isDevToolsOpened) {
+        currentWindow.webContents.openDevTools({mode: "bottom"});
+    }
+
+    // 主界面事件监听
+    currentWindow.once("ready-to-show", () => {
+        showMainWindowOnce("ready-to-show");
     });
 
     // 菜单


### PR DESCRIPTION
## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

fix https://github.com/siyuan-note/siyuan/issues/17212

我在 Windows 和 Mac 上测试可以正常通过 ready-to-show 事件启动。

用户测试可以通过 did-finish-load 事件启动。

## Type of change / 变更类型

<!--
A PR should only have one purpose, such as never putting multiple changes like refactoring, feature improvement, or bug fixes in one PR, otherwise the PR will be rejected.
一个 PR 应该只包含一个目的，比如切勿将重构、功能改进或者修复缺陷等多个变更放在一个 PR 中，否则提交将被拒。
-->

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突