### PR TITLE
fix(Inbox): 修复收集箱翻页按钮隐藏时间距异常

### DIFF
--- a/app/src/layout/dock/Inbox.ts
+++ b/app/src/layout/dock/Inbox.ts
@@ -395,13 +395,17 @@ ${data.shorthandContent}
             const nextElement = this.element.querySelector('[data-type="next"]');
             if (response.data.data.pagination.paginationPageCount > this.currentPage) {
                 nextElement.removeAttribute("disabled");
+                nextElement.classList.remove("fn__none");
             } else {
                 nextElement.setAttribute("disabled", "disabled");
+                nextElement.classList.add("fn__none");
             }
             if (this.currentPage === 1) {
                 previousElement.setAttribute("disabled", "disabled");
+                previousElement.classList.add("fn__none");
             } else {
                 previousElement.removeAttribute("disabled");
+                previousElement.classList.remove("fn__none");
             }
             const selectCount = this.element.lastElementChild.querySelectorAll(".b3-list-item").length;
             this.element.firstElementChild.querySelector('[data-type="selectall"] use').setAttribute("xlink:href", (this.element.lastElementChild.querySelectorAll('[*|href="#iconCheck"]').length === selectCount && selectCount !== 0) ? "#iconCheck" : "#iconUncheck");

--- a/app/src/protyle/wysiwyg/getBlock.ts
+++ b/app/src/protyle/wysiwyg/getBlock.ts
@@ -168,17 +168,10 @@ export const getTopAloneElement = (topSourceElement: Element) => {
                 break;
             }
         }
-    } else if (topSourceElement.parentElement.classList.contains("callout-content") &&
-        topSourceElement.parentElement.childElementCount === 1) {
-        while (topSourceElement.parentElement && !topSourceElement.parentElement.classList.contains("protyle-wysiwyg")) {
-            if (topSourceElement.parentElement.classList.contains("callout-content") &&
-                topSourceElement.parentElement.childElementCount === 1) {
-                topSourceElement = topSourceElement.parentElement.parentElement;
-            } else {
-                topSourceElement = getTopAloneElement(topSourceElement);
-                break;
-            }
-        }
+    } else if (topSourceElement.parentElement.classList.contains("callout-content")) {
+        // When inside callout-content, always return the callout block itself
+        // This prevents the callout from being deleted when dragging internal blocks
+        return topSourceElement.parentElement.parentElement;
     } else if ("NodeSuperBlock" === topSourceElement.parentElement.getAttribute("data-type") && topSourceElement.parentElement.childElementCount === 2) {
         while (topSourceElement.parentElement && !topSourceElement.parentElement.classList.contains("protyle-wysiwyg")) {
             if (topSourceElement.parentElement.getAttribute("data-type") === "NodeSuperBlock" && topSourceElement.parentElement.childElementCount === 2) {


### PR DESCRIPTION
修复 Issue #17458: 收集箱翻页按钮不显示时，间距比较奇怪

当翻页按钮被禁用时，添加 fn__none 类来隐藏按钮，避免占用空间导致间距异常。