### PR TITLE
fix(callout): prevent callout block from disappearing when dragging internal blocks

### DIFF
--- a/app/src/protyle/wysiwyg/getBlock.ts
+++ b/app/src/protyle/wysiwyg/getBlock.ts
@@ -168,17 +168,10 @@ export const getTopAloneElement = (topSourceElement: Element) => {
                 break;
             }
         }
-    } else if (topSourceElement.parentElement.classList.contains("callout-content") &&
-        topSourceElement.parentElement.childElementCount === 1) {
-        while (topSourceElement.parentElement && !topSourceElement.parentElement.classList.contains("protyle-wysiwyg")) {
-            if (topSourceElement.parentElement.classList.contains("callout-content") &&
-                topSourceElement.parentElement.childElementCount === 1) {
-                topSourceElement = topSourceElement.parentElement.parentElement;
-            } else {
-                topSourceElement = getTopAloneElement(topSourceElement);
-                break;
-            }
-        }
+    } else if (topSourceElement.parentElement.classList.contains("callout-content")) {
+        // When inside callout-content, always return the callout block itself
+        // This prevents the callout from being deleted when dragging internal blocks
+        return topSourceElement.parentElement.parentElement;
     } else if ("NodeSuperBlock" === topSourceElement.parentElement.getAttribute("data-type") && topSourceElement.parentElement.childElementCount === 2) {
         while (topSourceElement.parentElement && !topSourceElement.parentElement.classList.contains("protyle-wysiwyg")) {
             if (topSourceElement.parentElement.getAttribute("data-type") === "NodeSuperBlock" && topSourceElement.parentElement.childElementCount === 2) {


### PR DESCRIPTION
<!-- Please provide a clear and concise description of the change -->

Fix Issue #17467: 提示块内拖拽块之后整个块消失

<!-- Why is this change necessary? -->

在提示块(callout)内拖拽块时，整个提示块会消失。

<!-- What does this change do? -->

修复 getTopAloneElement() 函数对 callout-content 的处理逻辑。原代码只在 callout-content 有 1 个子元素时返回 callout 块本身。修复后，只要元素位于 callout-content 内，就直接返回 callout 块本身。

<!-- Testing performed -->

1. 创建一个包含多个块的提示块
2. 在提示块内拖拽其中一个块
3. 验证提示块不会消失