### PR TITLE
Isolate reconnectWebSocket pings to survive CONNECTING sockets

### DIFF
--- a/app/src/mobile/index.ts
+++ b/app/src/mobile/index.ts
@@ -213,10 +213,22 @@ const siyuanApp = new App();
 
 // https://github.com/siyuan-note/siyuan/issues/8441
 window.reconnectWebSocket = () => {
-    window.siyuan.ws.send("ping", {});
-    window.siyuan.mobile.docks.file.send("ping", {});
-    window.siyuan.mobile.editor.protyle.ws.send("ping", {});
-    window.siyuan.mobile.popEditor?.protyle.ws.send("ping", {});
+    // 后台唤醒时任一 socket 可能仍在 CONNECTING，调用 send 会抛 InvalidStateError，
+    // 单独 try/catch 防止首个错误中断整个 ping 序列；下次 reconnectWebSocket 会再次尝试
+    const tryPing = (m?: { send: (cmd: string, p: Record<string, unknown>) => void }) => {
+        if (!m) {
+            return;
+        }
+        try {
+            m.send("ping", {});
+        } catch (e) {
+            console.warn("reconnectWebSocket: ping skipped", e);
+        }
+    };
+    tryPing(window.siyuan.ws);
+    tryPing(window.siyuan.mobile.docks.file);
+    tryPing(window.siyuan.mobile.editor.protyle.ws);
+    tryPing(window.siyuan.mobile.popEditor?.protyle.ws);
 };
 window.lockscreenByMode = () => {
     if (window.siyuan.config.system.lockScreenMode === 1) {


### PR DESCRIPTION
## Description / 描述

`window.reconnectWebSocket` (`app/src/mobile/index.ts:215-220`, referenced from native iOS/Android via #8441) pings all four SiYuan WebSockets when the mobile app foregrounds. But mobile OSes routinely drop background WebSockets, so on foreground the sockets are mid-reconnect (`readyState === CONNECTING`). Per the [WebSocket spec](https://websockets.spec.whatwg.org/#dom-websocket-send), calling `send()` on a CONNECTING socket throws `InvalidStateError`. The first throwing socket aborts `reconnectWebSocket`, and the remaining three sockets are never pinged on that wakeup.

This PR isolates each ping in a small try/catch helper so a single CONNECTING socket can't crash the wakeup sequence. The pattern mirrors `app/src/protyle/util/destroy.ts:25-31`, where the project already uses try/catch for the same family of WebSocket-timing edge case.

`window.reconnectWebSocket`（`app/src/mobile/index.ts:215-220`，由原生 iOS/Android 通过 #8441 调用）在移动端应用前台唤醒时为四个 SiYuan WebSocket 发送 ping。但移动操作系统常常会断开后台 WebSocket，所以应用前台时这些 socket 都处于重连状态（`readyState === CONNECTING`）。根据 [WebSocket 规范](https://websockets.spec.whatwg.org/#dom-websocket-send)，对 CONNECTING 状态的 socket 调用 `send()` 会抛 `InvalidStateError`。首个抛错的 socket 会中断 `reconnectWebSocket`，剩余三个 socket 在本次唤醒中再也无法收到 ping。

本 PR 将每个 ping 单独包在 try/catch 中，防止单个 CONNECTING socket 中断整个唤醒序列。该模式与 `app/src/protyle/util/destroy.ts:25-31` 中已有的 try/catch 用法一致——项目已经在处理同一类 WebSocket 时机问题时使用此模式。

### Why this isn't fixed inside `Model.send`

The natural impulse is to add a `readyState !== OPEN` guard inside `Model.send()` itself. That would silently break `app/src/protyle/util/destroy.ts:25-31`, which explicitly relies on `Model.send()` throwing when the WebSocket isn't ready — the catch handler retries 10.24s later. Converting the throw to a silent return would skip that retry and leak the kernel-side `closews` message. Fixing the broken caller (`reconnectWebSocket`) directly preserves `Model.send()`'s existing contract for the existing-and-correct retry path in `destroy.ts`.

### Why each ping should NOT bubble its error

`reconnectWebSocket` is fire-and-forget — its native callers don't surface its result. The four pings target independent sockets; a CONNECTING socket means "this one isn't ready yet", not "the whole wakeup failed". The next foreground event (or the socket's own `onopen` handler elsewhere) will catch what was missed.

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突

---

### Notes on tests

The `app/` workspace has no test runner today (`app/package.json` ships `lint`, `dev`, `build`, `dist`, `gen:types`), so this PR doesn't add a unit test. Verified locally with:

- `eslint src/mobile/index.ts` → clean
- `tsc --noEmit` → no new TS errors. Pre-existing `VideoFrame` errors in `electron@41.5.0/electron.d.ts` reproduce on a clean checkout of `dev` and are unrelated.

Happy to set up a vitest harness for `app/src/mobile/index.ts` in a follow-up if helpful.
