### PR TITLE
fix(callout): 修复提示块内拖拽块时整个块消失的问题

### DIFF
--- a/app/src/layout/dock/Inbox.ts
+++ b/app/src/layout/dock/Inbox.ts
@@ -395,13 +395,17 @@ ${data.shorthandContent}
             const nextElement = this.element.querySelector('[data-type="next"]');
             if (response.data.data.pagination.paginationPageCount > this.currentPage) {
                 nextElement.removeAttribute("disabled");
+                nextElement.classList.remove("fn__none");
             } else {
                 nextElement.setAttribute("disabled", "disabled");
+                nextElement.classList.add("fn__none");
             }
             if (this.currentPage === 1) {
                 previousElement.setAttribute("disabled", "disabled");
+                previousElement.classList.add("fn__none");
             } else {
                 previousElement.removeAttribute("disabled");
+                previousElement.classList.remove("fn__none");
             }
             const selectCount = this.element.lastElementChild.querySelectorAll(".b3-list-item").length;
             this.element.firstElementChild.querySelector('[data-type="selectall"] use').setAttribute("xlink:href", (this.element.lastElementChild.querySelectorAll('[*|href="#iconCheck"]').length === selectCount && selectCount !== 0) ? "#iconCheck" : "#iconUncheck");

--- a/app/src/protyle/wysiwyg/getBlock.ts
+++ b/app/src/protyle/wysiwyg/getBlock.ts
@@ -168,17 +168,10 @@ export const getTopAloneElement = (topSourceElement: Element) => {
                 break;
             }
         }
-    } else if (topSourceElement.parentElement.classList.contains("callout-content") &&
-        topSourceElement.parentElement.childElementCount === 1) {
-        while (topSourceElement.parentElement && !topSourceElement.parentElement.classList.contains("protyle-wysiwyg")) {
-            if (topSourceElement.parentElement.classList.contains("callout-content") &&
-                topSourceElement.parentElement.childElementCount === 1) {
-                topSourceElement = topSourceElement.parentElement.parentElement;
-            } else {
-                topSourceElement = getTopAloneElement(topSourceElement);
-                break;
-            }
-        }
+    } else if (topSourceElement.parentElement.classList.contains("callout-content")) {
+        // When inside callout-content, always return the callout block itself
+        // This prevents the callout from being deleted when dragging internal blocks
+        return topSourceElement.parentElement.parentElement;
     } else if ("NodeSuperBlock" === topSourceElement.parentElement.getAttribute("data-type") && topSourceElement.parentElement.childElementCount === 2) {
         while (topSourceElement.parentElement && !topSourceElement.parentElement.classList.contains("protyle-wysiwyg")) {
             if (topSourceElement.parentElement.getAttribute("data-type") === "NodeSuperBlock" && topSourceElement.parentElement.childElementCount === 2) {


### PR DESCRIPTION
## 修复 Issue #17467

### 问题描述
在提示块(callout)内拖拽块时，整个提示块会消失。

### 根本原因
getTopAloneElement() 函数中，对 callout-content 的处理逻辑存在问题。原代码只在 callout-content 有 1 个子元素时返回 callout 块本身。

### 修复方案
当元素位于 callout-content 内时，直接返回 callout 块本身，防止在拖拽操作中被错误删除。