### PR TITLE
Fix path traversal vulnerability in /repo/diff/ endpoint

### DIFF
--- a/kernel/server/serve.go
+++ b/kernel/server/serve.go
@@ -668,9 +668,18 @@ func serveThumbnail(context *gin.Context, assetAbsPath, requestPath string) bool
 }
 
 func serveRepoDiff(ginServer *gin.Engine) {
+	repoDiffBaseDir := filepath.Join(util.TempDir, "repo", "diff")
 	ginServer.GET("/repo/diff/*path", model.CheckAuth, model.CheckAdminRole, func(context *gin.Context) {
-		requestPath := context.Param("path")
-		p := filepath.Join(util.TempDir, "repo", "diff", requestPath)
+		requestPath := filepath.Clean(context.Param("path"))
+		if strings.Contains(requestPath, "..") {
+			context.Status(http.StatusUnauthorized)
+			return
+		}
+		p := filepath.Join(repoDiffBaseDir, requestPath)
+		if !gulu.File.IsSubPath(repoDiffBaseDir, p) {
+			context.Status(http.StatusUnauthorized)
+			return
+		}
 		http.ServeFile(context.Writer, context.Request, p)
 	})
 }


### PR DESCRIPTION
## Summary

- Fix a path traversal vulnerability in the `/repo/diff/` endpoint in `kernel/server/serve.go`
- The endpoint used `context.Param("path")` directly in `filepath.Join(util.TempDir, "repo", "diff", ...)` without any validation, allowing an authenticated admin user to read arbitrary files on the system via path traversal sequences (e.g., `/repo/diff/../../../etc/passwd`).

## Changes

- Apply `filepath.Clean()` to normalize the path
- Reject paths containing `..` components
- Validate the final path with `gulu.File.IsSubPath()` to ensure it stays within the expected `{TempDir}/repo/diff/` directory
- Follows the same validation pattern used in other file-serving endpoints in this file

## Test plan

- [ ] Verify normal repo diff file access still works
- [ ] Verify `/repo/diff/../../../etc/passwd` returns 401 Unauthorized
- [ ] Run existing repo-related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)