### PR TITLE
fix(Inbox): hide disabled pagination buttons properly

### DIFF
--- a/app/src/layout/dock/Inbox.ts
+++ b/app/src/layout/dock/Inbox.ts
@@ -395,13 +395,17 @@ ${data.shorthandContent}
             const nextElement = this.element.querySelector('[data-type="next"]');
             if (response.data.data.pagination.paginationPageCount > this.currentPage) {
                 nextElement.removeAttribute("disabled");
+                nextElement.classList.remove("fn__none");
             } else {
                 nextElement.setAttribute("disabled", "disabled");
+                nextElement.classList.add("fn__none");
             }
             if (this.currentPage === 1) {
                 previousElement.setAttribute("disabled", "disabled");
+                previousElement.classList.add("fn__none");
             } else {
                 previousElement.removeAttribute("disabled");
+                previousElement.classList.remove("fn__none");
             }
             const selectCount = this.element.lastElementChild.querySelectorAll(".b3-list-item").length;
             this.element.firstElementChild.querySelector('[data-type="selectall"] use').setAttribute("xlink:href", (this.element.lastElementChild.querySelectorAll('[*|href="#iconCheck"]').length === selectCount && selectCount !== 0) ? "#iconCheck" : "#iconUncheck");


### PR DESCRIPTION
<!-- Please provide a clear and concise description of the change -->

Fix Issue #17458: 收集箱翻页按钮不显示时，间距比较奇怪

<!-- Why is this change necessary? -->

当翻页按钮被禁用时，仅设置 disabled 属性无法隐藏按钮，导致间距显示异常。

<!-- What does this change do? -->

当 paginationPageCount <= currentPage 或 currentPage === 1 时，添加 fn__none class 隐藏对应的翻页按钮。

<!-- Testing performed -->

1. 打开收集箱
2. 在只有一页时，验证翻页按钮是否被隐藏
3. 验证间距是否正常