### PR TITLE
Use parameterized queries in putStat to prevent SQL injection

### DIFF
--- a/kernel/sql/stat.go
+++ b/kernel/sql/stat.go
@@ -54,12 +54,12 @@ func setDatabaseVer() {
 }
 
 func putStat(tx *sql.Tx, key, value string) (err error) {
-	stmt := "DELETE FROM stat WHERE `key` = '" + key + "'"
-	if err = execStmtTx(tx, stmt); err != nil {
+	stmt := "DELETE FROM stat WHERE `key` = ?"
+	if err = execStmtTx(tx, stmt, key); err != nil {
 		return
 	}
 
-	stmt = "INSERT INTO stat VALUES ('" + key + "', '" + value + "')"
-	err = execStmtTx(tx, stmt)
+	stmt = "INSERT INTO stat VALUES (?, ?)"
+	err = execStmtTx(tx, stmt, key, value)
 	return
 }


### PR DESCRIPTION
## Summary

- Convert `putStat` in `kernel/sql/stat.go` to use parameterized queries (`?` placeholders) instead of string concatenation for SQL statements
- The function was building DELETE and INSERT queries by directly interpolating `key` and `value` into SQL strings, which is an SQL injection anti-pattern

## Details

While `putStat` is currently only called with hardcoded internal values (`"siyuan_database_ver"` and `util.DatabaseVer`), using string concatenation for SQL queries is a dangerous practice that could become a real vulnerability if future code paths pass user-controlled data to this function. The fix is straightforward since `execStmtTx` already supports variadic args.

## Test plan

- [ ] Verify the app starts correctly and database version is read/written properly
- [ ] Run existing database-related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)