### PR TITLE
Fix path traversal vulnerability in /export/temp/ endpoint

### DIFF
--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -304,10 +304,21 @@ func serveExport(ginServer *gin.Engine) {
 	exportGroup := ginServer.Group("/export/", model.CheckAuth)
 	exportBaseDir := filepath.Join(util.TempDir, "export")
 
-	// 应下载而不是查看导出的文件
 	exportGroup.GET("/*filepath", func(c *gin.Context) {
 		if strings.HasPrefix(c.Request.URL.Path, "/export/temp/") {
-			c.File(filepath.Join(util.TempDir, c.Request.URL.Path))
+			tempBaseDir := filepath.Join(util.TempDir, "export", "temp")
+			relativePath := strings.TrimPrefix(c.Request.URL.Path, "/export/temp/")
+			relativePath = filepath.Clean(relativePath)
+			if strings.Contains(relativePath, "..") {
+				c.Status(http.StatusUnauthorized)
+				return
+			}
+			fullPath := filepath.Join(tempBaseDir, relativePath)
+			if !gulu.File.IsSubPath(tempBaseDir, fullPath) {
+				c.Status(http.StatusUnauthorized)
+				return
+			}
+			c.File(fullPath)
 			return
 		}
 


### PR DESCRIPTION
## Summary

- Fix a path traversal vulnerability in the `/export/temp/` endpoint in `kernel/server/serve.go`
- The endpoint was using `c.Request.URL.Path` directly in `filepath.Join(util.TempDir, ...)` without any path validation, which could allow an authenticated user to access files outside the intended `{TempDir}/export/temp/` directory via path traversal sequences (e.g., `/export/temp/../../../etc/passwd`).

## Changes

- Extract the relative portion of the path (after `/export/temp/`)
- Apply `filepath.Clean()` to normalize the path
- Reject paths containing `..` components
- Validate the final path with `gulu.File.IsSubPath()` to ensure it stays within the expected base directory
- This mirrors the same validation pattern already used for the non-temp export path in the same function

## Test plan

- [ ] Verify normal export temp file access still works (e.g., `/export/temp/{randomId}`)
- [ ] Verify `/export/temp/../../../etc/passwd` returns 401 Unauthorized
- [ ] Verify `/export/temp/..%2F..%2F..%2Fetc%2Fpasswd` returns 401 Unauthorized
- [ ] Run existing export-related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)