### PR TITLE
Revert "改进在首个代码块中光标的移动 "

### DIFF
--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -658,18 +658,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                     ) ||
                     (!firstEditElement && nodeElement === protyle.wysiwyg.element.firstElementChild)) {
                     // 不能用\n判断，否则文字过长折行将错误 https://github.com/siyuan-note/siyuan/issues/6156
-                    // 代码块中光标在第一行之后时不应跳到标题，因为 getSelectionPosition 对非第一行的计算是错误的 https://github.com/siyuan-note/siyuan/issues/17602
-                    let skipJumpToTitle = false;
-                    if (nodeElement.classList.contains("code-block")) {
-                        const hljsElement = nodeElement.querySelector(".hljs");
-                        const codeText = hljsElement?.textContent || "";
-                        const firstNewlineIndex = codeText.indexOf("\n");
-                        // 有多行并且在第一行之后，则需要skipJumpToTitle
-                        if (firstNewlineIndex !== -1 && position.start > firstNewlineIndex) {
-                            skipJumpToTitle = true;
-                        }
-                    }
-                    if ((getSelectionPosition(nodeEditableElement, range).top - nodeEditableElement.getBoundingClientRect().top < 20 || nodeElement.classList.contains("av")) && !skipJumpToTitle) {
+                    if (getSelectionPosition(nodeEditableElement, range).top - nodeEditableElement.getBoundingClientRect().top < 20 || nodeElement.classList.contains("av")) {
                         if (protyle.title && protyle.title.editElement &&
                             (protyle.wysiwyg.element.firstElementChild.getAttribute("data-eof") === "1" ||
                                 protyle.contentElement.scrollTop === 0)) {


### PR DESCRIPTION
Reverts siyuan-note/siyuan#17619

光标在此处上键依旧有问题
<img width="1910" height="408" alt="QQ_1778221154538" src="https://github.com/user-attachments/assets/5ca1e075-c9c9-4488-b5a7-ed29437439f4" />
