### PR TITLE
为内核插件增加通用流式代理响应

### DIFF
--- a/kernel/api/network.go
+++ b/kernel/api/network.go
@@ -23,12 +23,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/textproto"
 	"net/url"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/88250/gulu"
@@ -188,6 +186,9 @@ func forwardProxy(c *gin.Context) {
 	}
 
 	client := getSafeClient(time.Duration(timeout) * time.Millisecond)
+	if redirectArg, ok := arg["redirect"].(bool); ok && !redirectArg {
+		client.SetRedirectPolicy(req.NoRedirectPolicy())
+	}
 	request := client.R()
 	if headers, ok := arg["headers"].([]any); ok {
 		for _, pair := range headers {
@@ -327,31 +328,9 @@ func forwardProxy(c *gin.Context) {
 	//	elapsed.Seconds(), len(bodyData), data["url"], headers, contentType, arg["payload"], data["status"], shortBody)
 }
 
-// ssrfSafeDialer returns a net.Dialer whose Control hook blocks private IPs.
-func ssrfSafeDialer(timeout time.Duration) *net.Dialer {
-	return &net.Dialer{
-		Timeout: timeout,
-		Control: func(network, address string, _ syscall.RawConn) error {
-			host, _, err := net.SplitHostPort(address)
-			if err != nil {
-				return err
-			}
-			if ip := net.ParseIP(host); ip != nil && isPrivateIP(ip) {
-				return fmt.Errorf("ip address [%s] is prohibited", host)
-			}
-			return nil
-		},
-	}
-}
-
-// 校验 IP 是否为私有内网地址
-func isPrivateIP(ip net.IP) bool {
-	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() || ip.IsUnspecified()
-}
-
 // 创建安全的 HTTP Client，防止 SSRF 和 DNS 重绑定
 func getSafeClient(timeout time.Duration) *req.Client {
-	dialer := ssrfSafeDialer(timeout)
+	dialer := util.SSRFSafeDialer(timeout)
 
 	client := req.C()
 	client.SetTimeout(timeout)
@@ -436,7 +415,7 @@ func httpProxy(c *gin.Context) {
 	}
 
 	transport := &http.Transport{
-		DialContext: ssrfSafeDialer(30 * time.Second).DialContext,
+		DialContext: util.SSRFSafeDialer(30 * time.Second).DialContext,
 	}
 	httpClient := &http.Client{Transport: transport}
 
@@ -491,7 +470,7 @@ func wsProxy(c *gin.Context) {
 	}
 
 	wsDialer := &websocket.Dialer{
-		NetDialContext:   ssrfSafeDialer(30 * time.Second).DialContext,
+		NetDialContext:   util.SSRFSafeDialer(30 * time.Second).DialContext,
 		HandshakeTimeout: 30 * time.Second,
 	}
 
@@ -584,7 +563,7 @@ func esProxy(c *gin.Context) {
 	}
 
 	transport := &http.Transport{
-		DialContext: ssrfSafeDialer(30 * time.Second).DialContext,
+		DialContext: util.SSRFSafeDialer(30 * time.Second).DialContext,
 	}
 	httpClient := &http.Client{Transport: transport}
 

--- a/kernel/plugin/server.go
+++ b/kernel/plugin/server.go
@@ -22,10 +22,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/gin-gonic/gin"
 	"github.com/siyuan-note/logging"
+	"github.com/siyuan-note/siyuan/kernel/util"
 )
 
 const (
@@ -187,26 +189,73 @@ func isSseRequest(c *gin.Context) bool {
 
 func isHopByHopHeader(header string) bool {
 	switch strings.ToLower(header) {
-	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "proxy-connection", "te", "trailer", "transfer-encoding", "upgrade":
 		return true
 	default:
 		return false
 	}
 }
 
-func writeProxyResponse(c *gin.Context, proxy *ResponseProxy) error {
+func connectionHopByHopHeaders(header http.Header) map[string]bool {
+	result := map[string]bool{}
+	for _, value := range header.Values("Connection") {
+		for _, part := range strings.Split(value, ",") {
+			if name := strings.ToLower(strings.TrimSpace(part)); name != "" {
+				result[name] = true
+			}
+		}
+	}
+	return result
+}
+
+func shouldProxyHeader(name string, connectionHeaders map[string]bool) bool {
+	lower := strings.ToLower(name)
+	return lower != "set-cookie" && !isHopByHopHeader(lower) && !connectionHeaders[lower]
+}
+
+func copyProxyHeaders(dst http.Header, src http.Header) {
+	connectionHeaders := connectionHopByHopHeaders(src)
+	for key, values := range src {
+		if !shouldProxyHeader(key, connectionHeaders) {
+			continue
+		}
+		dst.Del(key)
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func newProxyHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext:        util.SSRFSafeDialer(30 * time.Second).DialContext,
+			DisableCompression: true,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			req.Header.Del("Referer")
+			return nil
+		},
+		Timeout: 0,
+	}
+}
+
+func writeProxyResponse(c *gin.Context, proxy *ResponseProxy) {
 	if proxy.URL == "" {
 		c.String(http.StatusBadRequest, "missing proxy url")
-		return nil
+		return
 	}
 	targetURL, err := url.ParseRequestURI(proxy.URL)
 	if err != nil {
 		c.String(http.StatusBadRequest, "parse proxy url failed: %s", err.Error())
-		return nil
+		return
 	}
 	if targetURL.Scheme != "http" && targetURL.Scheme != "https" {
 		c.String(http.StatusBadRequest, "only http/https proxy url is allowed")
-		return nil
+		return
 	}
 
 	method := proxy.Method
@@ -216,43 +265,39 @@ func writeProxyResponse(c *gin.Context, proxy *ResponseProxy) error {
 	method = strings.ToUpper(method)
 	if method != http.MethodGet && method != http.MethodHead {
 		c.String(http.StatusBadRequest, "only GET/HEAD proxy method is allowed")
-		return nil
+		return
 	}
 	req, err := http.NewRequestWithContext(c.Request.Context(), method, targetURL.String(), nil)
 	if err != nil {
 		c.String(http.StatusBadRequest, "create proxy request failed: %s", err.Error())
-		return nil
+		return
 	}
+	requestConnectionHeaders := connectionHopByHopHeaders(http.Header(proxy.Headers))
 	for key, values := range proxy.Headers {
+		if !shouldProxyHeader(key, requestConnectionHeaders) {
+			continue
+		}
 		for _, value := range values {
 			req.Header.Add(key, value)
 		}
 	}
 
-	client := &http.Client{Timeout: 0}
+	client := newProxyHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		c.String(http.StatusBadGateway, "proxy request failed: %s", err.Error())
-		return nil
+		return
 	}
 	defer resp.Body.Close()
 
-	for key, values := range resp.Header {
-		if isHopByHopHeader(key) {
-			continue
-		}
-		for _, value := range values {
-			c.Writer.Header().Add(key, value)
-		}
-	}
+	copyProxyHeaders(c.Writer.Header(), resp.Header)
 	c.Writer.WriteHeader(resp.StatusCode)
 	if method == http.MethodHead {
-		return nil
+		return
 	}
 	if _, err = io.Copy(c.Writer, resp.Body); err != nil {
 		logging.LogWarnf("plugin proxy copy response failed: %s", err.Error())
 	}
-	return nil
 }
 
 func parseRequest(c *gin.Context) (request *Request, err error) {
@@ -493,9 +538,7 @@ func HandleHttpRequest(c *gin.Context, scope AccessScope) {
 			return
 		} else if response.Body.Proxy != nil {
 			// Streaming proxy
-			if proxyErr := writeProxyResponse(c, response.Body.Proxy); proxyErr != nil {
-				c.String(http.StatusInternalServerError, "[plugin:%s] Error occurred while proxying HTTP response: %s", name, proxyErr.Error())
-			}
+			writeProxyResponse(c, response.Body.Proxy)
 			return
 		} else {
 			// No body

--- a/kernel/plugin/server.go
+++ b/kernel/plugin/server.go
@@ -18,7 +18,10 @@ package plugin
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/gin-gonic/gin"
@@ -144,6 +147,7 @@ type ResponseBody struct {
 	String   *ResponseString         `json:"string"`   // if the response is a formatted string, String will be non-nil.
 	Raw      *ResponseRawData        `json:"raw"`      // if the response is raw data, Raw will be non-nil.
 	Redirect *ResponseRedirect       `json:"redirect"` // if the response is a redirect, Redirect will be non-nil.
+	Proxy    *ResponseProxy          `json:"proxy"`    // if the response is a streaming proxy, Proxy will be non-nil.
 }
 
 type ResponseSerializedData struct {
@@ -170,9 +174,85 @@ type ResponseRedirect struct {
 	Location string `json:"location"` // the URL to redirect to
 }
 
+type ResponseProxy struct {
+	URL     string              `json:"url"`     // target http/https URL
+	Method  string              `json:"method"`  // optional, defaults to the incoming request method, only GET/HEAD are supported
+	Headers map[string][]string `json:"headers"` // request headers forwarded to the target
+}
+
 // isSseRequest checks if the incoming HTTP request is a Server-Sent Events (SSE) request by inspecting the "Accept" header for the "text/event-stream" value.
 func isSseRequest(c *gin.Context) bool {
 	return c.GetHeader(SseHeaderAcceptName) == SseHeaderAcceptValue
+}
+
+func isHopByHopHeader(header string) bool {
+	switch strings.ToLower(header) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func writeProxyResponse(c *gin.Context, proxy *ResponseProxy) error {
+	if proxy.URL == "" {
+		c.String(http.StatusBadRequest, "missing proxy url")
+		return nil
+	}
+	targetURL, err := url.ParseRequestURI(proxy.URL)
+	if err != nil {
+		c.String(http.StatusBadRequest, "parse proxy url failed: %s", err.Error())
+		return nil
+	}
+	if targetURL.Scheme != "http" && targetURL.Scheme != "https" {
+		c.String(http.StatusBadRequest, "only http/https proxy url is allowed")
+		return nil
+	}
+
+	method := proxy.Method
+	if method == "" {
+		method = c.Request.Method
+	}
+	method = strings.ToUpper(method)
+	if method != http.MethodGet && method != http.MethodHead {
+		c.String(http.StatusBadRequest, "only GET/HEAD proxy method is allowed")
+		return nil
+	}
+	req, err := http.NewRequestWithContext(c.Request.Context(), method, targetURL.String(), nil)
+	if err != nil {
+		c.String(http.StatusBadRequest, "create proxy request failed: %s", err.Error())
+		return nil
+	}
+	for key, values := range proxy.Headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	client := &http.Client{Timeout: 0}
+	resp, err := client.Do(req)
+	if err != nil {
+		c.String(http.StatusBadGateway, "proxy request failed: %s", err.Error())
+		return nil
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		if isHopByHopHeader(key) {
+			continue
+		}
+		for _, value := range values {
+			c.Writer.Header().Add(key, value)
+		}
+	}
+	c.Writer.WriteHeader(resp.StatusCode)
+	if method == http.MethodHead {
+		return nil
+	}
+	if _, err = io.Copy(c.Writer, resp.Body); err != nil {
+		logging.LogWarnf("plugin proxy copy response failed: %s", err.Error())
+	}
+	return nil
 }
 
 func parseRequest(c *gin.Context) (request *Request, err error) {
@@ -410,6 +490,12 @@ func HandleHttpRequest(c *gin.Context, scope AccessScope) {
 		} else if response.Body.Redirect != nil {
 			// Redirect
 			c.Redirect(response.StatusCode, response.Body.Redirect.Location)
+			return
+		} else if response.Body.Proxy != nil {
+			// Streaming proxy
+			if proxyErr := writeProxyResponse(c, response.Body.Proxy); proxyErr != nil {
+				c.String(http.StatusInternalServerError, "[plugin:%s] Error occurred while proxying HTTP response: %s", name, proxyErr.Error())
+			}
 			return
 		} else {
 			// No body

--- a/kernel/plugin/server_test.go
+++ b/kernel/plugin/server_test.go
@@ -1,0 +1,129 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConnectionHopByHopHeaders(t *testing.T) {
+	header := http.Header{}
+	header.Add("Connection", "X-Request-Id, keep-alive")
+	header.Add("Connection", "X-Trace")
+
+	got := connectionHopByHopHeaders(header)
+	for _, name := range []string{"x-request-id", "keep-alive", "x-trace"} {
+		if !got[name] {
+			t.Fatalf("expected %q to be treated as hop-by-hop", name)
+		}
+	}
+}
+
+func TestCopyProxyHeadersFiltersAndOverwrites(t *testing.T) {
+	dst := http.Header{}
+	dst.Add("Content-Type", "application/json")
+	dst.Add("Accept-Ranges", "old")
+	dst.Add("X-Keep", "plugin")
+
+	src := http.Header{}
+	src.Add("Content-Type", "video/mp4")
+	src.Add("Accept-Ranges", "bytes")
+	src.Add("Connection", "X-Hop")
+	src.Add("X-Hop", "drop")
+	src.Add("Proxy-Connection", "close")
+	src.Add("Set-Cookie", "cloud=session")
+	src.Add("Transfer-Encoding", "chunked")
+
+	copyProxyHeaders(dst, src)
+
+	if got := dst.Values("Content-Type"); len(got) != 1 || got[0] != "video/mp4" {
+		t.Fatalf("expected upstream content type to overwrite plugin header, got %v", got)
+	}
+	if got := dst.Values("Accept-Ranges"); len(got) != 1 || got[0] != "bytes" {
+		t.Fatalf("expected upstream accept-ranges to overwrite plugin header, got %v", got)
+	}
+	for _, name := range []string{"Connection", "X-Hop", "Proxy-Connection", "Set-Cookie", "Transfer-Encoding"} {
+		if got := dst.Values(name); len(got) != 0 {
+			t.Fatalf("expected %q to be filtered, got %v", name, got)
+		}
+	}
+	if got := dst.Values("X-Keep"); len(got) != 1 || got[0] != "plugin" {
+		t.Fatalf("expected unrelated plugin header to remain, got %v", got)
+	}
+}
+
+func TestNewProxyHTTPClientStreamsRedirectsWithProxyHeaders(t *testing.T) {
+	client := newProxyHTTPClient()
+	if client.CheckRedirect == nil {
+		t.Fatal("expected redirect policy to be set")
+	}
+
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Range"); got != "bytes=0-" {
+			t.Fatalf("expected Range to reach redirected request, got %q", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != "pan.baidu.com" {
+			t.Fatalf("expected User-Agent to reach redirected request, got %q", got)
+		}
+		if got := r.Header.Get("Referer"); got != "" {
+			t.Fatalf("expected Referer to be dropped on redirected request, got %q", got)
+		}
+		w.WriteHeader(http.StatusPartialContent)
+	}))
+	defer final.Close()
+
+	start := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer start.Close()
+
+	savedTransport := client.Transport
+	client.Transport = http.DefaultTransport
+	req, err := http.NewRequest(http.MethodGet, start.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Range", "bytes=0-")
+	req.Header.Set("User-Agent", "pan.baidu.com")
+	req.Header.Set("Referer", "https://drop.example.test/")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("expected redirect to be followed, got %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("expected final response status, got %d", resp.StatusCode)
+	}
+	client.Transport = savedTransport
+
+	tooMany := make([]*http.Request, 10)
+	for i := range tooMany {
+		tooMany[i] = &http.Request{Header: http.Header{}}
+	}
+	if err := client.CheckRedirect(&http.Request{Header: http.Header{}}, tooMany); err == nil {
+		t.Fatal("expected redirect limit error")
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if !transport.DisableCompression {
+		t.Fatal("expected automatic compression handling to be disabled")
+	}
+}

--- a/kernel/util/net.go
+++ b/kernel/util/net.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/88250/gulu"
@@ -117,6 +118,27 @@ func IsLocalOrigin(origin string) bool {
 		return IsLocalHostname(u.Hostname())
 	}
 	return false
+}
+
+// SSRFSafeDialer returns a net.Dialer whose Control hook blocks private, loopback, link-local and unspecified IPs.
+func SSRFSafeDialer(timeout time.Duration) *net.Dialer {
+	return &net.Dialer{
+		Timeout: timeout,
+		Control: func(network, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return err
+			}
+			if ip := net.ParseIP(host); ip != nil && isPrivateIP(ip) {
+				return fmt.Errorf("ip address [%s] is prohibited", host)
+			}
+			return nil
+		},
+	}
+}
+
+func isPrivateIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() || ip.IsUnspecified()
 }
 
 func IsOnline(checkURL string, skipTlsVerify bool, timeout int) bool {


### PR DESCRIPTION
﻿## 需求背景

内核插件现在可以实现文件管理、播放器、网盘挂载等场景，但现有 HTTP 响应类型只有 JSON、File、String、Raw、Redirect。对于视频、音频、大文件下载和 Range 请求，插件如果先在 JS 侧把上游 body 读完再返回，会导致内存、延迟和媒体播放兼容性问题。

OpenList 这类文件服务的标准链路是：驱动返回下载链接和必要请求头，然后服务端透明代理上游响应，把 `206 Partial Content`、`Content-Range`、`Accept-Ranges`、`Content-Type` 等标准媒体头原样返回给浏览器媒体栈。因此内核插件需要一个通用的流式代理响应能力。

## 实现说明

本 PR 为内核插件 HTTP 响应新增 `body.proxy`：

```json
{
  "body": {
    "proxy": {
      "url": "https://example.com/video.mp4",
      "method": "GET",
      "headers": {
        "Range": ["bytes=0-"],
        "User-Agent": ["pan.baidu.com"]
      }
    }
  }
}
```

内核收到该响应后由 Go 侧接管流式代理：

- 目标 URL 只允许 `http` / `https`。
- 方法只允许 `GET` / `HEAD`。
- 使用原请求 context 创建上游请求，客户端断开时可以取消上游请求。
- 使用共享的 `util.SSRFSafeDialer`，与现有 `/api/network/*Proxy` 保持同一 SSRF 防护边界。
- 转发插件声明的请求头，同时过滤 hop-by-hop header 和 `Connection` 声明的动态 hop-by-hop header。
- 禁用 Go 自动压缩处理，避免 header/body 不透明。
- 服务端受控跟随最多 10 次下载重定向；使用 Go 标准 redirect header 策略，保留 `Range` / `User-Agent` 等普通代理请求头，不手动跨域复制敏感头，并删除 `Referer`。
- 复制最终上游状态码和安全响应头，覆盖重复 header，过滤 hop-by-hop header 和上游 `Set-Cookie`。
- `HEAD` 只返回状态和头；`GET` 通过 `io.Copy` 流式写回 body。

另外，`/api/network/forwardProxy` 增加可选参数 `redirect: false`。默认行为不变；需要做 HEAD/链接探测的插件可以显式关闭 req client 的自动重定向，用于先解析最终下载地址，再交给 `body.proxy` 流式输出。

## 审查与取舍

这不是某个网盘的专用逻辑，而是内核插件的通用 HTTP streaming primitive。下游插件只负责返回最终目标 URL 和必要 header，内核统一处理安全校验、Range/媒体响应头、重定向、SSRF 防护和流式复制。

对 Copilot review 中的几个点已处理：

- `writeProxyResponse` 改为无返回值函数，错误分支由函数内部直接写响应，避免死代码。
- 完整过滤 hop-by-hop header，包括 `Proxy-Connection` 和 `Connection` 中声明的动态 header。
- 复制上游响应头时先删除同名 header，再写入上游值，避免 `Content-Type` / `Content-Length` / `Accept-Ranges` 等重复。
- 使用专用 HTTP client，禁用自动压缩，并使用 SSRF-safe dialer。
- 最终根据真实媒体播放场景，将早先“完全不跟随重定向”调整为“服务端受控跟随下载重定向”：这样可以避免浏览器直接访问临时下载域导致插件提供的 `Range` / `User-Agent` 等 header 丢失，同时仍然不手动跨域复制敏感 header。
- 上游 `Set-Cookie` 不透传给客户端，避免云盘下载域 cookie 写入思源本地域。

## 本地验证

已在本地 Windows 环境验证：

```bash
go test -count=1 -vet=off ./plugin ./api ./util
```

并使用下游 `siyuan-openlist` 插件实测：

- 插件 `/p/<path>` 代理百度网盘视频可以正常播放。
- 百度下载链路中的 `302` 不再暴露给浏览器，而是在内核代理侧服务端跟随。
- 最终播放请求保留 `Range` 和驱动声明的 `User-Agent`。
- 浏览器收到标准媒体响应，不依赖 `/api/network/proxy` 的 `Siyuan-Proxy-*` 前缀头。

还重新构建了 Windows 安装包并本地验证可播放：

```text
app/build/siyuan-3.6.5-win.exe
SHA256: FA7C490E2A9BBC3AEFC6D664879C757DE72219D55B485A28922561D9981298A3
```

## 兼容性

这是向后兼容的新增响应体类型。未使用 `body.proxy` 的现有插件响应逻辑不受影响。

`forwardProxy` 的 `redirect` 参数也是可选参数，默认行为保持原样。
