### PR TITLE
Support cross-block selection of some inline elements and then settings

### DIFF
--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -1515,6 +1515,37 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
             }
         }
 
+        // multi-block INLINE_TYPE (框选时 Ctrl+B/U/T/S 格式化)
+        const selectElements = protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select");
+        if (selectElements.length > 0 && !nodeElement.classList.contains("code-block") && !event.repeat && !isInEmbedBlock(nodeElement)) {
+            let matchedInlineType: string | undefined;
+            protyle.options.toolbar.find((menuItem: IMenuItem) => {
+                if (menuItem.hotkey && matchHotKey(menuItem.hotkey, event) && Constants.INLINE_TYPE.includes(menuItem.name) && !["block-ref", "inline-math", "inline-memo", "a", "text"].includes(menuItem.name)) {
+                    matchedInlineType = menuItem.name;
+                    return true;
+                }
+            });
+            if (matchedInlineType) {
+                protyle.toolbar.range = range;
+                selectElements.forEach((block: Element) => {
+                    const editElement = getContenteditableElement(block);
+                    if (!editElement || editElement.tagName === "TABLE" || block.classList.contains("code-block")) {
+                        return;
+                    }
+                    const blockRange = document.createRange();
+                    blockRange.selectNodeContents(editElement);
+                    protyle.toolbar.range = blockRange;
+                    protyle.toolbar.setInlineMark(protyle, matchedInlineType, "range");
+                });
+                protyle.toolbar.range = range;
+                focusByRange(range);
+                event.preventDefault();
+                event.stopPropagation();
+                protyle.wysiwyg.preventKeyup = true;
+                return true;
+            }
+        }
+
         // toolbar action
         if (matchHotKey(window.siyuan.config.keymap.editor.insert.lastUsed.custom, event)) {
             protyle.toolbar.range = range;


### PR DESCRIPTION
Apply inline formatting (bold, italic, strikethrough, underline, mark, etc.) to all selected blocks when using multi-block selection (矩形框选).

### Background

When multiple blocks are selected via Ctrl/Shift + drag (`.protyle-wysiwyg--select`), the Backspace key removes them, but inline format shortcuts like Ctrl+B/Ctrl+U/⇧⌘S have no effect. The format path (`setInlineMark`) works solely on the browser Range, which is collapsed after multi-block selection. This change bridges the gap.

### Changes

- `app/src/protyle/wysiwyg/keydown.ts`: Before the regular toolbar hotkey loop, check if there are `.protyle-wysiwyg--select` elements. If so, find the matched INLINE_TYPE menu item and apply `setInlineMark` on each selected block's contenteditable container individually.
- Excluded menu items: `block-ref`, `inline-math`, `inline-memo`, `a`, `text` — these have dedicated interaction patterns not suitable for batch application.
- Excluded block types: TABLE and code-block — inline formatting does not apply meaningfully to these.
- After processing, the original cursor range is restored via `focusByRange`.

### Known limitation

Each block produces a separate undo transaction (N blocks = N Ctrl+Z presses). Merging all `setInlineMark` calls into a single transaction would require deeper refactoring of the 600-line formatting logic and is left as future improvement.

### References

- Closes #17730
