### PR TITLE
Harden RPC handling and improve error reporting in kernel plugin

### DIFF
--- a/kernel/api/network.go
+++ b/kernel/api/network.go
@@ -447,7 +447,9 @@ func httpProxy(c *gin.Context) {
 	}
 
 	proxyReq.ContentLength = c.Request.ContentLength
-	proxyReq.Header.Set("Content-Type", c.ContentType())
+	if c.ContentType() != "" {
+		proxyReq.Header.Set("Content-Type", c.ContentType())
+	}
 
 	for k, vs := range *targetHeaders {
 		for _, v := range vs {

--- a/kernel/plugin/api_rpc.go
+++ b/kernel/plugin/api_rpc.go
@@ -139,6 +139,9 @@ func injectRpc(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err erro
 			var method string
 			if m := call.Argument(0); goja.IsString(m) {
 				method = m.String()
+			} else {
+				err = fmt.Errorf("first argument must be method name string")
+				return
 			}
 
 			var params util.Optional[any]

--- a/kernel/plugin/manager.go
+++ b/kernel/plugin/manager.go
@@ -142,6 +142,11 @@ func (m *PluginManager) StartPlugin(petal *model.Petal) (ok bool) {
 		}
 	}()
 
+	if petal.Kernel.Incompatible || !petal.Kernel.Existed {
+		ok = false
+		return
+	}
+
 	pluginMu := m.getPluginMu(petal.Name)
 	pluginMu.Lock()
 	defer pluginMu.Unlock()

--- a/kernel/plugin/plugin.go
+++ b/kernel/plugin/plugin.go
@@ -760,7 +760,7 @@ func (p *KernelPlugin) handleHttpRequest(c *gin.Context, request *Request, scope
 			response = result.Value
 		}
 	case <-c.Request.Context().Done():
-		err = c.Request.Context().Err()
+		// err = c.Request.Context().Err()
 	}
 	return
 }
@@ -1221,7 +1221,7 @@ func (p *KernelPlugin) handleServerSentEventRequest(c *gin.Context, request *Req
 		case <-ctx.Done():
 			return
 		case <-c.Request.Context().Done():
-			err = c.Request.Context().Err()
+			// err = c.Request.Context().Err()
 			return
 		case handlerErr := <-done:
 			if handlerErr != nil {

--- a/kernel/plugin/rpc.go
+++ b/kernel/plugin/rpc.go
@@ -115,7 +115,7 @@ func (r *JsonRpcRequest) UnmarshalJSON(data []byte) error {
 	}
 
 	// Validate method field
-	if !request.Method.Exists {
+	if !request.Method.HasValue() {
 		return fmt.Errorf("missing method field")
 	}
 
@@ -148,8 +148,8 @@ func (r *JsonRpcRequest) Validate() *JsonRpcError {
 	} else if _, ok := r.Params.Value.(map[string]any); ok {
 	} else {
 		return &JsonRpcError{
-			Code:    JsonRpcErrorCodeInvalidRequest,
-			Message: JsonRpcErrorInvalidRequest.Message,
+			Code:    JsonRpcErrorCodeInvalidParams,
+			Message: JsonRpcErrorInvalidParams.Message,
 			Data:    "Invalid params: must be array or object if present",
 		}
 	}

--- a/kernel/plugin/sandbox.go
+++ b/kernel/plugin/sandbox.go
@@ -366,12 +366,14 @@ func invokeFunction(callback func(rt *goja.Runtime, result *CallResult), rt *goj
 		resultObj := resultJs.ToObject(rt)
 		if resultObj == nil {
 			callback(rt, &CallResult{Error: fmt.Errorf("expected promise object, got %T", result)})
+			return
 		}
 
 		thenValue := resultObj.Get("then")
 		then, ok := goja.AssertFunction(thenValue)
 		if !ok {
 			callback(rt, &CallResult{Error: fmt.Errorf("'promise.then property is not a function")})
+			return
 		}
 
 		then(resultObj, rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) {

--- a/kernel/plugin/sandbox.go
+++ b/kernel/plugin/sandbox.go
@@ -505,8 +505,8 @@ func getRequestHandler(rt *goja.Runtime, scope AccessScope, requestType RequestT
 // requestGoToJs converts a Go Request to a JavaScript value.
 func requestGoToJs(p *KernelPlugin, rt *goja.Runtime, request *Request) (jsRequest goja.Value, err error) {
 	// convert body raw data to js object
-	if request.Request.Body.Data != nil {
-		request.Request.Body.Data, err = NewDataObject(p, rt, *request.Request.Body.Data.(*[]byte))
+	if data, ok := request.Request.Body.Data.(*[]byte); ok && data != nil {
+		request.Request.Body.Data, err = NewDataObject(p, rt, *data)
 		if err != nil {
 			return
 		}
@@ -516,8 +516,8 @@ func requestGoToJs(p *KernelPlugin, rt *goja.Runtime, request *Request) (jsReque
 	if request.Request.Body.Form != nil {
 		for _, fileList := range request.Request.Body.Form.File {
 			for _, file := range fileList {
-				if file.Data != nil {
-					file.Data, err = NewDataObject(p, rt, *file.Data.(*[]byte))
+				if data, ok := file.Data.(*[]byte); ok && data != nil {
+					file.Data, err = NewDataObject(p, rt, *data)
 					if err != nil {
 						return
 					}

--- a/kernel/plugin/server.go
+++ b/kernel/plugin/server.go
@@ -106,8 +106,8 @@ type RequestBody struct {
 }
 
 type RequestForm struct {
-	Value map[string][]string      `json:"values"` // e.g. {"field1": ["value1"], "field2": ["value2-1", "value2-2"]}
-	File  map[string][]RequestFile `json:"files"`  // e.g. {"file1": [{"Filename": "hello.txt", "Headers": {"Content-Disposition": ["form-data; name=\"file1\"; filename=\"hello.txt\""], "Content-Type": ["text/plain"]}, "Size": 123, "Data": []byte{...}}]}
+	Value map[string][]string       `json:"values"` // e.g. {"field1": ["value1"], "field2": ["value2-1", "value2-2"]}
+	File  map[string][]*RequestFile `json:"files"`  // e.g. {"file1": [{"Filename": "hello.txt", "Headers": {"Content-Disposition": ["form-data; name=\"file1\"; filename=\"hello.txt\""], "Content-Type": ["text/plain"]}, "Size": 123, "Data": []byte{...}}]}
 }
 
 type RequestFile struct {
@@ -185,29 +185,32 @@ func parseRequest(c *gin.Context) (request *Request, err error) {
 		// multipart/form-data
 		form = &RequestForm{
 			Value: multipartForm.Value,
-			File:  make(map[string][]RequestFile),
+			File:  make(map[string][]*RequestFile),
 		}
 
 		for partName, fileHandlers := range multipartForm.File {
-			files := make([]RequestFile, len(fileHandlers))
+			files := make([]*RequestFile, len(fileHandlers))
 			form.File[partName] = files
 			for i, handler := range fileHandlers {
-				files[i].Filename = handler.Filename
-				files[i].Headers = handler.Header
-				files[i].Size = handler.Size
-				if file, openErr := handler.Open(); openErr != nil {
+				files[i] = &RequestFile{
+					Filename: handler.Filename,
+					Headers:  handler.Header,
+					Size:     handler.Size,
+				}
+				file, openErr := handler.Open()
+				if openErr != nil {
 					err = fmt.Errorf("open form part [%s] file [%s] error: %s", partName, handler.Filename, openErr.Error())
 					return
-				} else {
-					content := make([]byte, handler.Size)
-					if n, readErr := file.Read(content); readErr != nil {
-						err = fmt.Errorf("read form part [%s] file [%s] error: %s", partName, handler.Filename, readErr.Error())
-						return
-					} else {
-						fileData := content[:n]
-						files[i].Data = &fileData
-					}
 				}
+				content := make([]byte, handler.Size)
+				n, readErr := file.Read(content)
+				file.Close()
+				if readErr != nil {
+					err = fmt.Errorf("read form part [%s] file [%s] error: %s", partName, handler.Filename, readErr.Error())
+					return
+				}
+				fileData := content[:n]
+				files[i].Data = &fileData
 			}
 		}
 	} else if len(c.Request.PostForm) > 0 {
@@ -236,7 +239,7 @@ func parseRequest(c *gin.Context) (request *Request, err error) {
 		}
 	}
 
-	headers := map[string][]string(c.Request.Header)
+	headers := map[string][]string(c.Request.Header.Clone())
 	delete(headers, "Cookie")
 	delete(headers, "Authorization")
 


### PR DESCRIPTION
## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->
This pull request introduces several improvements and bug fixes related to request parsing, plugin management, and error handling in the kernel plugin system. The changes enhance type safety, improve error messaging, and ensure better compatibility and robustness when handling HTTP and RPC requests, especially around multipart form data and plugin startup validation.

**Request Parsing and Data Handling Improvements:**

* Changed `RequestForm.File` to use pointers to `RequestFile` for consistency and to avoid potential issues with value copying. Updated all related logic in `parseRequest` to handle pointers, improving memory management and correctness. [[1]](diffhunk://#diff-657301e0a4281dd71337ebfd1ca733e3f2e2e83a8a797b77cee92f91f865bdc8L110-R110) [[2]](diffhunk://#diff-657301e0a4281dd71337ebfd1ca733e3f2e2e83a8a797b77cee92f91f865bdc8L188-L212)
* Improved handling of file data in multipart forms by reading file contents safely, closing files after reading, and correctly assigning data pointers.
* Updated conversion of Go request bodies and form files to JavaScript objects to safely check for pointer types before processing, preventing panics. [[1]](diffhunk://#diff-343d98658a126e3c268d1fdc78212d19598f757a631ca9c533f5bb63ce2c4cb6L506-R509) [[2]](diffhunk://#diff-343d98658a126e3c268d1fdc78212d19598f757a631ca9c533f5bb63ce2c4cb6L517-R520)

**Plugin Management and Validation:**

* Added a check in `StartPlugin` to prevent starting plugins that are marked as incompatible or do not exist, ensuring only valid plugins are started.
* Improved error reporting in RPC injection by returning an explicit error if the method name argument is not a string, making debugging easier.

**Error Handling and Robustness:**

* Updated JSON-RPC request validation to use the correct error code/message (`InvalidParams`) when parameters are invalid, providing more accurate feedback to clients.
* Improved the check for the presence of the `method` field in JSON-RPC requests by using `HasValue()` for better reliability.
* Enhanced promise handling in the plugin sandbox by adding early returns if expected JavaScript objects or functions are missing, preventing further errors.

**HTTP Proxy and Header Handling:**

* Set the `Content-Type` header on proxied HTTP requests only if present, preventing unintended header overwrites.
* Cloned request headers when parsing requests to avoid unintended side effects from modifying the original header map.

**Miscellaneous:**

* Commented out error assignment on HTTP context cancellation in plugin handlers to avoid overwriting meaningful errors with context cancellation errors. [[1]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL763-R763) [[2]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL1224-R1224)
## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突

REL: #17487