### PR TITLE
Remove duplicate data-type attribute tags when converting inline elements to text

### DIFF
--- a/app/src/protyle/toolbar/util.ts
+++ b/app/src/protyle/toolbar/util.ts
@@ -66,20 +66,14 @@ export const removeSearchMark = (element: HTMLElement) => {
 };
 
 export const removeInlineType = (inlineElement: HTMLElement, type: string, range?: Range) => {
-    const types = inlineElement.getAttribute("data-type").split(" ");
-    if (types.length === 1) {
+    const types = (inlineElement.getAttribute("data-type") || "").split(" ").filter((item) => item !== "" && item !== type);
+    if (types.length === 0) {
         const linkParentElement = inlineElement.parentElement;
         inlineElement.outerHTML = inlineElement.innerHTML.replace(Constants.ZWSP, "") + "<wbr>";
         if (range) {
             focusByWbr(linkParentElement, range);
         }
     } else {
-        types.find((itemType, index) => {
-            if (type === itemType) {
-                types.splice(index, 1);
-                return true;
-            }
-        });
         inlineElement.setAttribute("data-type", types.join(" "));
         if (type === "a") {
             inlineElement.removeAttribute("data-href");


### PR DESCRIPTION


## Description / 描述

改为通过 .filter() 得到非该类型的标记

- item !== type：行级元素转换文本时去除重复的 data-type 类型标记 fix https://github.com/siyuan-note/siyuan/issues/17292
- item !== ""：处理了 `data-type="a "` 这种有多余空格的情况

## Type of change / 变更类型

<!--
A PR should only have one purpose, such as never putting multiple changes like refactoring, feature improvement, or bug fixes in one PR, otherwise the PR will be rejected.
一个 PR 应该只包含一个目的，比如切勿将重构、功能改进或者修复缺陷等多个变更放在一个 PR 中，否则提交将被拒。
-->

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突