### PR TITLE
Feature/font selector improvements

### DIFF
--- a/app/src/assets/scss/base.scss
+++ b/app/src/assets/scss/base.scss
@@ -24,6 +24,7 @@
 @use "component/typography" as *;
 @use "pdf/pdf" as *;
 @use "business/config" as *;
+@use "business/fontSelector" as *;
 @use "business/search" as *;
 @use "pickr/pcr" as *;
 @use "viewerjs/viewer" as *;

--- a/app/src/assets/scss/business/_fontSelector.scss
+++ b/app/src/assets/scss/business/_fontSelector.scss
@@ -185,7 +185,7 @@
         transition: all 0.12s ease;
         overflow: hidden;
 
-        &--hovered {
+        &:hover {
             background: var(--b3-theme-surface-variant);
         }
 

--- a/app/src/assets/scss/business/_fontSelector.scss
+++ b/app/src/assets/scss/business/_fontSelector.scss
@@ -118,7 +118,7 @@
 
     &__recent {
         flex-shrink: 0;
-        max-height: 30%;
+        max-height: 108px;
         overflow: hidden;
 
         &-list {
@@ -126,6 +126,8 @@
             display: flex;
             flex-wrap: wrap;
             gap: 6px;
+            max-height: 108px;
+            overflow: hidden;
         }
     }
 
@@ -181,6 +183,7 @@
         border-radius: 6px;
         cursor: pointer;
         transition: all 0.12s ease;
+        overflow: hidden;
 
         &--hovered {
             background: var(--b3-theme-surface-variant);
@@ -203,12 +206,14 @@
         font-size: 14px;
         color: var(--b3-theme-on-surface);
         line-height: 1.4;
+        overflow: hidden;
+        word-break: break-all;
 
         mark {
-            background: var(--b3-theme-primary-lightest);
-            color: var(--b3-theme-primary);
+            background: var(--b3-theme-secondary-lightest);
+            color: var(--b3-theme-secondary);
             border-radius: 2px;
-            padding: 0 2px;
+            padding: 1px 2px;
         }
     }
 

--- a/app/src/assets/scss/business/_fontSelector.scss
+++ b/app/src/assets/scss/business/_fontSelector.scss
@@ -1,0 +1,260 @@
+.font-selector {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    font-family: var(--b3-font-family);
+
+    &__search {
+        padding: 16px 20px 12px;
+        flex-shrink: 0;
+    }
+
+    &__search-wrapper {
+        position: relative;
+        display: flex;
+        align-items: center;
+    }
+
+    &__search-icon {
+        position: absolute;
+        left: 12px;
+        width: 16px;
+        height: 16px;
+        color: var(--b3-theme-on-surface-variant);
+        pointer-events: none;
+        opacity: 0.6;
+    }
+
+    &__search-input {
+        width: 100%;
+        height: 40px;
+        padding: 0 40px 0 40px;
+        border: 1px solid var(--b3-border-color);
+        border-radius: 8px;
+        background: var(--b3-theme-surface);
+        color: var(--b3-theme-on-surface);
+        font-size: 14px;
+        outline: none;
+        transition: border-color 0.2s, box-shadow 0.2s;
+
+        &::placeholder {
+            color: var(--b3-theme-on-surface-variant);
+            opacity: 0.6;
+        }
+
+        &:focus {
+            border-color: var(--b3-theme-primary);
+            box-shadow: 0 0 0 3px var(--b3-theme-primary-lightest);
+        }
+    }
+
+    &__clear-btn {
+        position: absolute;
+        right: 8px;
+        width: 28px;
+        height: 28px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        background: transparent;
+        color: var(--b3-theme-on-surface-variant);
+        cursor: pointer;
+        border-radius: 4px;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s, background-color 0.2s;
+
+        svg {
+            width: 14px;
+            height: 14px;
+        }
+
+        &:hover {
+            background: var(--b3-theme-surface-variant);
+        }
+
+        &--visible {
+            opacity: 1;
+            pointer-events: auto;
+        }
+    }
+
+    &__section-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 20px 6px;
+        color: var(--b3-theme-on-surface-variant);
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+    }
+
+    &__section-icon {
+        width: 12px;
+        height: 12px;
+        opacity: 0.7;
+    }
+
+    &__count {
+        margin-left: auto;
+        font-size: 11px;
+        opacity: 0.5;
+        font-weight: 400;
+        text-transform: none;
+        letter-spacing: 0;
+    }
+
+    &__divider {
+        height: 1px;
+        margin: 4px 20px 8px;
+        background: var(--b3-border-color);
+        opacity: 0.5;
+    }
+
+    &__recent {
+        flex-shrink: 0;
+        max-height: 30%;
+        overflow: hidden;
+
+        &-list {
+            padding: 4px 12px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+    }
+
+    &__recent-item {
+        padding: 6px 12px;
+        border-radius: 6px;
+        background: var(--b3-theme-surface);
+        border: 1px solid var(--b3-border-color);
+        cursor: pointer;
+        transition: all 0.15s ease;
+
+        &:hover {
+            background: var(--b3-theme-surface-variant);
+        }
+    }
+
+    &__all {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    &__list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 4px 12px 12px;
+
+        &::-webkit-scrollbar {
+            width: 6px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background: var(--b3-theme-surface-variant);
+            border-radius: 3px;
+
+            &:hover {
+                background: var(--b3-theme-on-surface-variant);
+            }
+        }
+    }
+
+    &__item {
+        display: flex;
+        align-items: center;
+        padding: 10px 12px;
+        margin: 2px 0;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: all 0.12s ease;
+
+        &--hovered {
+            background: var(--b3-theme-surface-variant);
+        }
+
+        &--selected {
+            background: var(--b3-theme-primary-lightest);
+
+            .font-selector__font-name {
+                color: var(--b3-theme-primary);
+            }
+        }
+
+        &:active {
+            transform: scale(0.98);
+        }
+    }
+
+    &__font-name {
+        font-size: 14px;
+        color: var(--b3-theme-on-surface);
+        line-height: 1.4;
+
+        mark {
+            background: var(--b3-theme-primary-lightest);
+            color: var(--b3-theme-primary);
+            border-radius: 2px;
+            padding: 0 2px;
+        }
+    }
+
+    &__empty {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 40px 20px;
+        color: var(--b3-theme-on-surface-variant);
+        font-size: 13px;
+        opacity: 0.6;
+    }
+
+    &__loading {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        display: flex;
+        gap: 6px;
+
+        &-dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--b3-theme-primary);
+            animation: font-selector-loading 1.2s ease-in-out infinite;
+
+            &:nth-child(2) {
+                animation-delay: 0.2s;
+            }
+
+            &:nth-child(3) {
+                animation-delay: 0.4s;
+            }
+        }
+    }
+}
+
+@keyframes font-selector-loading {
+    0%, 80%, 100% {
+        transform: scale(0.8);
+        opacity: 0.4;
+    }
+    40% {
+        transform: scale(1.2);
+        opacity: 1;
+    }
+}

--- a/app/src/config/editor.ts
+++ b/app/src/config/editor.ts
@@ -10,7 +10,7 @@ import {updateHotkeyTip} from "../protyle/util/compatibility";
 import {Constants} from "../constants";
 import {resize} from "../protyle/util/resize";
 import {setReadOnly} from "./util/setReadOnly";
-import {Menu} from "../plugin/Menu";
+import {openFontSelector} from "./util/FontSelector";
 
 export const editor = {
     element: undefined as Element,
@@ -435,41 +435,13 @@ export const editor = {
 
         const fontFamilyElement = editor.element.querySelector("#fontFamily") as HTMLSelectElement;
         fontFamilyElement.addEventListener("click", () => {
-            fetchPost("/api/system/getSysFonts", {}, (response) => {
-                const fontMenu = new Menu();
-                fontMenu.addItem({
-                    iconHTML: "",
-                    checked: window.siyuan.config.editor.fontFamily === "",
-                    label: `<div style='var(--b3-font-family);'>${window.siyuan.languages.default}</div>`,
-                    click: () => {
-                        if ("" === window.siyuan.config.editor.fontFamily) {
-                            return;
-                        }
-                        fontFamilyElement.value = "";
-                        fontFamilyElement.style.fontFamily = "";
-                        setEditor();
-                    }
-                });
-                response.data.forEach((item: string) => {
-                    fontMenu.addItem({
-                        iconHTML: "",
-                        checked: window.siyuan.config.editor.fontFamily === item,
-                        label: `<div style='font-family:"${item}",var(--b3-font-family);'>${item}</div>`,
-                        click: () => {
-                            if (item === window.siyuan.config.editor.fontFamily) {
-                                return;
-                            }
-                            fontFamilyElement.value = item;
-                            fontFamilyElement.style.fontFamily = item + ",var(--b3-font-family)";
-                            setEditor();
-                        }
-                    });
-                });
-                const rect = fontFamilyElement.getBoundingClientRect();
-                fontMenu.open({
-                    x: rect.left,
-                    y: rect.bottom
-                });
+            openFontSelector(window.siyuan.config.editor.fontFamily, window.siyuan.config.editor.recentFonts, (font) => {
+                if (font === window.siyuan.config.editor.fontFamily) {
+                    return;
+                }
+                fontFamilyElement.value = font;
+                fontFamilyElement.style.fontFamily = font ? font + ",var(--b3-font-family)" : "";
+                setEditor();
             });
         });
 

--- a/app/src/config/util/FontSelector.ts
+++ b/app/src/config/util/FontSelector.ts
@@ -14,17 +14,15 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
         const index = lowerText.indexOf(lowerSearch);
         if (index === -1) return text;
         return text.substring(0, index) +
-            "<mark style='background-color: var(--b3-theme-primary-lightest); color: inherit;'>" +
-            text.substring(index, index + search.length) +
-            "</mark>" +
-            text.substring(index + search.length);
+            "<mark>" + text.substring(index, index + search.length) +
+            "</mark>" + text.substring(index + search.length);
     };
 
     const renderFontList = (container: HTMLElement, fonts: string[], startIndex: number = 0) => {
         container.innerHTML = "";
         if (fonts.length === 0) {
-            container.innerHTML = `<div class="b3-list-item--readonly fn__flex-center" style="padding: 24px; opacity: 0.6; cursor: default">
-                <span>${window.siyuan.languages.empty || "无结果"}</span>
+            container.innerHTML = `<div class="font-selector__empty">
+                <span>${window.siyuan.languages.empty || "无匹配字体"}</span>
             </div>`;
             return;
         }
@@ -32,75 +30,81 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
             const item = document.createElement("div");
             const isSelected = font === currentFont;
             const isHighlighted = index === selectedIndex;
-            item.className = "b3-list-item" + (isSelected ? " b3-list-item--focus" : "") + (isHighlighted ? " b3-list-item--current" : "");
+            item.className = "font-selector__item" +
+                (isSelected ? " font-selector__item--selected" : "") +
+                (isHighlighted && !isSelected ? " font-selector__item--hovered" : "");
             item.setAttribute("data-index", (startIndex + index).toString());
-            item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${highlightText(font, searchValue)}</span>
-                ${isSelected ? '<svg style="width: 16px; height: 16px; margin-left: auto; color: var(--b3-theme-primary);"><use xlink:href="#iconCheck"></use></svg>' : ""}`;
+            item.innerHTML = `<span class="font-selector__font-name" style="font-family:'${font}',var(--b3-font-family)">${highlightText(font, searchValue)}</span>`;
             item.addEventListener("click", () => {
                 dialog.destroy();
                 callback(font);
             });
             item.addEventListener("mouseenter", () => {
                 selectedIndex = startIndex + index;
-                updateSelection();
+                updateSelection(container, startIndex);
             });
             container.appendChild(item);
         });
     };
 
-    const updateSelection = () => {
-        const items = allFontsList.querySelectorAll(".b3-list-item");
+    const updateSelection = (container: HTMLElement, startIndex: number) => {
+        const items = container.querySelectorAll(".font-selector__item");
         items.forEach((item, index) => {
-            item.classList.toggle("b3-list-item--current", index === selectedIndex);
+            const itemIndex = startIndex + index;
+            const isCurrentSelected = itemIndex === selectedIndex;
+            item.classList.toggle("font-selector__item--hovered", isCurrentSelected && !item.classList.contains("font-selector__item--selected"));
         });
-        if (selectedIndex >= 0 && selectedIndex < items.length) {
-            items[selectedIndex].scrollIntoView({block: "nearest", behavior: "smooth"});
+        if (selectedIndex >= 0 && selectedIndex >= startIndex && selectedIndex < startIndex + items.length) {
+            const targetItem = items[selectedIndex - startIndex];
+            if (targetItem) {
+                targetItem.scrollIntoView({block: "nearest", behavior: "smooth"});
+            }
         }
     };
 
     const dialog = new Dialog({
         title: window.siyuan.languages.font,
-        content: `<div class="fn__flex-column" style="height: 100%">
-    <div class="b3-form__icon" style="padding: 8px 16px; position: relative;">
-        <svg class="b3-form__icon-icon"><use xlink:href="#iconSearch"></use></svg>
-        <input class="b3-text-field fn__block b3-form__icon-input" id="fontSearch" placeholder="${window.siyuan.languages.search}" style="padding-right: 32px">
-        <svg id="clearSearch" class="b3-form__icon-icon fn__pointer" style="position: absolute; right: 16px; top: 50%; transform: translateY(-50%); opacity: 0.5; display: none;"><use xlink:href="#iconCloseRound"></use></svg>
-    </div>
-    <div class="fn__hr--b" style="margin: 0"></div>
-    <div class="fn__flex-1" style="overflow: hidden">
-        <div class="fn__flex-column" style="height: 100%; overflow: hidden">
-            <div id="recentFontsContainer" class="fn__none" style="flex: 0 0 auto; max-height: 30%; overflow: auto; padding: 8px 0;">
-                <div class="b3-list-item--readonly" style="padding: 8px 16px 4px; opacity: 0.7; cursor: default; display: flex; align-items: center; gap: 4px;">
-                    <svg style="width: 14px; height: 14px; color: var(--b3-theme-primary);"><use xlink:href="#iconStar"></use></svg>
-                    <span class="b3-list-item__text">${window.siyuan.languages.recentItems || "最近使用"}</span>
-                    <span id="recentCount" style="opacity: 0.5; font-size: 12px;"></span>
+        content: `<div class="font-selector">
+            <div class="font-selector__search">
+                <div class="font-selector__search-wrapper">
+                    <svg class="font-selector__search-icon"><use xlink:href="#iconSearch"></use></svg>
+                    <input class="font-selector__search-input" id="fontSearch" placeholder="${window.siyuan.languages.search}" autocomplete="off" spellcheck="false">
+                    <button class="font-selector__clear-btn" id="clearSearch">
+                        <svg><use xlink:href="#iconCloseRound"></use></svg>
+                    </button>
                 </div>
-                <div id="recentFontsList" style="padding: 0 8px;"></div>
             </div>
-            <div id="allFontsContainer" style="flex: 1; overflow: auto; padding: 8px 0;">
-                <div class="b3-list-item--readonly" style="padding: 8px 16px 4px; opacity: 0.7; cursor: default; display: flex; align-items: center; gap: 4px;">
-                    <svg style="width: 14px; height: 14px;"><use xlink:href="#iconFont"></use></svg>
-                    <span class="b3-list-item__text">${window.siyuan.languages.allItems || "全部字体"} (<span id="fontCount">0</span>)</span>
+            <div class="font-selector__recent" id="recentFontsContainer">
+                <div class="font-selector__section-header">
+                    <svg class="font-selector__section-icon"><use xlink:href="#iconStar"></use></svg>
+                    <span class="font-selector__section-title">${window.siyuan.languages.recentItems || "最近"}</span>
                 </div>
-                <div id="allFontsList" style="padding: 0 8px;"></div>
+                <div class="font-selector__recent-list" id="recentFontsList"></div>
             </div>
-            <div id="loadingState" class="fn__flex-center" style="flex: 1; opacity: 0.6;">
-                <span>${window.siyuan.languages.loading || "加载中..."}</span>
+            <div class="font-selector__divider"></div>
+            <div class="font-selector__all" id="allFontsContainer">
+                <div class="font-selector__section-header">
+                    <svg class="font-selector__section-icon"><use xlink:href="#iconFont"></use></svg>
+                    <span class="font-selector__section-title">${window.siyuan.languages.allItems || "全部"}</span>
+                    <span class="font-selector__count" id="fontCount">0</span>
+                </div>
+                <div class="font-selector__list" id="allFontsList"></div>
             </div>
-        </div>
-    </div>
-</div>`,
-        width: "520px",
-        height: "480px",
+            <div class="font-selector__loading" id="loadingState">
+                <div class="font-selector__loading-dot"></div>
+                <div class="font-selector__loading-dot"></div>
+                <div class="font-selector__loading-dot"></div>
+            </div>
+        </div>`,
+        width: "480px",
+        height: "520px",
     });
 
     const searchInput = dialog.element.querySelector("#fontSearch") as HTMLInputElement;
     const clearSearchBtn = dialog.element.querySelector("#clearSearch") as HTMLElement;
     const recentFontsContainer = dialog.element.querySelector("#recentFontsContainer") as HTMLElement;
     const recentFontsList = dialog.element.querySelector("#recentFontsList") as HTMLElement;
-    const recentCount = dialog.element.querySelector("#recentCount") as HTMLElement;
     const allFontsList = dialog.element.querySelector("#allFontsList") as HTMLElement;
-    const allFontsContainer = dialog.element.querySelector("#allFontsContainer") as HTMLElement;
     const fontCount = dialog.element.querySelector("#fontCount") as HTMLElement;
     const loadingState = dialog.element.querySelector("#loadingState") as HTMLElement;
 
@@ -114,21 +118,21 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
     const showRecentFonts = () => {
         if (recentFonts.length > 0) {
             recentFontsContainer.classList.remove("fn__none");
-            recentCount.textContent = `(${recentFonts.length})`;
             recentFontsList.innerHTML = "";
             recentFonts.forEach((font) => {
                 const item = document.createElement("div");
                 const isSelected = font === currentFont;
-                item.className = "b3-list-item" + (isSelected ? " b3-list-item--focus" : "");
-                item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${font}</span>
-                    ${isSelected ? '<svg style="width: 16px; height: 16px; margin-left: auto; color: var(--b3-theme-primary);"><use xlink:href="#iconCheck"></use></svg>' : ""}`;
+                item.className = "font-selector__recent-item" + (isSelected ? " font-selector__item--selected" : "");
+                item.innerHTML = `<span class="font-selector__font-name" style="font-family:'${font}',var(--b3-font-family)">${font}</span>`;
                 item.addEventListener("click", () => {
                     dialog.destroy();
                     callback(font);
                 });
                 item.addEventListener("mouseenter", () => {
-                    recentFontsList.querySelectorAll(".b3-list-item").forEach(el => el.classList.remove("b3-list-item--current"));
-                    item.classList.add("b3-list-item--current");
+                    recentFontsList.querySelectorAll(".font-selector__recent-item").forEach(el => el.classList.remove("font-selector__item--hovered"));
+                    if (!item.classList.contains("font-selector__item--selected")) {
+                        item.classList.add("font-selector__item--hovered");
+                    }
                 });
                 recentFontsList.appendChild(item);
             });
@@ -139,14 +143,14 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
 
     searchInput.addEventListener("input", (e) => {
         searchValue = (e.target as HTMLInputElement).value;
-        clearSearchBtn.style.display = searchValue ? "block" : "none";
+        clearSearchBtn.classList.toggle("font-selector__clear-btn--visible", searchValue.length > 0);
         filterFonts();
     });
 
     clearSearchBtn.addEventListener("click", () => {
         searchInput.value = "";
         searchValue = "";
-        clearSearchBtn.style.display = "none";
+        clearSearchBtn.classList.remove("font-selector__clear-btn--visible");
         filterFonts();
         searchInput.focus();
     });
@@ -157,16 +161,16 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
             const maxIndex = filteredFonts.length - 1;
             if (selectedIndex < maxIndex) {
                 selectedIndex++;
-                updateSelection();
-            } else if (selectedIndex === -1) {
+                updateSelection(allFontsList, 0);
+            } else if (selectedIndex === -1 && maxIndex >= 0) {
                 selectedIndex = 0;
-                updateSelection();
+                updateSelection(allFontsList, 0);
             }
         } else if (e.key === "ArrowUp") {
             e.preventDefault();
             if (selectedIndex > 0) {
                 selectedIndex--;
-                updateSelection();
+                updateSelection(allFontsList, 0);
             }
         } else if (e.key === "Enter" && selectedIndex >= 0 && selectedIndex < filteredFonts.length) {
             e.preventDefault();
@@ -176,17 +180,6 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
         } else if (e.key === "Escape") {
             dialog.destroy();
         }
-    });
-
-    allFontsContainer.addEventListener("scroll", () => {
-        const containerRect = allFontsContainer.getBoundingClientRect();
-        const items = allFontsList.querySelectorAll(".b3-list-item");
-        items.forEach((item, index) => {
-            const itemRect = item.getBoundingClientRect();
-            if (itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom) {
-                selectedIndex = index;
-            }
-        });
     });
 
     fetchPost("/api/system/getSysFonts", {}, (response) => {

--- a/app/src/config/util/FontSelector.ts
+++ b/app/src/config/util/FontSelector.ts
@@ -86,7 +86,11 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
         items.forEach((item, index) => {
             const itemIndex = startIndex + index;
             const isCurrentSelected = itemIndex === selectedIndex;
-            item.classList.toggle("font-selector__item--hovered", isCurrentSelected && !item.classList.contains("font-selector__item--selected"));
+            if (isCurrentSelected) {
+                item.classList.add("font-selector__item--hovered");
+            } else {
+                item.classList.remove("font-selector__item--hovered");
+            }
         });
         if (selectedIndex >= 0 && selectedIndex >= startIndex && selectedIndex < startIndex + items.length) {
             const targetItem = items[selectedIndex - startIndex];

--- a/app/src/config/util/FontSelector.ts
+++ b/app/src/config/util/FontSelector.ts
@@ -7,45 +7,85 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
     let filteredFonts: string[] = [];
     let selectedIndex = -1;
 
+    const highlightText = (text: string, search: string): string => {
+        if (!search) return text;
+        const lowerText = text.toLowerCase();
+        const lowerSearch = search.toLowerCase();
+        const index = lowerText.indexOf(lowerSearch);
+        if (index === -1) return text;
+        return text.substring(0, index) +
+            "<mark style='background-color: var(--b3-theme-primary-lightest); color: inherit;'>" +
+            text.substring(index, index + search.length) +
+            "</mark>" +
+            text.substring(index + search.length);
+    };
+
     const renderFontList = (container: HTMLElement, fonts: string[], startIndex: number = 0) => {
         container.innerHTML = "";
+        if (fonts.length === 0) {
+            container.innerHTML = `<div class="b3-list-item--readonly fn__flex-center" style="padding: 24px; opacity: 0.6; cursor: default">
+                <span>${window.siyuan.languages.empty || "无结果"}</span>
+            </div>`;
+            return;
+        }
         fonts.forEach((font, index) => {
             const item = document.createElement("div");
-            item.className = "b3-list-item" + (font === currentFont ? " b3-list-item--focus" : "");
+            const isSelected = font === currentFont;
+            const isHighlighted = index === selectedIndex;
+            item.className = "b3-list-item" + (isSelected ? " b3-list-item--focus" : "") + (isHighlighted ? " b3-list-item--current" : "");
             item.setAttribute("data-index", (startIndex + index).toString());
-            item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${font}</span>`;
+            item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${highlightText(font, searchValue)}</span>
+                ${isSelected ? '<svg style="width: 16px; height: 16px; margin-left: auto; color: var(--b3-theme-primary);"><use xlink:href="#iconCheck"></use></svg>' : ""}`;
             item.addEventListener("click", () => {
                 dialog.destroy();
                 callback(font);
+            });
+            item.addEventListener("mouseenter", () => {
+                selectedIndex = startIndex + index;
+                updateSelection();
             });
             container.appendChild(item);
         });
     };
 
+    const updateSelection = () => {
+        const items = allFontsList.querySelectorAll(".b3-list-item");
+        items.forEach((item, index) => {
+            item.classList.toggle("b3-list-item--current", index === selectedIndex);
+        });
+        if (selectedIndex >= 0 && selectedIndex < items.length) {
+            items[selectedIndex].scrollIntoView({block: "nearest", behavior: "smooth"});
+        }
+    };
+
     const dialog = new Dialog({
         title: window.siyuan.languages.font,
         content: `<div class="fn__flex-column" style="height: 100%">
-    <div class="b3-form__icon" style="padding: 8px 16px;">
+    <div class="b3-form__icon" style="padding: 8px 16px; position: relative;">
         <svg class="b3-form__icon-icon"><use xlink:href="#iconSearch"></use></svg>
-        <input class="b3-text-field fn__block b3-form__icon-input" id="fontSearch" placeholder="${window.siyuan.languages.search}" style="padding-right: 0">
+        <input class="b3-text-field fn__block b3-form__icon-input" id="fontSearch" placeholder="${window.siyuan.languages.search}" style="padding-right: 32px">
+        <svg id="clearSearch" class="b3-form__icon-icon fn__pointer" style="position: absolute; right: 16px; top: 50%; transform: translateY(-50%); opacity: 0.5; display: none;"><use xlink:href="#iconCloseRound"></use></svg>
     </div>
     <div class="fn__hr--b" style="margin: 0"></div>
     <div class="fn__flex-1" style="overflow: hidden">
         <div class="fn__flex-column" style="height: 100%; overflow: hidden">
             <div id="recentFontsContainer" class="fn__none" style="flex: 0 0 auto; max-height: 30%; overflow: auto; padding: 8px 0;">
-                <div class="fn__hr--b" style="margin: 0 16px 8px"></div>
-                <div class="b3-list-item--readonly" style="padding: 4px 16px; opacity: 0.6; cursor: default">
-                    <svg style="width: 16px; height: 16px; margin-right: 4px"><use xlink:href="#iconHistory"></use></svg>
+                <div class="b3-list-item--readonly" style="padding: 8px 16px 4px; opacity: 0.7; cursor: default; display: flex; align-items: center; gap: 4px;">
+                    <svg style="width: 14px; height: 14px; color: var(--b3-theme-primary);"><use xlink:href="#iconStar"></use></svg>
                     <span class="b3-list-item__text">${window.siyuan.languages.recentItems || "最近使用"}</span>
+                    <span id="recentCount" style="opacity: 0.5; font-size: 12px;"></span>
                 </div>
                 <div id="recentFontsList" style="padding: 0 8px;"></div>
             </div>
             <div id="allFontsContainer" style="flex: 1; overflow: auto; padding: 8px 0;">
-                <div class="fn__hr--b" style="margin: 0 16px 8px"></div>
-                <div class="b3-list-item--readonly" style="padding: 4px 16px; opacity: 0.6; cursor: default">
+                <div class="b3-list-item--readonly" style="padding: 8px 16px 4px; opacity: 0.7; cursor: default; display: flex; align-items: center; gap: 4px;">
+                    <svg style="width: 14px; height: 14px;"><use xlink:href="#iconFont"></use></svg>
                     <span class="b3-list-item__text">${window.siyuan.languages.allItems || "全部字体"} (<span id="fontCount">0</span>)</span>
                 </div>
                 <div id="allFontsList" style="padding: 0 8px;"></div>
+            </div>
+            <div id="loadingState" class="fn__flex-center" style="flex: 1; opacity: 0.6;">
+                <span>${window.siyuan.languages.loading || "加载中..."}</span>
             </div>
         </div>
     </div>
@@ -55,11 +95,14 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
     });
 
     const searchInput = dialog.element.querySelector("#fontSearch") as HTMLInputElement;
+    const clearSearchBtn = dialog.element.querySelector("#clearSearch") as HTMLElement;
     const recentFontsContainer = dialog.element.querySelector("#recentFontsContainer") as HTMLElement;
     const recentFontsList = dialog.element.querySelector("#recentFontsList") as HTMLElement;
+    const recentCount = dialog.element.querySelector("#recentCount") as HTMLElement;
     const allFontsList = dialog.element.querySelector("#allFontsList") as HTMLElement;
     const allFontsContainer = dialog.element.querySelector("#allFontsContainer") as HTMLElement;
     const fontCount = dialog.element.querySelector("#fontCount") as HTMLElement;
+    const loadingState = dialog.element.querySelector("#loadingState") as HTMLElement;
 
     const filterFonts = () => {
         filteredFonts = searchValue ? allFonts.filter(f => f.toLowerCase().includes(searchValue.toLowerCase())) : allFonts;
@@ -71,14 +114,21 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
     const showRecentFonts = () => {
         if (recentFonts.length > 0) {
             recentFontsContainer.classList.remove("fn__none");
+            recentCount.textContent = `(${recentFonts.length})`;
             recentFontsList.innerHTML = "";
             recentFonts.forEach((font) => {
                 const item = document.createElement("div");
-                item.className = "b3-list-item" + (font === currentFont ? " b3-list-item--focus" : "");
-                item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${font}</span>`;
+                const isSelected = font === currentFont;
+                item.className = "b3-list-item" + (isSelected ? " b3-list-item--focus" : "");
+                item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${font}</span>
+                    ${isSelected ? '<svg style="width: 16px; height: 16px; margin-left: auto; color: var(--b3-theme-primary);"><use xlink:href="#iconCheck"></use></svg>' : ""}`;
                 item.addEventListener("click", () => {
                     dialog.destroy();
                     callback(font);
+                });
+                item.addEventListener("mouseenter", () => {
+                    recentFontsList.querySelectorAll(".b3-list-item").forEach(el => el.classList.remove("b3-list-item--current"));
+                    item.classList.add("b3-list-item--current");
                 });
                 recentFontsList.appendChild(item);
             });
@@ -89,25 +139,58 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
 
     searchInput.addEventListener("input", (e) => {
         searchValue = (e.target as HTMLInputElement).value;
+        clearSearchBtn.style.display = searchValue ? "block" : "none";
         filterFonts();
+    });
+
+    clearSearchBtn.addEventListener("click", () => {
+        searchInput.value = "";
+        searchValue = "";
+        clearSearchBtn.style.display = "none";
+        filterFonts();
+        searchInput.focus();
     });
 
     searchInput.addEventListener("keydown", (e) => {
         if (e.key === "ArrowDown") {
             e.preventDefault();
-            selectedIndex = Math.min(selectedIndex + 1, filteredFonts.length - 1);
+            const maxIndex = filteredFonts.length - 1;
+            if (selectedIndex < maxIndex) {
+                selectedIndex++;
+                updateSelection();
+            } else if (selectedIndex === -1) {
+                selectedIndex = 0;
+                updateSelection();
+            }
         } else if (e.key === "ArrowUp") {
             e.preventDefault();
-            selectedIndex = Math.max(selectedIndex - 1, 0);
-        } else if (e.key === "Enter" && selectedIndex >= 0) {
+            if (selectedIndex > 0) {
+                selectedIndex--;
+                updateSelection();
+            }
+        } else if (e.key === "Enter" && selectedIndex >= 0 && selectedIndex < filteredFonts.length) {
             e.preventDefault();
             const selectedFont = filteredFonts[selectedIndex];
             dialog.destroy();
             callback(selectedFont);
+        } else if (e.key === "Escape") {
+            dialog.destroy();
         }
     });
 
+    allFontsContainer.addEventListener("scroll", () => {
+        const containerRect = allFontsContainer.getBoundingClientRect();
+        const items = allFontsList.querySelectorAll(".b3-list-item");
+        items.forEach((item, index) => {
+            const itemRect = item.getBoundingClientRect();
+            if (itemRect.top >= containerRect.top && itemRect.bottom <= containerRect.bottom) {
+                selectedIndex = index;
+            }
+        });
+    });
+
     fetchPost("/api/system/getSysFonts", {}, (response) => {
+        loadingState.classList.add("fn__none");
         allFonts = response.data;
         filteredFonts = [...allFonts];
         fontCount.textContent = allFonts.length.toString();

--- a/app/src/config/util/FontSelector.ts
+++ b/app/src/config/util/FontSelector.ts
@@ -7,7 +7,6 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
     let searchValue = "";
     let allFonts: string[] = [];
     let filteredFonts: string[] = [];
-    let selectedIndex = -1;
 
     const highlightText = (text: string, search: string): string => {
         if (!search) return text;
@@ -32,7 +31,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
             "</mark>" + escaped.substring(index + lowerSearch.length);
     };
 
-    const renderFontList = (container: HTMLElement, fonts: string[], startIndex: number = 0) => {
+    const renderFontList = (container: HTMLElement, fonts: string[]) => {
         container.innerHTML = "";
         if (fonts.length === 0 && !searchValue) {
             container.innerHTML = `<div class="font-selector__empty">
@@ -42,62 +41,29 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
         }
 
         // Default font option (reset to empty string)
-        const isDefaultHighlighted = selectedIndex === -1 && (!searchValue || window.siyuan.languages.default.toLowerCase().includes(searchValue.toLowerCase()));
         const isDefaultSelected = currentFont === "";
         const defaultItem = document.createElement("div");
         defaultItem.className = "font-selector__item" +
-            (isDefaultSelected ? " font-selector__item--selected" : "") +
-            (isDefaultHighlighted && !isDefaultSelected ? " font-selector__item--hovered" : "");
-        defaultItem.setAttribute("data-index", "-1");
+            (isDefaultSelected ? " font-selector__item--selected" : "");
         defaultItem.innerHTML = `<span class="font-selector__font-name" style="font-family:var(--b3-font-family)">${highlightText(window.siyuan.languages.default, searchValue)}</span>`;
         defaultItem.addEventListener("click", () => {
             dialog.destroy();
             callback("");
         });
-        defaultItem.addEventListener("mouseenter", () => {
-            selectedIndex = -1;
-            updateSelection(container, -1);
-        });
         container.appendChild(defaultItem);
 
-        fonts.forEach((font, index) => {
+        fonts.forEach((font) => {
             const item = document.createElement("div");
             const isSelected = font === currentFont;
-            const isHighlighted = index === selectedIndex;
             item.className = "font-selector__item" +
-                (isSelected ? " font-selector__item--selected" : "") +
-                (isHighlighted && !isSelected ? " font-selector__item--hovered" : "");
-            item.setAttribute("data-index", (startIndex + index).toString());
+                (isSelected ? " font-selector__item--selected" : "");
             item.innerHTML = `<span class="font-selector__font-name" style="font-family:${CSS.escape(font)},var(--b3-font-family)">${escapeAndHighlight(font, searchValue)}</span>`;
             item.addEventListener("click", () => {
                 dialog.destroy();
                 callback(font);
             });
-            item.addEventListener("mouseenter", () => {
-                selectedIndex = startIndex + index;
-                updateSelection(container, startIndex);
-            });
             container.appendChild(item);
         });
-    };
-
-    const updateSelection = (container: HTMLElement, startIndex: number) => {
-        const items = container.querySelectorAll(".font-selector__item");
-        items.forEach((item, index) => {
-            const itemIndex = startIndex + index;
-            const isCurrentSelected = itemIndex === selectedIndex;
-            if (isCurrentSelected) {
-                item.classList.add("font-selector__item--hovered");
-            } else {
-                item.classList.remove("font-selector__item--hovered");
-            }
-        });
-        if (selectedIndex >= 0 && selectedIndex >= startIndex && selectedIndex < startIndex + items.length) {
-            const targetItem = items[selectedIndex - startIndex];
-            if (targetItem) {
-                targetItem.scrollIntoView({block: "nearest", behavior: "smooth"});
-            }
-        }
     };
 
     const dialog = new Dialog({
@@ -148,7 +114,6 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
 
     const filterFonts = () => {
         filteredFonts = searchValue ? allFonts.filter(f => f.toLowerCase().includes(searchValue.toLowerCase())) : allFonts;
-        selectedIndex = -1;
         renderFontList(allFontsList, filteredFonts);
         fontCount.textContent = filteredFonts.length.toString();
     };
@@ -165,12 +130,6 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
                 item.addEventListener("click", () => {
                     dialog.destroy();
                     callback(font);
-                });
-                item.addEventListener("mouseenter", () => {
-                    recentFontsList.querySelectorAll(".font-selector__recent-item").forEach(el => el.classList.remove("font-selector__item--hovered"));
-                    if (!item.classList.contains("font-selector__item--selected")) {
-                        item.classList.add("font-selector__item--hovered");
-                    }
                 });
                 recentFontsList.appendChild(item);
             });
@@ -194,42 +153,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
     });
 
     searchInput.addEventListener("keydown", (e) => {
-        if (e.key === "ArrowDown") {
-            e.preventDefault();
-            const maxIndex = filteredFonts.length - 1;
-            if (selectedIndex === -1) {
-                selectedIndex = 0;
-                updateSelection(allFontsList, 0);
-            } else if (selectedIndex < maxIndex) {
-                selectedIndex++;
-                updateSelection(allFontsList, 0);
-            } else if (selectedIndex === maxIndex) {
-                selectedIndex = -1;
-                updateSelection(allFontsList, -1);
-            }
-        } else if (e.key === "ArrowUp") {
-            e.preventDefault();
-            if (selectedIndex === -1) {
-                selectedIndex = filteredFonts.length - 1;
-                updateSelection(allFontsList, 0);
-            } else if (selectedIndex > 0) {
-                selectedIndex--;
-                updateSelection(allFontsList, 0);
-            } else if (selectedIndex === 0) {
-                selectedIndex = -1;
-                updateSelection(allFontsList, -1);
-            }
-        } else if (e.key === "Enter") {
-            e.preventDefault();
-            if (selectedIndex === -1) {
-                dialog.destroy();
-                callback("");
-            } else if (selectedIndex >= 0 && selectedIndex < filteredFonts.length) {
-                const selectedFont = filteredFonts[selectedIndex];
-                dialog.destroy();
-                callback(selectedFont);
-            }
-        } else if (e.key === "Escape") {
+        if (e.key === "Escape") {
             dialog.destroy();
         }
     });

--- a/app/src/config/util/FontSelector.ts
+++ b/app/src/config/util/FontSelector.ts
@@ -1,0 +1,118 @@
+import {fetchPost} from "../../util/fetch";
+import {Dialog} from "../../dialog";
+
+export const openFontSelector = (currentFont: string, recentFonts: string[], callback: (font: string) => void) => {
+    let searchValue = "";
+    let allFonts: string[] = [];
+    let filteredFonts: string[] = [];
+    let selectedIndex = -1;
+
+    const renderFontList = (container: HTMLElement, fonts: string[], startIndex: number = 0) => {
+        container.innerHTML = "";
+        fonts.forEach((font, index) => {
+            const item = document.createElement("div");
+            item.className = "b3-list-item" + (font === currentFont ? " b3-list-item--focus" : "");
+            item.setAttribute("data-index", (startIndex + index).toString());
+            item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${font}</span>`;
+            item.addEventListener("click", () => {
+                dialog.destroy();
+                callback(font);
+            });
+            container.appendChild(item);
+        });
+    };
+
+    const dialog = new Dialog({
+        title: window.siyuan.languages.font,
+        content: `<div class="fn__flex-column" style="height: 100%">
+    <div class="b3-form__icon" style="padding: 8px 16px;">
+        <svg class="b3-form__icon-icon"><use xlink:href="#iconSearch"></use></svg>
+        <input class="b3-text-field fn__block b3-form__icon-input" id="fontSearch" placeholder="${window.siyuan.languages.search}" style="padding-right: 0">
+    </div>
+    <div class="fn__hr--b" style="margin: 0"></div>
+    <div class="fn__flex-1" style="overflow: hidden">
+        <div class="fn__flex-column" style="height: 100%; overflow: hidden">
+            <div id="recentFontsContainer" class="fn__none" style="flex: 0 0 auto; max-height: 30%; overflow: auto; padding: 8px 0;">
+                <div class="fn__hr--b" style="margin: 0 16px 8px"></div>
+                <div class="b3-list-item--readonly" style="padding: 4px 16px; opacity: 0.6; cursor: default">
+                    <svg style="width: 16px; height: 16px; margin-right: 4px"><use xlink:href="#iconHistory"></use></svg>
+                    <span class="b3-list-item__text">${window.siyuan.languages.recentItems || "最近使用"}</span>
+                </div>
+                <div id="recentFontsList" style="padding: 0 8px;"></div>
+            </div>
+            <div id="allFontsContainer" style="flex: 1; overflow: auto; padding: 8px 0;">
+                <div class="fn__hr--b" style="margin: 0 16px 8px"></div>
+                <div class="b3-list-item--readonly" style="padding: 4px 16px; opacity: 0.6; cursor: default">
+                    <span class="b3-list-item__text">${window.siyuan.languages.allItems || "全部字体"} (<span id="fontCount">0</span>)</span>
+                </div>
+                <div id="allFontsList" style="padding: 0 8px;"></div>
+            </div>
+        </div>
+    </div>
+</div>`,
+        width: "520px",
+        height: "480px",
+    });
+
+    const searchInput = dialog.element.querySelector("#fontSearch") as HTMLInputElement;
+    const recentFontsContainer = dialog.element.querySelector("#recentFontsContainer") as HTMLElement;
+    const recentFontsList = dialog.element.querySelector("#recentFontsList") as HTMLElement;
+    const allFontsList = dialog.element.querySelector("#allFontsList") as HTMLElement;
+    const allFontsContainer = dialog.element.querySelector("#allFontsContainer") as HTMLElement;
+    const fontCount = dialog.element.querySelector("#fontCount") as HTMLElement;
+
+    const filterFonts = () => {
+        filteredFonts = searchValue ? allFonts.filter(f => f.toLowerCase().includes(searchValue.toLowerCase())) : allFonts;
+        selectedIndex = -1;
+        renderFontList(allFontsList, filteredFonts);
+        fontCount.textContent = filteredFonts.length.toString();
+    };
+
+    const showRecentFonts = () => {
+        if (recentFonts.length > 0) {
+            recentFontsContainer.classList.remove("fn__none");
+            recentFontsList.innerHTML = "";
+            recentFonts.forEach((font) => {
+                const item = document.createElement("div");
+                item.className = "b3-list-item" + (font === currentFont ? " b3-list-item--focus" : "");
+                item.innerHTML = `<span class="b3-list-item__text" style="font-family:'${font}',var(--b3-font-family)">${font}</span>`;
+                item.addEventListener("click", () => {
+                    dialog.destroy();
+                    callback(font);
+                });
+                recentFontsList.appendChild(item);
+            });
+        } else {
+            recentFontsContainer.classList.add("fn__none");
+        }
+    };
+
+    searchInput.addEventListener("input", (e) => {
+        searchValue = (e.target as HTMLInputElement).value;
+        filterFonts();
+    });
+
+    searchInput.addEventListener("keydown", (e) => {
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            selectedIndex = Math.min(selectedIndex + 1, filteredFonts.length - 1);
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            selectedIndex = Math.max(selectedIndex - 1, 0);
+        } else if (e.key === "Enter" && selectedIndex >= 0) {
+            e.preventDefault();
+            const selectedFont = filteredFonts[selectedIndex];
+            dialog.destroy();
+            callback(selectedFont);
+        }
+    });
+
+    fetchPost("/api/system/getSysFonts", {}, (response) => {
+        allFonts = response.data;
+        filteredFonts = [...allFonts];
+        fontCount.textContent = allFonts.length.toString();
+        showRecentFonts();
+        renderFontList(allFontsList, filteredFonts);
+        searchInput.focus();
+    });
+};

--- a/app/src/config/util/FontSelector.ts
+++ b/app/src/config/util/FontSelector.ts
@@ -22,7 +22,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
         container.innerHTML = "";
         if (fonts.length === 0) {
             container.innerHTML = `<div class="font-selector__empty">
-                <span>${window.siyuan.languages.empty || "无匹配字体"}</span>
+                <span>${window.siyuan.languages.emptyContent}</span>
             </div>`;
             return;
         }
@@ -77,7 +77,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
             <div class="font-selector__recent" id="recentFontsContainer">
                 <div class="font-selector__section-header">
                     <svg class="font-selector__section-icon"><use xlink:href="#iconStar"></use></svg>
-                    <span class="font-selector__section-title">${window.siyuan.languages.recentItems || "最近"}</span>
+                    <span class="font-selector__section-title">${window.siyuan.languages.recentDocs}</span>
                 </div>
                 <div class="font-selector__recent-list" id="recentFontsList"></div>
             </div>
@@ -85,7 +85,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
             <div class="font-selector__all" id="allFontsContainer">
                 <div class="font-selector__section-header">
                     <svg class="font-selector__section-icon"><use xlink:href="#iconFont"></use></svg>
-                    <span class="font-selector__section-title">${window.siyuan.languages.allItems || "全部"}</span>
+                    <span class="font-selector__section-title">${window.siyuan.languages.all}</span>
                     <span class="font-selector__count" id="fontCount">0</span>
                 </div>
                 <div class="font-selector__list" id="allFontsList"></div>

--- a/app/src/config/util/FontSelector.ts
+++ b/app/src/config/util/FontSelector.ts
@@ -1,7 +1,9 @@
 import {fetchPost} from "../../util/fetch";
 import {Dialog} from "../../dialog";
+import {escapeHtml} from "../../util/escape";
 
 export const openFontSelector = (currentFont: string, recentFonts: string[], callback: (font: string) => void) => {
+    recentFonts = recentFonts || [];
     let searchValue = "";
     let allFonts: string[] = [];
     let filteredFonts: string[] = [];
@@ -18,14 +20,46 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
             "</mark>" + text.substring(index + search.length);
     };
 
+    const escapeAndHighlight = (text: string, search: string): string => {
+        const escaped = escapeHtml(text);
+        if (!search) return escaped;
+        const lowerEscaped = escaped.toLowerCase();
+        const lowerSearch = search.toLowerCase();
+        const index = lowerEscaped.indexOf(lowerSearch);
+        if (index === -1) return escaped;
+        return escaped.substring(0, index) +
+            "<mark>" + escaped.substring(index, index + lowerSearch.length) +
+            "</mark>" + escaped.substring(index + lowerSearch.length);
+    };
+
     const renderFontList = (container: HTMLElement, fonts: string[], startIndex: number = 0) => {
         container.innerHTML = "";
-        if (fonts.length === 0) {
+        if (fonts.length === 0 && !searchValue) {
             container.innerHTML = `<div class="font-selector__empty">
                 <span>${window.siyuan.languages.emptyContent}</span>
             </div>`;
             return;
         }
+
+        // Default font option (reset to empty string)
+        const isDefaultHighlighted = selectedIndex === -1 && (!searchValue || window.siyuan.languages.default.toLowerCase().includes(searchValue.toLowerCase()));
+        const isDefaultSelected = currentFont === "";
+        const defaultItem = document.createElement("div");
+        defaultItem.className = "font-selector__item" +
+            (isDefaultSelected ? " font-selector__item--selected" : "") +
+            (isDefaultHighlighted && !isDefaultSelected ? " font-selector__item--hovered" : "");
+        defaultItem.setAttribute("data-index", "-1");
+        defaultItem.innerHTML = `<span class="font-selector__font-name" style="font-family:var(--b3-font-family)">${highlightText(window.siyuan.languages.default, searchValue)}</span>`;
+        defaultItem.addEventListener("click", () => {
+            dialog.destroy();
+            callback("");
+        });
+        defaultItem.addEventListener("mouseenter", () => {
+            selectedIndex = -1;
+            updateSelection(container, -1);
+        });
+        container.appendChild(defaultItem);
+
         fonts.forEach((font, index) => {
             const item = document.createElement("div");
             const isSelected = font === currentFont;
@@ -34,7 +68,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
                 (isSelected ? " font-selector__item--selected" : "") +
                 (isHighlighted && !isSelected ? " font-selector__item--hovered" : "");
             item.setAttribute("data-index", (startIndex + index).toString());
-            item.innerHTML = `<span class="font-selector__font-name" style="font-family:'${font}',var(--b3-font-family)">${highlightText(font, searchValue)}</span>`;
+            item.innerHTML = `<span class="font-selector__font-name" style="font-family:${CSS.escape(font)},var(--b3-font-family)">${escapeAndHighlight(font, searchValue)}</span>`;
             item.addEventListener("click", () => {
                 dialog.destroy();
                 callback(font);
@@ -97,7 +131,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
             </div>
         </div>`,
         width: "480px",
-        height: "520px",
+        height: "600px",
     });
 
     const searchInput = dialog.element.querySelector("#fontSearch") as HTMLInputElement;
@@ -123,7 +157,7 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
                 const item = document.createElement("div");
                 const isSelected = font === currentFont;
                 item.className = "font-selector__recent-item" + (isSelected ? " font-selector__item--selected" : "");
-                item.innerHTML = `<span class="font-selector__font-name" style="font-family:'${font}',var(--b3-font-family)">${font}</span>`;
+                item.innerHTML = `<span class="font-selector__font-name" style="font-family:${CSS.escape(font)},var(--b3-font-family)">${escapeHtml(font)}</span>`;
                 item.addEventListener("click", () => {
                     dialog.destroy();
                     callback(font);
@@ -159,24 +193,38 @@ export const openFontSelector = (currentFont: string, recentFonts: string[], cal
         if (e.key === "ArrowDown") {
             e.preventDefault();
             const maxIndex = filteredFonts.length - 1;
-            if (selectedIndex < maxIndex) {
-                selectedIndex++;
-                updateSelection(allFontsList, 0);
-            } else if (selectedIndex === -1 && maxIndex >= 0) {
+            if (selectedIndex === -1) {
                 selectedIndex = 0;
                 updateSelection(allFontsList, 0);
+            } else if (selectedIndex < maxIndex) {
+                selectedIndex++;
+                updateSelection(allFontsList, 0);
+            } else if (selectedIndex === maxIndex) {
+                selectedIndex = -1;
+                updateSelection(allFontsList, -1);
             }
         } else if (e.key === "ArrowUp") {
             e.preventDefault();
-            if (selectedIndex > 0) {
+            if (selectedIndex === -1) {
+                selectedIndex = filteredFonts.length - 1;
+                updateSelection(allFontsList, 0);
+            } else if (selectedIndex > 0) {
                 selectedIndex--;
                 updateSelection(allFontsList, 0);
+            } else if (selectedIndex === 0) {
+                selectedIndex = -1;
+                updateSelection(allFontsList, -1);
             }
-        } else if (e.key === "Enter" && selectedIndex >= 0 && selectedIndex < filteredFonts.length) {
+        } else if (e.key === "Enter") {
             e.preventDefault();
-            const selectedFont = filteredFonts[selectedIndex];
-            dialog.destroy();
-            callback(selectedFont);
+            if (selectedIndex === -1) {
+                dialog.destroy();
+                callback("");
+            } else if (selectedIndex >= 0 && selectedIndex < filteredFonts.length) {
+                const selectedFont = filteredFonts[selectedIndex];
+                dialog.destroy();
+                callback(selectedFont);
+            }
         } else if (e.key === "Escape") {
             dialog.destroy();
         }

--- a/app/src/types/config.d.ts
+++ b/app/src/types/config.d.ts
@@ -450,6 +450,7 @@ declare namespace Config {
          * The font used in the editor
          */
         fontFamily: string;
+        recentFonts: string[];
         /**
          * The font size used in the editor
          */

--- a/kernel/api/setting.go
+++ b/kernel/api/setting.go
@@ -329,9 +329,13 @@ func setEditor(c *gin.Context) {
 	oldVirtualBlockRefExclude := model.Conf.Editor.VirtualBlockRefExclude
 	oldReadOnly := model.Conf.Editor.ReadOnly
 
+	recentFonts := model.Conf.Editor.RecentFonts
+	if nil == recentFonts {
+		recentFonts = []string{}
+	}
+	editor.RecentFonts = make([]string, len(recentFonts))
+	copy(editor.RecentFonts, recentFonts)
 	if oldFontFamily != editor.FontFamily {
-		editor.RecentFonts = make([]string, len(model.Conf.Editor.RecentFonts))
-		copy(editor.RecentFonts, model.Conf.Editor.RecentFonts)
 		editor.AddRecentFont(editor.FontFamily)
 	}
 

--- a/kernel/api/setting.go
+++ b/kernel/api/setting.go
@@ -293,6 +293,7 @@ func setEditor(c *gin.Context) {
 	}
 
 	oldGenerateHistoryInterval := model.Conf.Editor.GenerateHistoryInterval
+	oldFontFamily := model.Conf.Editor.FontFamily
 
 	editor := conf.NewEditor()
 	if err = gulu.JSON.UnmarshalJSON(param, editor); err != nil {
@@ -327,6 +328,12 @@ func setEditor(c *gin.Context) {
 	oldVirtualBlockRefInclude := model.Conf.Editor.VirtualBlockRefInclude
 	oldVirtualBlockRefExclude := model.Conf.Editor.VirtualBlockRefExclude
 	oldReadOnly := model.Conf.Editor.ReadOnly
+
+	if oldFontFamily != editor.FontFamily {
+		editor.RecentFonts = make([]string, len(model.Conf.Editor.RecentFonts))
+		copy(editor.RecentFonts, model.Conf.Editor.RecentFonts)
+		editor.AddRecentFont(editor.FontFamily)
+	}
 
 	model.Conf.Editor = editor
 	model.Conf.Save()

--- a/kernel/conf/editor.go
+++ b/kernel/conf/editor.go
@@ -24,6 +24,7 @@ type Editor struct {
 	FontSize                        int            `json:"fontSize"`                        // 字体大小
 	FontSizeScrollZoom              bool           `json:"fontSizeScrollZoom"`              // 字体大小是否支持滚轮缩放
 	FontFamily                      string         `json:"fontFamily"`                      // 字体
+	RecentFonts                     []string       `json:"recentFonts"`                     // 最近使用的字体
 	CodeSyntaxHighlightLineNum      bool           `json:"codeSyntaxHighlightLineNum"`      // 代码块是否显示行号
 	CodeTabSpaces                   int            `json:"codeTabSpaces"`                   // 代码块中 Tab 转换空格数，配置为 0 则表示不转换
 	CodeLineWrap                    bool           `json:"codeLineWrap"`                    // 代码块是否自动折行
@@ -103,5 +104,22 @@ func NewEditor() *Editor {
 		HeadingEmbedMode:                0,
 		PasteURLAutoConvert:             false,
 		Markdown:                        util.MarkdownSettings,
+		RecentFonts:                     []string{},
+	}
+}
+
+func (e *Editor) AddRecentFont(fontFamily string) {
+	if fontFamily == "" {
+		return
+	}
+	for i, f := range e.RecentFonts {
+		if f == fontFamily {
+			e.RecentFonts = append(e.RecentFonts[:i], e.RecentFonts[i+1:]...)
+			break
+		}
+	}
+	e.RecentFonts = append([]string{fontFamily}, e.RecentFonts...)
+	if len(e.RecentFonts) > 8 {
+		e.RecentFonts = e.RecentFonts[:8]
 	}
 }


### PR DESCRIPTION
## Self-Introduction
Hello everyone, I'm Tiancheng Tan, currently a student at Duke Kunshan University!!! I'm a loyal user of Siyuan 😁, and one of the pain points I experience is the old font selector: it shows all fonts in a long menu without any search or filtering, making it tedious to find the right font. As a result, I designed and implemented a new FontSelector component with real‑time search, recent fonts tracking, and a cleaner UI to make font selection much faster and more enjoyable. （with opencode and minimax)

## Description / 描述

This PR adds a new **FontSelector** component to the editor settings that significantly improves the font selection experience:

### Problems Fixed /解决的问题
- Old font selector showed all fonts in a Menu popup without search or filtering
- Users had to scroll through dozens/hundreds of fonts to find the one they wanted
- No way to quickly access recently used fonts

### Solution / 解决方案
- Created a new FontSelector dialog with real-time search filtering
- Added "Recent Fonts" section that tracks and displays recently used fonts (persisted in config)
- Implemented keyboard navigation (Arrow keys + Enter to select)
- Complete UI/UX redesign with minimalist luxury aesthetic

### Changes / 更改内容
- **Backend (kernel/)**: Added `RecentFonts` field to Editor config struct with auto-tracking when font changes
- **Frontend (app/)**: New FontSelector component with search, recent fonts, and polished UI
- **Styling**: Dedicated `_fontSelector.scss` with refined minimalist design

### Technical Details / 技术细节
- Backend: `RecentFonts []string` stored in `kernel/conf/editor.go`, auto-populated via `AddRecentFont()` method
- Frontend: FontSelector at `app/src/config/util/FontSelector.ts` using existing Dialog component
- Max 8 recent fonts stored, newest first, duplicates removed

## Type of change / 变更类型

- [ ] Bug fix
- [ ] Refactoring
- [x] New feature
- [ ] Text updates or new language additions

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
- [x] PR is submitted to the `dev` branch and has no merge conflicts