### PR TITLE
鼠标点击两个列表项中间，光标会跳到最后一个列表项末尾

### DIFF
--- a/app/src/protyle/util/selection.ts
+++ b/app/src/protyle/util/selection.ts
@@ -639,7 +639,14 @@ export const focusByRange = (range: Range) => {
     selection.addRange(range);
 };
 
-export const focusBlock = (element: Element, parentElement?: HTMLElement, toStart = true): false | Range => {
+/**
+ * 将光标定位到指定块元素
+ * @param element - 目标块元素
+ * @param parentElement - 可选的父元素，当块内无法定位时聚焦此元素
+ * @param toStart - true: 定位到块开头; false: 定位到块末尾
+ * @param toFirstChild - 当 toStart=false 时，true: 聚焦到第一个可编辑项; false: 聚焦到最后一个可编辑项
+ */
+export const focusBlock = (element: Element, parentElement?: HTMLElement, toStart = true, toFirstChild = false): false | Range => {
     if (!element) {
         return false;
     }
@@ -704,7 +711,13 @@ export const focusBlock = (element: Element, parentElement?: HTMLElement, toStar
     if (toStart) {
         cursorElement = getContenteditableElement(element);
     } else {
-        Array.from(element.querySelectorAll('[contenteditable="true"]')).reverse().find(item => {
+        
+        let items = Array.from(element.querySelectorAll('[contenteditable="true"]'));
+        // 有时候toStart=false，但是需要聚焦到第一个可编辑项，而不是最后一个可编辑项
+        if (!toFirstChild) {
+            items = items.reverse();
+        }
+        items.find(item => {
             if (item.getBoundingClientRect().width > 0) {
                 cursorElement = item;
                 return true;

--- a/app/src/protyle/util/selection.ts
+++ b/app/src/protyle/util/selection.ts
@@ -639,14 +639,7 @@ export const focusByRange = (range: Range) => {
     selection.addRange(range);
 };
 
-/**
- * 将光标定位到指定块元素
- * @param element - 目标块元素
- * @param parentElement - 可选的父元素，当块内无法定位时聚焦此元素
- * @param toStart - true: 定位到块开头; false: 定位到块末尾
- * @param toFirstChild - 当 toStart=false 时，true: 聚焦到第一个可编辑项; false: 聚焦到最后一个可编辑项
- */
-export const focusBlock = (element: Element, parentElement?: HTMLElement, toStart = true, toFirstChild = false): false | Range => {
+export const focusBlock = (element: Element, parentElement?: HTMLElement, toStart = true): false | Range => {
     if (!element) {
         return false;
     }
@@ -711,13 +704,7 @@ export const focusBlock = (element: Element, parentElement?: HTMLElement, toStar
     if (toStart) {
         cursorElement = getContenteditableElement(element);
     } else {
-        
-        let items = Array.from(element.querySelectorAll('[contenteditable="true"]'));
-        // 有时候toStart=false，但是需要聚焦到第一个可编辑项，而不是最后一个可编辑项
-        if (!toFirstChild) {
-            items = items.reverse();
-        }
-        items.find(item => {
+        Array.from(element.querySelectorAll('[contenteditable="true"]')).reverse().find(item => {
             if (item.getBoundingClientRect().width > 0) {
                 cursorElement = item;
                 return true;

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -3235,7 +3235,7 @@ export class WYSIWYG {
                                 if (preciseBlock) {
                                     if (preciseBlock.classList.contains("list")) {
                                         // 命中 list 容器空白区，找最近 li（这里解决的是点击右侧的列表项间隙，也就是鼠标位于列表内容之中的情况）
-                                        const nearestLi = getNearestLi(blockElement, event.clientY);
+                                        const nearestLi = getNearestLi(preciseBlock, event.clientY);
                                         if (nearestLi) {
                                             blockElement = nearestLi as HTMLElement;
                                         }

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -3243,7 +3243,7 @@ export class WYSIWYG {
                                         // 命中具体 li 或其他块
                                         blockElement = preciseBlock as HTMLElement;
                                         // 命中 li 但是 li 可能有子项，此时若 toStart=false，应该聚焦到当前li，而不是他的最后一个子项
-                                        toFirstChild = true;
+                                        toFirstChild = preciseBlock.classList.contains("li");
                                     }
                                 }
                             } else {

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -3211,7 +3211,52 @@ export class WYSIWYG {
                         if (embedElement) {
                             blockElement = embedElement;
                         }
-                        newRange = focusBlock(blockElement, undefined, event.clientX < rect.left + parseInt(this.element.style.paddingLeft)) || newRange;
+
+                        // 如果是列表块（list/li），需要修正 blockElement 为最近的 li 元素，而不是 list 容器 https://github.com/siyuan-note/siyuan/issues/17604
+                        let toFirstChild = false;
+                        if (blockElement.classList.contains("list") || blockElement.classList.contains("li")) {
+                            const getNearestLi = (container: Element, clientY: number) => {
+                                const liElements = container.querySelectorAll(":scope > .li");
+                                let nearestLi: Element | null = null;
+                                let nearestDistance = Infinity;
+                                liElements.forEach(li => {
+                                    const rect = li.getBoundingClientRect();
+                                    const distance = Math.abs(rect.top + rect.height / 2 - clientY);
+                                    if (distance < nearestDistance) {
+                                        nearestDistance = distance;
+                                        nearestLi = li;
+                                    }
+                                });
+                                return nearestLi;
+                            };
+                            const preciseElement = document.elementFromPoint(event.clientX, event.clientY);
+                            if (preciseElement && preciseElement !== this.element) {
+                                const preciseBlock = hasClosestBlock(preciseElement);
+                                if (preciseBlock) {
+                                    if (preciseBlock.classList.contains("list")) {
+                                        // 命中 list 容器空白区，找最近 li（这里解决的是点击右侧的列表项间隙，也就是鼠标位于列表内容之中的情况）
+                                        const nearestLi = getNearestLi(blockElement, event.clientY);
+                                        if (nearestLi) {
+                                            blockElement = nearestLi as HTMLElement;
+                                        }
+                                    } else {
+                                        // 命中具体 li 或其他块
+                                        blockElement = preciseBlock as HTMLElement;
+                                        // 命中 li 但是 li 可能有子项，此时若 toStart=false，应该聚焦到当前li，而不是他的最后一个子项
+                                        toFirstChild = true;
+                                    }
+                                }
+                            } else {
+                                // 命中空白区域或 wysiwyg element，回退到 nearestLi（这里解决的是点击左侧的列表项间隙，也就是鼠标位于列表内容左侧的空白区的情况）
+                                const nearestLi = getNearestLi(blockElement, event.clientY);
+                                if (nearestLi) {
+                                    blockElement = nearestLi as HTMLElement;
+                                }
+                            }
+                        }
+
+                        const toStart = event.clientX < rect.left + parseInt(this.element.style.paddingLeft);
+                        newRange = focusBlock(blockElement, undefined, toStart, toFirstChild) || newRange;
                         if (protyle.options.render.breadcrumb) {
                             protyle.breadcrumb.render(protyle, false, blockElement);
                         }

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -3212,7 +3212,6 @@ export class WYSIWYG {
                             blockElement = embedElement;
                         }
 
-                        const toStart = event.clientX < rect.left + parseInt(this.element.style.paddingLeft);
                         // 如果是列表块（list/li），不修正 range https://github.com/siyuan-note/siyuan/issues/17604
                         if (blockElement.classList.contains("list") || blockElement.classList.contains("li")) {
                             if (protyle.options.render.breadcrumb) {
@@ -3222,7 +3221,7 @@ export class WYSIWYG {
                                 }
                             }
                         } else {
-                            newRange = focusBlock(blockElement, undefined, toStart) || newRange;
+                            newRange = focusBlock(blockElement, undefined, event.clientX < rect.left + parseInt(this.element.style.paddingLeft)) || newRange;
                             if (protyle.options.render.breadcrumb) {
                                 protyle.breadcrumb.render(protyle, false, blockElement);
                             }

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -3216,9 +3216,7 @@ export class WYSIWYG {
                         if (blockElement.classList.contains("list") || blockElement.classList.contains("li")) {
                             if (protyle.options.render.breadcrumb) {
                                 const breadcrumbElement = hasClosestBlock(newRange.startContainer);
-                                if (protyle.options.render.breadcrumb) {
-                                    protyle.breadcrumb.render(protyle, false, breadcrumbElement);
-                                }
+                                protyle.breadcrumb.render(protyle, false, breadcrumbElement);
                             }
                         } else {
                             newRange = focusBlock(blockElement, undefined, event.clientX < rect.left + parseInt(this.element.style.paddingLeft)) || newRange;

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -3212,53 +3212,20 @@ export class WYSIWYG {
                             blockElement = embedElement;
                         }
 
-                        // 如果是列表块（list/li），需要修正 blockElement 为最近的 li 元素，而不是 list 容器 https://github.com/siyuan-note/siyuan/issues/17604
-                        let toFirstChild = false;
+                        const toStart = event.clientX < rect.left + parseInt(this.element.style.paddingLeft);
+                        // 如果是列表块（list/li），不修正 range https://github.com/siyuan-note/siyuan/issues/17604
                         if (blockElement.classList.contains("list") || blockElement.classList.contains("li")) {
-                            const getNearestLi = (container: Element, clientY: number) => {
-                                const liElements = container.querySelectorAll(":scope > .li");
-                                let nearestLi: Element | null = null;
-                                let nearestDistance = Infinity;
-                                liElements.forEach(li => {
-                                    const rect = li.getBoundingClientRect();
-                                    const distance = Math.abs(rect.top + rect.height / 2 - clientY);
-                                    if (distance < nearestDistance) {
-                                        nearestDistance = distance;
-                                        nearestLi = li;
-                                    }
-                                });
-                                return nearestLi;
-                            };
-                            const preciseElement = document.elementFromPoint(event.clientX, event.clientY);
-                            if (preciseElement && preciseElement !== this.element) {
-                                const preciseBlock = hasClosestBlock(preciseElement);
-                                if (preciseBlock) {
-                                    if (preciseBlock.classList.contains("list")) {
-                                        // 命中 list 容器空白区，找最近 li（这里解决的是点击右侧的列表项间隙，也就是鼠标位于列表内容之中的情况）
-                                        const nearestLi = getNearestLi(preciseBlock, event.clientY);
-                                        if (nearestLi) {
-                                            blockElement = nearestLi as HTMLElement;
-                                        }
-                                    } else {
-                                        // 命中具体 li 或其他块
-                                        blockElement = preciseBlock as HTMLElement;
-                                        // 命中 li 但是 li 可能有子项，此时若 toStart=false，应该聚焦到当前li，而不是他的最后一个子项
-                                        toFirstChild = preciseBlock.classList.contains("li");
-                                    }
-                                }
-                            } else {
-                                // 命中空白区域或 wysiwyg element，回退到 nearestLi（这里解决的是点击左侧的列表项间隙，也就是鼠标位于列表内容左侧的空白区的情况）
-                                const nearestLi = getNearestLi(blockElement, event.clientY);
-                                if (nearestLi) {
-                                    blockElement = nearestLi as HTMLElement;
+                            if (protyle.options.render.breadcrumb) {
+                                const breadcrumbElement = hasClosestBlock(newRange.startContainer);
+                                if (protyle.options.render.breadcrumb) {
+                                    protyle.breadcrumb.render(protyle, false, breadcrumbElement);
                                 }
                             }
-                        }
-
-                        const toStart = event.clientX < rect.left + parseInt(this.element.style.paddingLeft);
-                        newRange = focusBlock(blockElement, undefined, toStart, toFirstChild) || newRange;
-                        if (protyle.options.render.breadcrumb) {
-                            protyle.breadcrumb.render(protyle, false, blockElement);
+                        } else {
+                            newRange = focusBlock(blockElement, undefined, toStart) || newRange;
+                            if (protyle.options.render.breadcrumb) {
+                                protyle.breadcrumb.render(protyle, false, blockElement);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

[Issue - 17604](https://github.com/siyuan-note/siyuan/issues/17604)

```ts
// app\src\protyle\wysiwyg\index.ts  3197 行
setTimeout(() => {
                // 选中后，在选中的文字上点击需等待 range 更新
                let newRange = getEditorRange(this.element);
                // 点击两侧或间隙导致光标跳转到开头 https://github.com/siyuan-note/siyuan/issues/16179
                if (hasClosestBlock(event.target) !== hasClosestBlock(newRange.startContainer) &&
                    this.element.querySelector("[data-node-id]")?.contains(newRange.startContainer)) {
                      // 省略。。
                 }
```

**触发条件**： （if 里的两个条件）

 - 点击位置（event.target）和当前光标（newRange.startContainer）在不同块
 - 当前光标在第一个 data-node 块里（这就是为什么如果标题后面有其他 data-node 不会触发这个bug。 ）

**bug 的原因**： focusBlock 函数传入的参数 blockElement 在列表项的场景下有误（点击间隙的时候，会传入 list 而非具体的一个 li），导致三种不符合预期的情况，如下表。

| 点击位置-x | 点击位置-y | bug表现 | 预期表现 |
|------------|------------|---------|----------|
| 内容区左侧，即toStart=true | 相邻子项之间的间隙 | 聚焦到第一个子项 | 聚焦到最近的子项 |
| 内容区右侧，即toStart=false | 相邻子项之间的间隙 | 聚焦到最后一个子项 | 聚焦到最近的子项 |
| 内容区左侧，即toStart=true | 父子项之间的间隙 | 无bug | 聚焦到父项 |
| 内容区右侧，即toStart=false | 父子项之间的间隙 | 聚焦到最后一个子项 | 聚焦到父项 |


第1和2种情况：

<img width="706" height="543" alt="image" src="https://github.com/user-attachments/assets/92665632-2ade-4602-99c7-273d3c1e9c64" />

第4种情况：

<img width="904" height="339" alt="image" src="https://github.com/user-attachments/assets/ff3abde1-1b83-4ecb-9d52-5fcc1d9c1837" />


**解决方式**：通过修正 blockElement 和新增 focusBlock 函数的 toFirstChild 参数，使光标修正的逻辑符合预期。

## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突