### PR TITLE
支持插件自定义块渲染

### DIFF
--- a/app/src/ai/actions.ts
+++ b/app/src/ai/actions.ts
@@ -22,7 +22,7 @@ export const fillContent = (protyle: IProtyle, data: string, elements: Element[]
     protyle.toolbar.range.collapse(true);
     insertHTML(protyle.lute.SpinBlockDOM(data), protyle, true, true);
     blockRender(protyle, protyle.wysiwyg.element);
-    processRender(protyle.wysiwyg.element);
+    processRender(protyle.wysiwyg.element, protyle.app);
     highlightRender(protyle.wysiwyg.element);
 };
 

--- a/app/src/editor/getIcon.ts
+++ b/app/src/editor/getIcon.ts
@@ -51,6 +51,9 @@ export const getIconByType = (type: string, sub?: string) => {
         case "NodeMathBlock":
             iconName = "iconMath";
             break;
+        case "NodeCustomBlock":
+            iconName = "iconPlugin";
+            break;
         case "NodeHTMLBlock":
             iconName = "iconHTML5";
             break;

--- a/app/src/mobile/util/MobileBackFoward.ts
+++ b/app/src/mobile/util/MobileBackFoward.ts
@@ -89,7 +89,7 @@ const focusStack = (backStack: IBackStack) => {
         protyle.block.action = backStack.callback;
         protyle.wysiwyg.element.setAttribute("data-doc-type", getResponse.data.type);
         protyle.wysiwyg.element.innerHTML = getResponse.data.content;
-        processRender(protyle.wysiwyg.element);
+        processRender(protyle.wysiwyg.element, protyle.app);
         highlightRender(protyle.wysiwyg.element);
         avRender(protyle.wysiwyg.element, protyle);
         blockRender(protyle, protyle.wysiwyg.element, backStack.scrollTop);

--- a/app/src/plugin/customBlockRender.ts
+++ b/app/src/plugin/customBlockRender.ts
@@ -1,21 +1,126 @@
 import {App} from "../index";
 import {genIconHTML} from "../protyle/render/util";
 import {hasClosestByClassName} from "../protyle/util/hasClosest";
+import {getAllEditor} from "../layout/getAll";
+import {updateTransaction} from "../protyle/wysiwyg/transaction";
 
 /**
- * 渲染自定义块
+ * 将插件名和块名编码为 data-info 值，/ 转义为 \/
+ */
+export const encodeCustomBlockInfo = (pluginName: string, blockName: string) =>
+    pluginName.replace(/\//g, "\\/") + "/" + blockName.replace(/\//g, "\\/");
+
+/**
+ * 从 data-info 值解码出插件名和块名
+ */
+export const decodeCustomBlockInfo = (info: string): { pluginName: string, blockName: string } | null => {
+    let slashIdx = -1;
+    for (let i = 0; i < info.length; i++) {
+        if (info[i] === "/" && (i === 0 || info[i - 1] !== "\\")) {
+            slashIdx = i;
+            break;
+        }
+    }
+    if (slashIdx === -1) {
+        return null;
+    }
+    return {
+        pluginName: info.substring(0, slashIdx).replace(/\\\//g, "/"),
+        blockName: info.substring(slashIdx + 1).replace(/\\\//g, "/"),
+    };
+};
+
+/**
+ * 清除自定义块的所有渲染子元素
+ */
+const clearBlockContent = (item: Element) => {
+    for (let i = item.children.length - 1; i >= 0; i--) {
+        item.children[i].remove();
+    }
+};
+
+/**
+ * 为自定义块元素创建 setContent 回调
  *
- * 遍历 element 内所有未渲染的 [data-type="NodeCustomBlock"] 元素，
- * 查找插件注册的 customBlockRenders 中匹配 data-info 的渲染器并调用。
+ * 修改 data-content 后重新渲染，发送给后端的是不含渲染子 DOM 的干净 HTML
+ */
+const createSetContent = (app: App, element: Element) => (newContent: string) => {
+    const oldContent = Lute.UnEscapeHTMLStr(element.getAttribute("data-content") || "");
+    if (newContent === oldContent) return;
+
+    const id = element.getAttribute("data-node-id") || "";
+    if (!id) return;
+
+    /** 找到对应的编辑器 */
+    for (const editor of getAllEditor()) {
+        if (editor.protyle.wysiwyg?.element.contains(element)) {
+            const oldHTML = element.outerHTML;
+            element.setAttribute("data-content", Lute.EscapeHTMLStr(newContent));
+            clearBlockContent(element);
+            renderBlock(app, element, hasClosestByClassName(element, "protyle-wysiwyg", true));
+            updateTransaction(editor.protyle, id, element.outerHTML, oldHTML);
+            return;
+        }
+    }
+};
+
+/**
+ * 渲染单个自定义块元素
+ *
+ * 统一流程：确保 icons → 清除旧内容 → 调用插件 render 或显示 fallback
+ */
+const renderBlock = (app: App, item: Element, wysiwygElement: false | HTMLElement) => {
+    const info = item.getAttribute("data-info") || "";
+    /** data-content 经 Lute.EscapeHTMLStr 转义，需要还原后传给插件 */
+    const content = Lute.UnEscapeHTMLStr(item.getAttribute("data-content") || "");
+
+    if (!item.querySelector(".protyle-icons")) {
+        item.insertAdjacentHTML("afterbegin", genIconHTML(wysiwygElement));
+    }
+    clearBlockContent(item);
+
+    const decoded = decodeCustomBlockInfo(info);
+    let rendered = false;
+    if (decoded) {
+        const plugin = (app.plugins || []).find(p => p.name === decoded.pluginName);
+        const renderer = plugin?.customBlockRenders[decoded.blockName];
+        if (renderer) {
+            try {
+                renderer.render({app, element: item, content, setContent: createSetContent(app, item)});
+                rendered = true;
+            } catch (e) {
+                console.error(`[CustomBlock] plugin ${plugin.name} render error:`, e);
+            }
+        }
+    }
+
+    if (!rendered) {
+        const fallback = document.createElement("div");
+        fallback.style.cssText = "padding: 8px; color: var(--b3-theme-on-surface-light); font-size: 12px;";
+        const title = document.createElement("div");
+        title.style.cssText = "margin-bottom: 4px; font-weight: 500;";
+        title.textContent = `Custom Block: ${info}`;
+        const pre = document.createElement("pre");
+        pre.style.cssText = "margin: 0; white-space: pre-wrap; word-break: break-all;";
+        pre.textContent = content;
+        fallback.append(title, pre);
+        item.appendChild(fallback);
+    }
+};
+
+/**
+ * 渲染 element 内所有自定义块
+ *
+ * 自定义块不使用 data-render 做持久化标记，每次调用都会重新渲染。
+ * 这是因为插件可能随时加载/卸载，渲染结果不应被缓存。
  */
 export const customBlockRender = (app: App, element: Element) => {
-    let customElements: Element[] = [];
-    if (element.getAttribute("data-type") === "NodeCustomBlock"
-        && element.getAttribute("data-render") !== "true") {
+    let customElements: Element[];
+    if (element.getAttribute("data-type") === "NodeCustomBlock") {
         customElements = [element];
     } else {
         customElements = Array.from(
-            element.querySelectorAll('[data-type="NodeCustomBlock"]:not([data-render="true"])')
+            element.querySelectorAll('[data-type="NodeCustomBlock"]')
         );
     }
     if (customElements.length === 0) {
@@ -24,45 +129,23 @@ export const customBlockRender = (app: App, element: Element) => {
 
     const wysiwygElement = hasClosestByClassName(element, "protyle-wysiwyg", true);
     for (const item of customElements) {
-        const info = item.getAttribute("data-info") || "";
-        const content = item.getAttribute("data-content") || "";
-
-        if (!item.querySelector(".protyle-icons")) {
-            item.insertAdjacentHTML("afterbegin", genIconHTML(wysiwygElement));
-        }
-
-        let rendered = false;
-        for (const plugin of (app.plugins || [])) {
-            const renderer = plugin.customBlockRenders[info];
-            if (renderer) {
-                try {
-                    renderer.render({app, element: item, content});
-                    rendered = true;
-                } catch (e) {
-                    console.error(`[CustomBlock] plugin ${plugin.name} render error:`, e);
-                }
-                break;
-            }
-        }
-
-        if (!rendered) {
-            const fallback = document.createElement("div");
-            fallback.style.cssText = "padding: 8px; color: var(--b3-theme-on-surface-light); font-size: 12px;";
-            const title = document.createElement("div");
-            title.style.cssText = "margin-bottom: 4px; font-weight: 500;";
-            title.textContent = `Custom Block: ${info}`;
-            const pre = document.createElement("pre");
-            pre.style.cssText = "margin: 0; white-space: pre-wrap; word-break: break-all;";
-            pre.textContent = content;
-            fallback.append(title, pre);
-
-            const iconsEl = item.querySelector(".protyle-icons");
-            if (iconsEl?.nextElementSibling) {
-                iconsEl.nextElementSibling.remove();
-            }
-            item.appendChild(fallback);
-        }
-
-        item.setAttribute("data-render", "true");
+        renderBlock(app, item, wysiwygElement);
     }
+};
+
+/**
+ * 按插件名重新渲染所有编辑器中属于该插件的自定义块
+ *
+ * 用于插件启用/禁用时定向刷新，不影响其他插件的自定义块
+ */
+export const rerenderCustomBlocksByPlugin = (app: App, pluginName: string) => {
+    getAllEditor().forEach(editor => {
+        const wysiwyg = editor.protyle.wysiwyg;
+        if (!wysiwyg) return;
+        wysiwyg.element.querySelectorAll('[data-type="NodeCustomBlock"]').forEach((el: Element) => {
+            const decoded = decodeCustomBlockInfo(el.getAttribute("data-info") || "");
+            if (decoded?.pluginName !== pluginName) return;
+            renderBlock(app, el, hasClosestByClassName(el, "protyle-wysiwyg", true));
+        });
+    });
 };

--- a/app/src/plugin/customBlockRender.ts
+++ b/app/src/plugin/customBlockRender.ts
@@ -1,3 +1,68 @@
-// TODO
-export const customBlockRender = () => {
+import {App} from "../index";
+import {genIconHTML} from "../protyle/render/util";
+import {hasClosestByClassName} from "../protyle/util/hasClosest";
+
+/**
+ * 渲染自定义块
+ *
+ * 遍历 element 内所有未渲染的 [data-type="NodeCustomBlock"] 元素，
+ * 查找插件注册的 customBlockRenders 中匹配 data-info 的渲染器并调用。
+ */
+export const customBlockRender = (app: App, element: Element) => {
+    let customElements: Element[] = [];
+    if (element.getAttribute("data-type") === "NodeCustomBlock"
+        && element.getAttribute("data-render") !== "true") {
+        customElements = [element];
+    } else {
+        customElements = Array.from(
+            element.querySelectorAll('[data-type="NodeCustomBlock"]:not([data-render="true"])')
+        );
+    }
+    if (customElements.length === 0) {
+        return;
+    }
+
+    const wysiwygElement = hasClosestByClassName(element, "protyle-wysiwyg", true);
+    for (const item of customElements) {
+        const info = item.getAttribute("data-info") || "";
+        const content = item.getAttribute("data-content") || "";
+
+        if (!item.querySelector(".protyle-icons")) {
+            item.insertAdjacentHTML("afterbegin", genIconHTML(wysiwygElement));
+        }
+
+        let rendered = false;
+        for (const plugin of (app.plugins || [])) {
+            const renderer = plugin.customBlockRenders[info];
+            if (renderer) {
+                try {
+                    renderer.render({app, element: item, content});
+                    rendered = true;
+                } catch (e) {
+                    console.error(`[CustomBlock] plugin ${plugin.name} render error:`, e);
+                }
+                break;
+            }
+        }
+
+        if (!rendered) {
+            const fallback = document.createElement("div");
+            fallback.style.cssText = "padding: 8px; color: var(--b3-theme-on-surface-light); font-size: 12px;";
+            const title = document.createElement("div");
+            title.style.cssText = "margin-bottom: 4px; font-weight: 500;";
+            title.textContent = `Custom Block: ${info}`;
+            const pre = document.createElement("pre");
+            pre.style.cssText = "margin: 0; white-space: pre-wrap; word-break: break-all;";
+            pre.textContent = content;
+            fallback.append(title, pre);
+
+            const iconsEl = item.querySelector(".protyle-icons");
+            if (iconsEl?.nextElementSibling) {
+                iconsEl.nextElementSibling.remove();
+            }
+            item.appendChild(fallback);
+        }
+
+        item.setAttribute("data-render", "true");
+    }
 };

--- a/app/src/plugin/index.ts
+++ b/app/src/plugin/index.ts
@@ -38,7 +38,7 @@ export class Plugin {
             icon: string,
             action: ("edit" | "more")[],
             genCursor: boolean,
-            render: (options: { app: App, element: Element, content: string }) => void,
+            render: (options: { app: App, element: Element, content: string, setContent: (newContent: string) => void }) => void,
         }
     } = {};
     public topBarIcons: Element[] = [];

--- a/app/src/plugin/index.ts
+++ b/app/src/plugin/index.ts
@@ -33,13 +33,12 @@ export class Plugin {
         id: string,
         callback: (protyle: import("../protyle").Protyle, nodeElement: HTMLElement) => void
     }[] = [];
-    // TODO
     public customBlockRenders: {
         [key: string]: {
             icon: string,
-            action: "edit" | "more"[],
+            action: ("edit" | "more")[],
             genCursor: boolean,
-            render: (options: { app: App, element: Element }) => void
+            render: (options: { app: App, element: Element, content: string }) => void,
         }
     } = {};
     public topBarIcons: Element[] = [];

--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -1,6 +1,7 @@
 import {fetchSyncPost} from "../util/fetch";
 import {App} from "../index";
 import {Plugin} from "./index";
+import {rerenderCustomBlocksByPlugin} from "./customBlockRender";
 /// #if !MOBILE
 import {resizeTopBar, saveLayout} from "../layout/util";
 /// #endif
@@ -106,6 +107,7 @@ export const loadPlugin = async (app: App, item: IPluginData) => {
     getAllEditor().forEach(editor => {
         editor.protyle.toolbar.update(editor.protyle);
     });
+    rerenderCustomBlocksByPlugin(app, item.name);
     return plugin;
 };
 
@@ -262,6 +264,9 @@ export const reloadPlugin = async (app: App, data: {
                     editor.protyle.toolbar.update(editor.protyle);
                 });
             }
+        });
+        reloadPlugins.forEach(pluginName => {
+            rerenderCustomBlocksByPlugin(app, pluginName);
         });
     });
     app.plugins.forEach(item => {

--- a/app/src/plugin/uninstall.ts
+++ b/app/src/plugin/uninstall.ts
@@ -1,5 +1,6 @@
 import {App} from "../index";
 import {Plugin} from "./index";
+import {rerenderCustomBlocksByPlugin} from "./customBlockRender";
 /// #if !MOBILE
 import {getAllModels} from "../layout/getAll";
 import {resizeTopBar} from "../layout/util";
@@ -76,6 +77,8 @@ export const uninstall = (app: App, name: string, isReload: boolean) => {
             });
             // rm plugin
             app.plugins.splice(index, 1);
+            // re-render custom blocks belonging to this plugin (will fallback since plugin removed)
+            rerenderCustomBlocksByPlugin(app, plugin.name);
             // rm icons
             document.querySelector(`svg[data-name="${plugin.name}"]`)?.remove();
             // rm protyle toolbar

--- a/app/src/protyle/hint/extend.ts
+++ b/app/src/protyle/hint/extend.ts
@@ -365,10 +365,11 @@ export const hintSlash = (key: string, protyle: IProtyle) => {
         });
         for (const cbKey of Object.keys(plugin.customBlockRenders)) {
             const config = plugin.customBlockRenders[cbKey];
+            const info = `${plugin.name}/${cbKey}`;
             allList.push({
                 filter: [cbKey],
-                id: "customBlock_" + cbKey,
-                value: `customBlock${Constants.ZWSP}${cbKey}`,
+                id: "customBlock_" + info,
+                value: `customBlock${Constants.ZWSP}${info}`,
                 html: `<div class="b3-list-item__first">${config.icon || '<svg class="b3-list-item__graphic"><use xlink:href="#iconPlugin"></use></svg>'}<span class="b3-list-item__text">${cbKey}</span></div>`,
             });
             hasPlugin = true;

--- a/app/src/protyle/hint/extend.ts
+++ b/app/src/protyle/hint/extend.ts
@@ -363,6 +363,16 @@ export const hintSlash = (key: string, protyle: IProtyle) => {
             });
             hasPlugin = true;
         });
+        for (const cbKey of Object.keys(plugin.customBlockRenders)) {
+            const config = plugin.customBlockRenders[cbKey];
+            allList.push({
+                filter: [cbKey],
+                id: "customBlock_" + cbKey,
+                value: `customBlock${Constants.ZWSP}${cbKey}`,
+                html: `<div class="b3-list-item__first">${config.icon || '<svg class="b3-list-item__graphic"><use xlink:href="#iconPlugin"></use></svg>'}<span class="b3-list-item__text">${cbKey}</span></div>`,
+            });
+            hasPlugin = true;
+        }
     });
     if (!hasPlugin) {
         allList.pop();
@@ -556,7 +566,7 @@ export const hintRenderTemplate = (value: string, protyle: IProtyle, nodeElement
             item.remove();
         });
         blockRender(protyle, protyle.wysiwyg.element);
-        processRender(protyle.wysiwyg.element);
+        processRender(protyle.wysiwyg.element, protyle.app);
         highlightRender(protyle.wysiwyg.element);
         avRender(protyle.wysiwyg.element, protyle);
         hideElements(["util"], protyle);

--- a/app/src/protyle/hint/index.ts
+++ b/app/src/protyle/hint/index.ts
@@ -9,6 +9,7 @@ import {
     getSelectionPosition,
 } from "../util/selection";
 import {genHintItemHTML, hintEmbed, hintRef, hintSlash} from "./extend";
+import {customBlockRender} from "../../plugin/customBlockRender";
 import {getSavePath, newFile} from "../../util/newFile";
 import {isAbnormalItem, upDownHint} from "../../util/upDownHint";
 import {setPosition} from "../../util/setPosition";
@@ -745,6 +746,14 @@ ${genHintItemHTML(item)}
                 nodeElement.setAttribute("style", value.split(Constants.ZWSP)[1] || "");
                 updateTransaction(protyle, id, nodeElement.outerHTML, html);
                 return;
+            } else if (value.startsWith("customBlock")) {
+                const key = value.split(Constants.ZWSP)[1];
+                range.deleteContents();
+                this.fixImageCursor(range);
+                insertHTML(protyle.lute.SpinBlockDOM(`;;;${key}\n\n;;;`), protyle, true);
+                customBlockRender(protyle.app, protyle.wysiwyg.element);
+                hideElements(["util"], protyle);
+                return;
             } else if (value.startsWith("plugin")) {
                 protyle.app.plugins.find((plugin) => {
                     const ids = value.split(Constants.ZWSP);
@@ -862,7 +871,7 @@ ${genHintItemHTML(item)}
                 }
                 if (value === "<div>" || value === "$$" || (value.indexOf("```") > -1 && (value.length > 3 || nodeElement.classList.contains("render-node")))) {
                     protyle.toolbar.showRender(protyle, nodeElement);
-                    processRender(nodeElement);
+                    processRender(nodeElement, protyle.app);
                 } else if (value.startsWith("```")) {
                     highlightRender(nodeElement);
                 } else if (value.startsWith("<iframe") || value.startsWith("<video") || value.startsWith("<audio")) {

--- a/app/src/protyle/hint/index.ts
+++ b/app/src/protyle/hint/index.ts
@@ -9,7 +9,7 @@ import {
     getSelectionPosition,
 } from "../util/selection";
 import {genHintItemHTML, hintEmbed, hintRef, hintSlash} from "./extend";
-import {customBlockRender} from "../../plugin/customBlockRender";
+import {customBlockRender, encodeCustomBlockInfo} from "../../plugin/customBlockRender";
 import {getSavePath, newFile} from "../../util/newFile";
 import {isAbnormalItem, upDownHint} from "../../util/upDownHint";
 import {setPosition} from "../../util/setPosition";
@@ -747,10 +747,13 @@ ${genHintItemHTML(item)}
                 updateTransaction(protyle, id, nodeElement.outerHTML, html);
                 return;
             } else if (value.startsWith("customBlock")) {
-                const key = value.split(Constants.ZWSP)[1];
+                const raw = value.split(Constants.ZWSP)[1];
+                const slashIdx = raw.indexOf("/");
+                const pluginName = raw.substring(0, slashIdx);
+                const blockName = raw.substring(slashIdx + 1);
                 range.deleteContents();
                 this.fixImageCursor(range);
-                insertHTML(protyle.lute.SpinBlockDOM(`;;;${key}\n\n;;;`), protyle, true);
+                insertHTML(protyle.lute.SpinBlockDOM(`;;;${encodeCustomBlockInfo(pluginName, blockName)}\n\n;;;`), protyle, true);
                 customBlockRender(protyle.app, protyle.wysiwyg.element);
                 hideElements(["util"], protyle);
                 return;

--- a/app/src/protyle/preview/index.ts
+++ b/app/src/protyle/preview/index.ts
@@ -190,7 +190,7 @@ export class Preview {
             }, response => {
                 const oldScrollTop = protyle.preview.previewElement.scrollTop;
                 protyle.preview.previewElement.innerHTML = response.data.html;
-                processRender(protyle.preview.previewElement);
+                processRender(protyle.preview.previewElement, protyle.app);
                 highlightRender(protyle.preview.previewElement);
                 avRender(protyle.preview.previewElement, protyle);
                 speechRender(protyle.preview.previewElement, window.siyuan.config.appearance.lang);

--- a/app/src/protyle/render/av/gallery/render.ts
+++ b/app/src/protyle/render/av/gallery/render.ts
@@ -154,7 +154,7 @@ const renderGroupGallery = (options: ITableOptions) => {
 export const afterRenderGallery = (options: ITableOptions) => {
     const view = options.data.view as IAVGallery;
     if (view.coverFrom === 1 || view.coverFrom === 3) {
-        processRender(options.blockElement);
+        processRender(options.blockElement, options.protyle.app);
     }
     if (typeof options.resetData.oldOffset === "number") {
         options.protyle.contentElement.scrollTop = options.resetData.oldOffset;

--- a/app/src/protyle/render/blockRender.ts
+++ b/app/src/protyle/render/blockRender.ts
@@ -117,7 +117,7 @@ const renderEmbed = (blocks: {
         item.firstElementChild.insertAdjacentHTML("afterend", `<div class="protyle-wysiwyg__embed ft__smaller ft__secondary b3-form__space--small" contenteditable="false">${errorTip || window.siyuan.languages.refExpired}</div>`);
     }
 
-    processRender(item);
+    processRender(item, protyle.app);
     highlightRender(item);
     avRender(item, protyle);
     if (top) {

--- a/app/src/protyle/toolbar/index.ts
+++ b/app/src/protyle/toolbar/index.ts
@@ -1079,7 +1079,7 @@ export class Toolbar {
                 renderElement.removeAttribute("data-render");
             }
             if (!types.includes("NodeBlockQueryEmbed") || !types.includes("NodeHTMLBlock") || !isInlineMemo) {
-                processRender(renderElement);
+                processRender(renderElement, protyle.app);
             }
             event.stopPropagation();
         });
@@ -1161,7 +1161,7 @@ export class Toolbar {
                 if (textElement.value) {
                     renderElement.setAttribute("data-content", Lute.EscapeHTMLStr(textElement.value));
                     renderElement.removeAttribute("data-render");
-                    processRender(renderElement);
+                    processRender(renderElement, protyle.app);
                 } else {
                     inlineLastNode = renderElement;
                     // esc 后需要 focus range，但点击空白处不能 focus range，否则光标无法留在点击位置
@@ -1174,7 +1174,7 @@ export class Toolbar {
                     blockRender(protyle, renderElement);
                     (renderElement as HTMLElement).style.height = "";
                 } else {
-                    processRender(renderElement);
+                    processRender(renderElement, protyle.app);
                 }
             }
             // 光标定位
@@ -1890,7 +1890,7 @@ export class Toolbar {
                     nodeElement.dataset.subtype = currentLang;
                     nodeElement.className = "render-node";
                     nodeElement.innerHTML = `<div spin="1"></div><div class="protyle-attr" contenteditable="false">${Constants.ZWSP}</div>`;
-                    processRender(nodeElement);
+                    processRender(nodeElement, protyle.app);
                 } else {
                     (editElement as HTMLElement).textContent = editElement.textContent;
                     editElement.parentElement.removeAttribute("data-render");

--- a/app/src/protyle/util/onGet.ts
+++ b/app/src/protyle/util/onGet.ts
@@ -229,7 +229,7 @@ const setHTML = (options: {
     if (options.action.includes(Constants.CB_GET_BACKLINK)) {
         foldPassiveType(options.expand, protyle.wysiwyg.element);
     }
-    processRender(protyle.wysiwyg.element);
+    processRender(protyle.wysiwyg.element, protyle.app);
     highlightRender(protyle.wysiwyg.element);
     avRender(protyle.wysiwyg.element, protyle);
     blockRender(protyle, protyle.wysiwyg.element);

--- a/app/src/protyle/util/paste.ts
+++ b/app/src/protyle/util/paste.ts
@@ -493,7 +493,7 @@ export const paste = async (protyle: IProtyle, event: (ClipboardEvent | DragEven
             insertHTML(tempInnerHTML, protyle, isBlock, false, true);
         }
         blockRender(protyle, protyle.wysiwyg.element);
-        processRender(protyle.wysiwyg.element);
+        processRender(protyle.wysiwyg.element, protyle.app);
         highlightRender(protyle.wysiwyg.element);
         avRender(protyle.wysiwyg.element, protyle);
     } else if (code) {
@@ -595,7 +595,7 @@ export const paste = async (protyle: IProtyle, event: (ClipboardEvent | DragEven
                     }
                 });
                 blockRender(protyle, protyle.wysiwyg.element);
-                processRender(protyle.wysiwyg.element);
+                processRender(protyle.wysiwyg.element, protyle.app);
                 highlightRender(protyle.wysiwyg.element);
                 avRender(protyle.wysiwyg.element, protyle);
                 scrollCenter(protyle, undefined, "nearest", "smooth");
@@ -664,7 +664,7 @@ export const paste = async (protyle: IProtyle, event: (ClipboardEvent | DragEven
             insertHTML(textPlainDom, protyle, false, false, true);
         }
         blockRender(protyle, protyle.wysiwyg.element);
-        processRender(protyle.wysiwyg.element);
+        processRender(protyle.wysiwyg.element, protyle.app);
         highlightRender(protyle.wysiwyg.element);
         avRender(protyle.wysiwyg.element, protyle);
     }

--- a/app/src/protyle/util/processCode.ts
+++ b/app/src/protyle/util/processCode.ts
@@ -7,8 +7,10 @@ import {mindmapRender} from "../render/mindmapRender";
 import {flowchartRender} from "../render/flowchartRender";
 import {plantumlRender} from "../render/plantumlRender";
 import {htmlRender} from "../render/htmlRender";
+import {customBlockRender} from "../../plugin/customBlockRender";
 import {Constants} from "../../constants";
 import {escapeHtml} from "../../util/escape";
+import {App} from "../../index";
 
 export const processPasteCode = (html: string, text: string, originalTextHTML: string, protyle: IProtyle) => {
     const tempElement = document.createElement("div");
@@ -56,7 +58,7 @@ const RENDER_MAP: Record<string, (previewPanel: Element) => void> = {
     math: mathRender,
 };
 
-export const processRender = (previewPanel: Element) => {
+export const processRender = (previewPanel: Element, app?: App) => {
     const language = previewPanel.getAttribute("data-subtype");
     if (RENDER_MAP[language]) {
         RENDER_MAP[language](previewPanel);
@@ -70,4 +72,7 @@ export const processRender = (previewPanel: Element) => {
         render(previewPanel);
     }
     htmlRender(previewPanel);
+    if (app) {
+        customBlockRender(app, previewPanel);
+    }
 };

--- a/app/src/protyle/util/selection.ts
+++ b/app/src/protyle/util/selection.ts
@@ -645,7 +645,7 @@ export const focusBlock = (element: Element, parentElement?: HTMLElement, toStar
     }
 
     // hr、嵌入块、数学公式、iframe、音频、视频、图表渲染块等，删除段落块后，光标位置矫正 https://github.com/siyuan-note/siyuan/issues/4143
-    if (element.classList.contains("render-node") || element.classList.contains("iframe") || element.classList.contains("hr") || element.classList.contains("av")) {
+    if (element.classList.contains("render-node") || element.classList.contains("iframe") || element.classList.contains("hr") || element.classList.contains("av") || element.classList.contains("custom-block")) {
         const range = document.createRange();
         const type = element.getAttribute("data-type");
         let setRange = false;
@@ -673,6 +673,10 @@ export const focusBlock = (element: Element, parentElement?: HTMLElement, toStar
             setRange = true;
         } else if (type === "NodeAudio") {
             range.setStart(element.firstElementChild.lastChild, 0);
+            setRange = true;
+        } else if (type === "NodeCustomBlock") {
+            range.setStart(element, 0);
+            range.collapse(true);
             setRange = true;
         } else if (type === "NodeCodeBlock") {
             range.selectNodeContents(element);

--- a/app/src/protyle/wysiwyg/enter.ts
+++ b/app/src/protyle/wysiwyg/enter.ts
@@ -90,13 +90,13 @@ export const enter = (blockElement: HTMLElement, range: Range, protyle: IProtyle
                     blockElement.className = "render-node";
                     blockElement.innerHTML = `<div spin="1"></div><div class="protyle-attr" contenteditable="false">${Constants.ZWSP}</div>`;
                     protyle.toolbar.showRender(protyle, blockElement);
-                    processRender(blockElement);
+                    processRender(blockElement, protyle.app);
                 } else {
                     highlightRender(blockElement);
                 }
             } else {
                 protyle.toolbar.showRender(protyle, blockElement);
-                processRender(blockElement);
+                processRender(blockElement, protyle.app);
             }
             updateTransaction(protyle, blockElement.getAttribute("data-node-id"), blockElement.outerHTML, oldHTML);
             return true;
@@ -480,7 +480,7 @@ const listEnter = (protyle: IProtyle, blockElement: HTMLElement, range: Range) =
             listItemElement.insertAdjacentElement("afterend", newElement);
             blockRender(protyle, newElement);
             mathRender(newElement);
-            processRender(newElement);
+            processRender(newElement, protyle.app);
             if (listItemElement.getAttribute("data-subtype") === "o") {
                 updateListOrder(listItemElement.parentElement);
             }
@@ -561,14 +561,14 @@ const listEnter = (protyle: IProtyle, blockElement: HTMLElement, range: Range) =
     listItemElement.insertAdjacentElement("afterend", newElement);
     blockRender(protyle, newElement);
     mathRender(newElement);
-    processRender(newElement);
+    processRender(newElement, protyle.app);
     // https://github.com/siyuan-note/siyuan/issues/3850
     // https://github.com/siyuan-note/siyuan/issues/6018
     // img 后有文字，在 img 后换行
     editableElement.parentElement.outerHTML = protyle.lute.SpinBlockDOM(editableElement.parentElement.outerHTML);
     blockRender(protyle, listItemElement);
     mathRender(listItemElement);
-    processRender(listItemElement);
+    processRender(listItemElement, protyle.app);
     if (listItemElement.getAttribute("data-subtype") === "o") {
         updateListOrder(listItemElement.parentElement);
     }

--- a/app/src/protyle/wysiwyg/getBlock.ts
+++ b/app/src/protyle/wysiwyg/getBlock.ts
@@ -128,7 +128,7 @@ export const isNotEditBlock = (element: Element) => {
         });
         return !hasEditable;
     }
-    return ["NodeBlockQueryEmbed", "NodeThematicBreak", "NodeMathBlock", "NodeHTMLBlock", "NodeIFrame", "NodeWidget", "NodeVideo", "NodeAudio"].includes(element.getAttribute("data-type")) ||
+    return ["NodeBlockQueryEmbed", "NodeThematicBreak", "NodeMathBlock", "NodeHTMLBlock", "NodeIFrame", "NodeWidget", "NodeVideo", "NodeAudio", "NodeCustomBlock"].includes(element.getAttribute("data-type")) ||
         (element.getAttribute("data-type") === "NodeCodeBlock" && element.classList.contains("render-node"));
 };
 

--- a/app/src/protyle/wysiwyg/remove.ts
+++ b/app/src/protyle/wysiwyg/remove.ts
@@ -509,6 +509,12 @@ export const removeBlock = async (protyle: IProtyle, blockElement: Element, rang
         undoOperations.splice(0, 1);
     } else {
         const previousLastEditElement = getContenteditableElement(previousLastElement);
+        if (!previousLastEditElement) {
+            removeElement.remove();
+            transaction(protyle, doOperations, undoOperations.reverse());
+            focusBlock(previousLastElement, undefined, false);
+            return;
+        }
         if (editableElement && (editableElement.textContent !== "" || editableElement.querySelector(".emoji"))) {
             // 非空块
             range.setEndAfter(editableElement.lastChild);

--- a/app/src/protyle/wysiwyg/renderBacklink.ts
+++ b/app/src/protyle/wysiwyg/renderBacklink.ts
@@ -21,7 +21,7 @@ export const renderBacklink = (protyle: IProtyle, backlinkData: {
     });
     protyle.wysiwyg.element.innerHTML = html;
     improveBreadcrumbAppearance(protyle.wysiwyg.element);
-    processRender(protyle.wysiwyg.element);
+    processRender(protyle.wysiwyg.element, protyle.app);
     highlightRender(protyle.wysiwyg.element);
     avRender(protyle.wysiwyg.element, protyle);
     blockRender(protyle, protyle.wysiwyg.element);
@@ -76,7 +76,7 @@ export const loadBreadcrumb = (protyle: IProtyle, element: HTMLElement) => {
             tempElement.remove();
         }
         element.parentElement.insertAdjacentHTML("afterend", setBacklinkFold(getResponse.data.content, true));
-        processRender(element.parentElement.parentElement);
+        processRender(element.parentElement.parentElement, protyle.app);
         avRender(element.parentElement.parentElement, protyle);
         blockRender(protyle, element.parentElement.parentElement);
         if (getResponse.data.isSyncing) {

--- a/app/src/protyle/wysiwyg/transaction.ts
+++ b/app/src/protyle/wysiwyg/transaction.ts
@@ -112,7 +112,7 @@ const promiseTransaction = () => {
                             }
                         }
                     });
-                    processRender(protyle.wysiwyg.element);
+                    processRender(protyle.wysiwyg.element, protyle.app);
                     highlightRender(protyle.wysiwyg.element);
                     avRender(protyle.wysiwyg.element, protyle);
                     blockRender(protyle, protyle.wysiwyg.element);
@@ -232,7 +232,7 @@ const promiseTransaction = () => {
                         }
                     });
                     cursorElements.forEach(item => {
-                        processRender(item);
+                        processRender(item, protyle.app);
                         highlightRender(item);
                         avRender(item, protyle);
                         blockRender(protyle, item);
@@ -312,7 +312,7 @@ const updateEmbed = (protyle: IProtyle, operation: IOperation) => {
         }
     });
     if (updatedEmbed) {
-        processRender(protyle.wysiwyg.element);
+        processRender(protyle.wysiwyg.element, protyle.app);
         highlightRender(protyle.wysiwyg.element);
         avRender(protyle.wysiwyg.element, protyle);
     }
@@ -372,7 +372,7 @@ const updateBlock = (updateElements: Element[], protyle: IProtyle, operation: IO
     } else if (wbrElement) {
         wbrElement.remove();
     }
-    processRender(updateElements.length === 1 ? updateElements[0] : protyle.wysiwyg.element);
+    processRender(updateElements.length === 1 ? updateElements[0] : protyle.wysiwyg.element, protyle.app);
     highlightRender(updateElements.length === 1 ? updateElements[0] : protyle.wysiwyg.element);
     avRender(updateElements.length === 1 ? updateElements[0] : protyle.wysiwyg.element, protyle);
     blockRender(protyle, updateElements.length === 1 ? updateElements[0] : protyle.wysiwyg.element);
@@ -426,7 +426,7 @@ export const onTransaction = (protyle: IProtyle, operation: IOperation, isUndo: 
             if (protyle.disabled) {
                 disabledProtyle(protyle);
             }
-            processRender(protyle.wysiwyg.element);
+            processRender(protyle.wysiwyg.element, protyle.app);
             highlightRender(protyle.wysiwyg.element);
             avRender(protyle.wysiwyg.element, protyle);
             blockRender(protyle, protyle.wysiwyg.element);
@@ -885,7 +885,7 @@ export const onTransaction = (protyle: IProtyle, operation: IOperation, isUndo: 
                     item.removeAttribute(attr);
                 }
             });
-            processRender(item);
+            processRender(item, protyle.app);
             highlightRender(item);
             avRender(item, protyle);
             blockRender(protyle, item);
@@ -1252,7 +1252,7 @@ export const turnsIntoTransaction = (options: {
         }
     });
     transaction(options.protyle, doOperations, undoOperations);
-    processRender(options.protyle.wysiwyg.element);
+    processRender(options.protyle.wysiwyg.element, options.protyle.app);
     highlightRender(options.protyle.wysiwyg.element);
     avRender(options.protyle.wysiwyg.element, options.protyle);
     blockRender(options.protyle, options.protyle.wysiwyg.element);
@@ -1356,7 +1356,7 @@ export const turnsOneInto = async (options: {
         }
     });
     blockRender(options.protyle, options.protyle.wysiwyg.element);
-    processRender(options.protyle.wysiwyg.element);
+    processRender(options.protyle.wysiwyg.element, options.protyle.app);
     highlightRender(options.protyle.wysiwyg.element);
     avRender(options.protyle.wysiwyg.element, options.protyle);
 };
@@ -1491,7 +1491,7 @@ const processFold = (operation: IOperation, protyle: IProtyle) => {
             if (protyle.disabled) {
                 disabledProtyle(protyle);
             }
-            processRender(protyle.wysiwyg.element);
+            processRender(protyle.wysiwyg.element, protyle.app);
             highlightRender(protyle.wysiwyg.element);
             avRender(protyle.wysiwyg.element, protyle);
             blockRender(protyle, protyle.wysiwyg.element);


### PR DESCRIPTION
## Description / 描述

实现插件自定义块（Custom Block）渲染能力，允许插件注册自定义块类型并在编辑器中渲染。关联 Issue: https://github.com/siyuan-note/siyuan/issues/8418

通过 Lute 新增 `;;;key\ncontent\n;;;` 语法，解析生成 `data-type="NodeCustomBlock"` DOM 节点（Lute 侧变更见 https://github.com/88250/lute/pull/229 ）。插件通过 `Plugin.customBlockRenders` 注册渲染器，在编辑器所有渲染入口自动调用。同时集成了斜杠菜单插入、编辑面板编辑、光标定位、删除保护等完整编辑体验。

### 插件接入示例

```typescript
export default class MyPlugin extends Plugin {
  onload() {
    this.customBlockRenders["mermaid-custom"] = {
      icon: '<svg class="b3-list-item__graphic"><use xlink:href="#iconGraph"></use></svg>',
      action: ["edit", "more"],
      genCursor: true,
      render: ({app, element, content}) => {
        element.innerHTML = `<div class="my-renderer">${content}</div>`;
      },
    };
  }
}
```

## Type of change / 变更类型

- [x] New feature
      新功能

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突
