### PR TITLE
feat: implement visual unfold for folded blocks in focus mode https:/…

### DIFF
--- a/app/src/assets/scss/protyle/_wysiwyg.scss
+++ b/app/src/assets/scss/protyle/_wysiwyg.scss
@@ -723,6 +723,95 @@
       }
     }
   }
+
+  // Focus mode visual unfold
+  [data-node-id].protyle-wysiwyg--focus-unfold[fold="1"] {
+    @include mixin.text-clamp(unset);
+    opacity: 1 !important;
+    height: auto !important;
+    line-height: normal;
+    font-size: inherit;
+
+    .protyle-attr {
+      opacity: 1 !important;
+    }
+
+    & > div:nth-child(3):not(.protyle-attr),
+    & > div:nth-child(3) ~ div:not(.protyle-attr) {
+      display: block !important;
+    }
+
+    & > .protyle-action::after {
+      background-color: transparent !important;
+    }
+
+    &.list {
+      height: auto !important;
+
+      .li:first-child {
+        overflow: visible;
+        height: auto;
+      }
+    }
+
+    &.bq {
+      height: auto !important;
+
+      & > div:first-child {
+        font-size: inherit;
+        height: auto;
+        line-height: normal;
+        overflow: visible;
+      }
+    }
+
+    &.code-block {
+      height: auto !important;
+      line-height: 1.625;
+    }
+
+    &.sb,
+    &.table {
+      height: auto !important;
+    }
+
+    &.av {
+      height: auto !important;
+    }
+
+    &[data-type="NodeBlockQueryEmbed"] {
+      height: auto !important;
+
+      .protyle-wysiwyg__embed {
+        height: auto;
+        overflow: visible;
+      }
+    }
+  }
+
+  [data-node-id].protyle-wysiwyg--focus-unfold[fold="1"][data-type="NodeHeading"]::before {
+    display: none !important;
+  }
+
+  [data-node-id].protyle-wysiwyg--focus-unfold.li[fold="1"] {
+    &::before {
+      content: "" !important;
+      position: absolute;
+      border-left: .5px solid var(--b3-theme-background-light);
+      left: 17px;
+      height: calc(100% - 1em * 1.625 - 12px);
+      top: calc(1em * 1.625 + 12px);
+    }
+
+    & > .protyle-action::after {
+      background-color: transparent !important;
+    }
+
+    & > div:nth-child(3):not(.protyle-attr),
+    & > div:nth-child(3) ~ div:not(.protyle-attr) {
+      display: block !important;
+    }
+  }
 }
 
 .protyle .protyle-wysiwyg {

--- a/app/src/protyle/gutter/index.ts
+++ b/app/src/protyle/gutter/index.ts
@@ -2673,7 +2673,7 @@ data-type="fold" style="cursor:inherit;"><svg style="width: 10px;${fold && fold 
                     // 前一个块存在时，只显示到当前层级
                     hideParent = true;
                     // 由于折叠块的第二个子块在界面上不显示，因此移除块标 https://github.com/siyuan-note/siyuan/issues/14304
-                    if (parentElement && parentElement.getAttribute("fold") === "1") {
+                    if (parentElement && parentElement.getAttribute("fold") === "1" && !parentElement.classList.contains("protyle-wysiwyg--focus-unfold")) {
                         return;
                     }
                     // 列表项中的引述块中的第二个段落块块标和引述块左侧样式重叠

--- a/app/src/protyle/util/onGet.ts
+++ b/app/src/protyle/util/onGet.ts
@@ -229,6 +229,42 @@ const setHTML = (options: {
     if (options.action.includes(Constants.CB_GET_BACKLINK)) {
         foldPassiveType(options.expand, protyle.wysiwyg.element);
     }
+    // Focus mode visual unfold
+    if (protyle.block.showAll && protyle.block.id !== protyle.block.rootID) {
+        const focusedBlock = protyle.wysiwyg.element.querySelector(`:scope > [data-node-id="${protyle.block.id}"]`) as HTMLElement;
+        if (focusedBlock) {
+            focusedBlock.classList.add("protyle-wysiwyg--focus-unfold");
+            
+            const isFolded = focusedBlock.getAttribute("fold") === "1";
+            const blockType = focusedBlock.getAttribute("data-type");
+            
+            if (isFolded && blockType === "NodeHeading") {
+                fetchPost("/api/block/getHeadingChildrenDOM", {
+                    id: protyle.block.id,
+                    removeFoldAttr: true,
+                }, (response) => {
+                    if (response.code === 0 && response.data) {
+                        const template = document.createElement("template");
+                        template.innerHTML = response.data;
+                        const allElements = Array.from(template.content.children);
+                        
+                        allElements.slice(1).reverse().forEach((child: Element) => {
+                            child.setAttribute("data-focus-unfold-child", "true");
+                            focusedBlock.insertAdjacentElement("afterend", child);
+                        });
+                        
+                        const parentElement = focusedBlock.parentElement;
+                        if (parentElement) {
+                            processRender(parentElement);
+                            highlightRender(parentElement);
+                            avRender(parentElement, protyle);
+                            blockRender(protyle, parentElement);
+                        }
+                    }
+                });
+            }
+        }
+    }
     processRender(protyle.wysiwyg.element);
     highlightRender(protyle.wysiwyg.element);
     avRender(protyle.wysiwyg.element, protyle);


### PR DESCRIPTION
## Description / 描述

Implements visual unfold for folded blocks when entering focus mode (zoom in). When a user zooms into a folded block, the block visually expands to show its children without modifying the underlying `fold` attribute. This provides a better editing experience while maintaining the document's fold state.

Closes #8956 

## Changes

### CSS ([`app/src/assets/scss/protyle/_wysiwyg.scss`](app/src/assets/scss/protyle/_wysiwyg.scss))
- Added `.protyle-wysiwyg--focus-unfold` class styles that override folded block appearance
- Supports all block types: headings, list items, blockquotes, code blocks, super blocks, tables, attribute views, and block query embeds
- Uses CSS-only approach for most block types; headings require DOM manipulation due to children not being present in the DOM

### TypeScript ([`app/src/protyle/util/onGet.ts`](app/src/protyle/util/onGet.ts))
- Adds `protyle-wysiwyg--focus-unfold` class to focused block when entering focus mode
- For folded headings, fetches children via `/api/block/getHeadingChildrenDOM` API and inserts them into DOM
- Children are marked with `data-focus-unfold-child` attribute for identification

### Gutter ([`app/src/protyle/gutter/index.ts`](app/src/protyle/gutter/index.ts))
- Updated block gutter logic to show block markers for children of visually unfolded blocks
- Previously, children of folded blocks had their gutter hidden; now checks for `protyle-wysiwyg--focus-unfold` class

## Technical Details
- **CSS-first approach**: Most block types are handled purely via CSS overrides, minimizing JavaScript overhead
- **API integration**: Folded headings require fetching children via API since they're not rendered in the DOM
- **No data mutation**: The `fold="1"` attribute remains unchanged; this is purely a visual/UI enhancement

## Demo Video

https://github.com/user-attachments/assets/704d3fb0-3db4-4486-b1d7-52925bb1d9ea



<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [ ] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [x] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突