### PR TITLE
Implement kernel plugin lifecycle management and client plugin API

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -217,6 +217,15 @@ export class App {
                                 if (isBrowser() && !isInMobileApp()) {
                                     window.location.href = "about:blank";
                                 }
+                                break;
+                            case "updateKernelPluginState": {
+                                const {name, state} = data.data as {name: string, state: TKernelPluginState};
+                                const plugin = this.plugins.find(p => p.name === name);
+                                if (plugin) {
+                                    plugin.kernel.state.code = state;
+                                }
+                                break;
+                            }
                         }
                     }
                 }

--- a/app/src/plugin/index.ts
+++ b/app/src/plugin/index.ts
@@ -19,10 +19,12 @@ import {Constants} from "../constants";
 import {uninstall} from "./uninstall";
 import {addPluginDock, afterLoadPlugin, loadPlugins} from "./loader";
 import {normalizeStoragePath} from "../util/pathName";
+import {Kernel} from "./kernel";
 
 export class Plugin {
     private app: App;
     public i18n: IObject;
+    public kernel: InstanceType<typeof Kernel>;
     public eventBus: EventBus;
     public data: any = {};
     public displayName: string;
@@ -71,6 +73,7 @@ export class Plugin {
     }) {
         this.app = options.app;
         this.i18n = options.i18n;
+        this.kernel = new Kernel(options.app.appId, options.name);
         this.displayName = options.displayName;
         this.eventBus = new EventBus(options.name);
 

--- a/app/src/plugin/index.ts
+++ b/app/src/plugin/index.ts
@@ -24,8 +24,8 @@ import {Kernel} from "./kernel";
 export class Plugin {
     private app: App;
     public i18n: IObject;
-    public kernel: InstanceType<typeof Kernel>;
     public eventBus: EventBus;
+    public kernel: Kernel;
     public data: any = {};
     public displayName: string;
     public readonly name: string;
@@ -73,9 +73,13 @@ export class Plugin {
     }) {
         this.app = options.app;
         this.i18n = options.i18n;
-        this.kernel = new Kernel(options.app.appId, options.name);
         this.displayName = options.displayName;
         this.eventBus = new EventBus(options.name);
+        this.kernel = new Kernel({
+            appId: options.app.appId,
+            name: options.name,
+            eventBus: this.eventBus,
+        });
 
         // https://github.com/siyuan-note/siyuan/issues/9943
         Object.defineProperty(this, "name", {

--- a/app/src/plugin/kernel.ts
+++ b/app/src/plugin/kernel.ts
@@ -55,7 +55,7 @@ export class Kernel implements IKernelPlugin {
     #createState(): IKernelPluginState {
         return new KernelState((state) => {
             switch (state.code) {
-                case 3: // running
+                case 2: // running
                     if (this.#rpcWs == null) {
                         this.#rpcWs = this.#createJsonRpcWebSocket();
                         break;

--- a/app/src/plugin/kernel.ts
+++ b/app/src/plugin/kernel.ts
@@ -1,5 +1,7 @@
 import {fetchSyncPost} from "../util/fetch";
 
+import type {EventBus} from "./EventBus";
+
 export class Kernel implements IKernelPlugin {
     public state: IKernelPluginState;
     public rpc: IKernelPluginRpc;
@@ -15,6 +17,11 @@ export class Kernel implements IKernelPlugin {
     #name: string;
 
     /**
+     * 客户端插件的事件总线
+     */
+    #eventBus: EventBus;
+
+    /**
      * JSON RPC WebSocket 连接，用于接收内核插件通知类型的 RPC 调用
      *
      * 普通的 RPC 调用使用 POST 请求
@@ -28,12 +35,15 @@ export class Kernel implements IKernelPlugin {
 
     #rpcCallUrl: string;
 
-    constructor(
-        appId: string,
-        name: string,
-    ) {
-        this.#appId = appId;
-        this.#name = name;
+    constructor(options: {
+        appId: string;
+        name: string;
+        eventBus: EventBus;
+    }) {
+        this.#appId = options.appId;
+        this.#name = options.name;
+        this.#eventBus = options.eventBus;
+
         this.#handlers = new Map();
         this.#rpcWs = null;
         this.#rpcCallUrl = this.#createJsonRpcCallUrl();
@@ -44,7 +54,7 @@ export class Kernel implements IKernelPlugin {
 
     #createState(): IKernelPluginState {
         return new KernelState((state) => {
-            switch (state) {
+            switch (state.code) {
                 case 3: // running
                     if (this.#rpcWs == null) {
                         this.#rpcWs = this.#createJsonRpcWebSocket();
@@ -64,6 +74,7 @@ export class Kernel implements IKernelPlugin {
                     }
                     break;
             }
+            this.#eventBus.emit("kernel-plugin-state-change", state);
         });
     }
 
@@ -215,19 +226,17 @@ export class Kernel implements IKernelPlugin {
 }
 
 export class KernelState implements IKernelPluginState {
-    #state: TKernelPluginState = -1;
+    #code: TKernelPluginState = -1;
     #description: string = "inactive";
 
-    #onchange: ((state: TKernelPluginState) => void);
+    #onchange: ((state: IKernelPluginState) => void);
 
-    public onchange: ((state: TKernelPluginState) => void) | null = null;
-
-    constructor(onchange: ((state: TKernelPluginState) => void)) {
+    constructor(onchange: ((state: IKernelPluginState) => void)) {
         this.#onchange = onchange;
     }
 
     set code(state: TKernelPluginState) {
-        this.#state = state;
+        this.#code = state;
         this.#description = (() => {
             switch (state) {
                 case -1:
@@ -251,17 +260,14 @@ export class KernelState implements IKernelPluginState {
             }
         })();
 
-        this.#onchange(state);
-
-        try {
-            this.onchange?.(state);
-        } catch (error) {
-            console.error("Error in kernel plugin state onchange handler:", error);
-        }
+        this.#onchange({
+            code: this.#code,
+            description: this.#description,
+        });
     }
 
     get code() {
-        return this.#state;
+        return this.#code;
     }
 
     get description() {

--- a/app/src/plugin/kernel.ts
+++ b/app/src/plugin/kernel.ts
@@ -1,0 +1,282 @@
+import {fetchSyncPost} from "../util/fetch";
+
+export class Kernel implements IKernelPlugin {
+    public state: IKernelPluginState;
+    public rpc: IKernelPluginRpc;
+
+    /**
+     * 内核插件所属的应用 ID，用于区分不同应用的内核插件，建立 WebSocket 连接时会携带该 ID，以便内核正确路由消息
+     */
+    #appId: string;
+
+    /**
+     * 内核插件的名称，必须与内核插件注册时使用的名称一致，用于建立 WebSocket 连接和接收通知
+     */
+    #name: string;
+
+    /**
+     * JSON RPC WebSocket 连接，用于接收内核插件通知类型的 RPC 调用
+     *
+     * 普通的 RPC 调用使用 POST 请求
+     */
+    #rpcWs: WebSocket | null;
+
+    /**
+     * 内核插件通知类型的 RPC 调用的处理函数
+     */
+    #handlers: Map<TJsonRpcMethod, Set<TJsonRpcHandler<void>>>;
+
+    #rpcCallUrl: string;
+
+    constructor(
+        appId: string,
+        name: string,
+    ) {
+        this.#appId = appId;
+        this.#name = name;
+        this.#handlers = new Map();
+        this.#rpcWs = null;
+        this.#rpcCallUrl = this.#createJsonRpcCallUrl();
+
+        this.state = this.#createState();
+        this.rpc = this.#createRpc();
+    }
+
+    #createState(): IKernelPluginState {
+        return new KernelState((state) => {
+            switch (state) {
+                case 3: // running
+                    if (this.#rpcWs == null) {
+                        this.#rpcWs = this.#createJsonRpcWebSocket();
+                        break;
+                    }
+
+                    switch (this.#rpcWs.readyState) {
+                        case WebSocket.CONNECTING:
+                        case WebSocket.OPEN:
+                            // 内核插件正在运行，且 WebSocket 连接已建立或正在建立，无需处理
+                            break;
+                        case WebSocket.CLOSING:
+                        case WebSocket.CLOSED:
+                            // 内核插件已在运行，但 WebSocket 连接未建立或已断开，尝试重新建立连接
+                            this.#rpcWs = this.#createJsonRpcWebSocket();
+                            break;
+                    }
+                    break;
+            }
+        });
+    }
+
+    #createRpc(): IKernelPluginRpc {
+        const self = this;
+
+        const call = new Proxy({} as Record<TJsonRpcMethod, (...args: TJsonRpcMethodParams) => Promise<any>>, {
+            get(_target, method: string) {
+                return (...args: TJsonRpcMethodParams) => self.#rpcCall(method, ...args);
+            }
+        });
+
+        const notify = new Proxy({} as Record<TJsonRpcMethod, (...args: TJsonRpcMethodParams) => void>, {
+            get(_target, method: string) {
+                return (...args: TJsonRpcMethodParams) => self.#rpcNotify(method, ...args);
+            }
+        });
+
+        return {
+            call,
+            notify,
+            batch: self.#rpcBatchCall.bind(self),
+            bind: (method: TJsonRpcMethod, handler: TJsonRpcHandler<void>) => {
+                const handlers = (() => {
+                    let handlers = self.#handlers.get(method);
+                    if (!handlers) {
+                        handlers = new Set();
+                        self.#handlers.set(method, handlers);
+                    }
+                    return handlers;
+                })();
+                handlers.add(handler);
+            },
+            unbind: (method: TJsonRpcMethod, handler: TJsonRpcHandler<void>) => {
+                const handlers = self.#handlers.get(method);
+                if (handlers) {
+                    handlers.delete(handler);
+                    if (handlers.size === 0) {
+                        self.#handlers.delete(method);
+                    }
+                }
+            },
+        };
+    }
+
+    #createJsonRpcWebSocket() {
+        const websocketURL = new URL(window.location.origin);
+        websocketURL.protocol = websocketURL.protocol === "https:" ? "wss:" : "ws:";
+        websocketURL.pathname = "/ws/plugin/rpc";
+        websocketURL.searchParams.set("name", this.#name);
+        const ws = new WebSocket(websocketURL);
+        ws.addEventListener("message", (event) => {
+            const message = JSON.parse(event.data);
+            // JSON-RPC 通知：无 id 字段，有 method 字段
+            if (message.method && message.id === undefined) {
+                const handlers = this.#handlers.get(message.method);
+                if (handlers) {
+                    const params = Array.isArray(message.params) ? message.params : [message.params];
+                    handlers.forEach(async handler => {
+                        try {
+                            await handler(...params);
+                        } catch (error) {
+                            console.error(`Error handling JSON-RPC notification for method ${message.method}:`, error);
+                        }
+                    });
+                }
+            }
+        });
+        return ws;
+    }
+
+    #createJsonRpcCallUrl() {
+        const searchParams = new URLSearchParams({ name: this.#name, appId: this.#appId });
+        return `api/plugin/rpc?${searchParams.toString()}`;
+    }
+
+    #generateId(): TJsonRpcId {
+        return Lute.NewNodeID();
+    }
+
+    async #initState() {
+        const response = await fetchSyncPost("api/plugin/getLoadedPlugin", { name: this.#name });
+        if (this.state.code === -1 && response.data?.stateCode != null) {
+            this.state.code = response.data.stateCode;
+        }
+    }
+
+    async #rpcCall(method: TJsonRpcMethod, ...params: TJsonRpcMethodParams): Promise<any> {
+        const id = this.#generateId();
+
+        const response = await fetch(this.#rpcCallUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+        });
+
+        const data = await response.json();
+        if (data.error) {
+            throw new JsonRpcError(data.error);
+        }
+        return data.result;
+    }
+
+    #rpcNotify(method: TJsonRpcMethod, ...params: TJsonRpcMethodParams): void {
+        fetch(this.#rpcCallUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ jsonrpc: "2.0", method, params }),
+        });
+    }
+
+    async #rpcBatchCall(...calls: IKernelPluginRpcCall[]): Promise<IKernelPluginRpcError | (IKernelPluginRpcResultResponse | IKernelPluginRpcErrorResponse)[]> {
+        const requests = calls.map(call => {
+            const request: IKernelPluginRpcRequest = { jsonrpc: "2.0", method: call.method };
+            if (call.params != null) {
+                request.params = call.params;
+            }
+            if (!call.notification) {
+                request.id = call.id ?? this.#generateId();
+            }
+            return request;
+        });
+
+        const response = await fetch(this.#rpcCallUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(requests),
+        });
+
+        const data = await response.json();
+        return data;
+    }
+
+    public async init() {
+        try {
+            await this.#initState();
+        } catch (error) {
+            console.error("Failed to initialize kernel plugin state:", error);
+        }
+    }
+
+    public async destroy() {
+        try {
+            this.#rpcWs?.close();
+        } catch (error) {
+            console.error("Failed to close JSON-RPC WebSocket connection:", error);
+        }
+    }
+}
+
+export class KernelState implements IKernelPluginState {
+    #state: TKernelPluginState = -1;
+    #description: string = "inactive";
+
+    #onchange: ((state: TKernelPluginState) => void);
+
+    public onchange: ((state: TKernelPluginState) => void) | null = null;
+
+    constructor(onchange: ((state: TKernelPluginState) => void)) {
+        this.#onchange = onchange;
+    }
+
+    set code(state: TKernelPluginState) {
+        this.#state = state;
+        this.#description = (() => {
+            switch (state) {
+                case -1:
+                    return "inactive";
+                case 0:
+                    return "ready";
+                case 1:
+                    return "loading";
+                case 2:
+                    return "loaded";
+                case 3:
+                    return "running";
+                case 4:
+                    return "stopping";
+                case 5:
+                    return "stopped";
+                case 6:
+                    return "error";
+                default:
+                    return "unknown";
+            }
+        })();
+
+        this.#onchange(state);
+
+        try {
+            this.onchange?.(state);
+        } catch (error) {
+            console.error("Error in kernel plugin state onchange handler:", error);
+        }
+    }
+
+    get code() {
+        return this.#state;
+    }
+
+    get description() {
+        return this.#description;
+    }
+}
+
+export class JsonRpcError extends Error implements IKernelPluginRpcError {
+    code: number;
+    data?: any;
+
+    constructor(error: IKernelPluginRpcError) {
+        super(error.message);
+
+        this.code = error.code;
+        this.data = error.data;
+    }
+}

--- a/app/src/plugin/kernel.ts
+++ b/app/src/plugin/kernel.ts
@@ -246,14 +246,12 @@ export class KernelState implements IKernelPluginState {
                 case 1:
                     return "loading";
                 case 2:
-                    return "loaded";
-                case 3:
                     return "running";
-                case 4:
+                case 3:
                     return "stopping";
-                case 5:
+                case 4:
                     return "stopped";
-                case 6:
+                case 5:
                     return "error";
                 default:
                     return "unknown";

--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -69,6 +69,7 @@ const loadPluginJS = async (app: App, item: IPluginData) => {
         i18n: item.i18n
     }) as Plugin;
     app.plugins.push(plugin);
+    await plugin.kernel.init();
     try {
         await plugin.onload();
     } catch (e) {

--- a/app/src/plugin/loader.ts
+++ b/app/src/plugin/loader.ts
@@ -69,12 +69,12 @@ const loadPluginJS = async (app: App, item: IPluginData) => {
         i18n: item.i18n
     }) as Plugin;
     app.plugins.push(plugin);
-    await plugin.kernel.init();
     try {
         await plugin.onload();
     } catch (e) {
         console.error(`plugin ${item.name} onload error:`, e);
     }
+    await plugin.kernel.init();
     return plugin;
 };
 

--- a/app/src/plugin/uninstall.ts
+++ b/app/src/plugin/uninstall.ts
@@ -17,6 +17,7 @@ export const uninstall = (app: App, name: string, isReload: boolean) => {
             } catch (e) {
                 console.error(`plugin ${plugin.name} onunload error:`, e);
             }
+            plugin.kernel.destroy();
             if (!isReload) {
                 try {
                     plugin.uninstall();

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -138,13 +138,12 @@ type TPublishAccessLevel = "public" | "protected" | "hidden" | "private" | "forb
  * - `-1`: inactive 内核插件未安装或不可用
  * - `0`: ready 内核插件已安装但未启动
  * - `1`: loading 内核插件正在启动
- * - `2`: loaded 内核插件已启动
- * - `3`: running 内核插件正在运行, 可正常使用
- * - `4`: stopping 内核插件正在停止
- * - `5`: stopped 内核插件已停止
- * - `6`: error 内核插件出现不可恢复的错误
+ * - `2`: running 内核插件正在运行, 可正常使用
+ * - `3`: stopping 内核插件正在停止
+ * - `4`: stopped 内核插件已停止
+ * - `5`: error 内核插件出现不可恢复的错误
  */
-type TKernelPluginState = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6
+type TKernelPluginState = -1 | 0 | 1 | 2 | 3 | 4 | 5
 
 type TJsonRpcId = string | number;
 type TJsonRpcMethod = string;

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -91,7 +91,8 @@ type TEventBus = "ws-main" | "sync-start" | "sync-end" | "sync-fail" |
     "destroy-protyle" |
     "lock-screen" |
     "mobile-keyboard-show" | "mobile-keyboard-hide" |
-    "code-language-update" | "code-language-change"
+    "code-language-update" | "code-language-change" |
+    "kernel-plugin-state-change"
 type TAVView = "table" | "gallery" | "kanban"
 type TAVCol =
     "text"
@@ -656,7 +657,6 @@ interface IOperationSrcs {
     isDetached: boolean
 }
 
-
 interface IObject {
     [key: string]: string;
 }
@@ -1209,11 +1209,6 @@ interface IKernelPluginState {
      * 内核插件状态的描述信息
      */
     description: string;
-
-    /**
-     * 当内核插件的状态发生变化时触发的事件处理函数，插件开发者可以通过 `onchange` 来监听状态变化
-     */
-    onchange: ((state: TKernelPluginState) => void) | null;
 }
 
 interface IKernelPluginRpcCall {

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -132,6 +132,27 @@ type TAVFilterOperator =
 type TRecentDocsSort = "viewedAt" | "closedAt" | "openAt" | "updated"
 type TPublishAccessLevel = "public" | "protected" | "hidden" | "private" | "forbidden";
 
+/**
+ * 内核插件状态
+ * - `-1`: inactive 内核插件未安装或不可用
+ * - `0`: ready 内核插件已安装但未启动
+ * - `1`: loading 内核插件正在启动
+ * - `2`: loaded 内核插件已启动
+ * - `3`: running 内核插件正在运行, 可正常使用
+ * - `4`: stopping 内核插件正在停止
+ * - `5`: stopped 内核插件已停止
+ * - `6`: error 内核插件出现不可恢复的错误
+ */
+type TKernelPluginState = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+type TJsonRpcId = string | number;
+type TJsonRpcMethod = string;
+type TJsonRpcPositionalParams = any[];
+type TJsonRpcNamedParams = Record<string, any>;
+type TJsonRpcParams = TJsonRpcPositionalParams | TJsonRpcNamedParams | undefined;
+type TJsonRpcMethodParams = TJsonRpcPositionalParams | [TJsonRpcNamedParams] | [];
+type TJsonRpcHandler<T = any> = (...args: TJsonRpcMethodParams) => Promise<T> | T;
+
 declare module "blueimp-md5"
 
 declare class Highlight {
@@ -437,7 +458,7 @@ interface IInbox {
 interface IPdfAnno {
     pages?: {
         index: number
-        positions: number []
+        positions: number[]
     }[]
     index?: number,
     color: string,
@@ -853,7 +874,7 @@ interface IRiffCard {
 }
 
 interface IModels {
-    editor: import("../editor").Editor [],
+    editor: import("../editor").Editor[],
     graph: import("../layout/dock/Graph").Graph[],
     outline: import("../layout/dock/Outline").Outline[]
     backlink: import("../layout/dock/Backlink").Backlink[]
@@ -1164,4 +1185,111 @@ interface IPublishAccessItem {
     password: string,
     disable: boolean
     iconHTML?: string
+}
+
+interface IKernelPlugin {
+    /**
+     * 内核插件的状态管理接口
+     */
+    state: IKernelPluginState;
+
+    /**
+     * 内核插件的 JSON-RPC 调用接口
+     */
+    rpc: IKernelPluginRpc;
+}
+
+interface IKernelPluginState {
+    /**
+     * 内核插件的当前状态
+     */
+    code: TKernelPluginState;
+
+    /**
+     * 内核插件状态的描述信息
+     */
+    description: string;
+
+    /**
+     * 当内核插件的状态发生变化时触发的事件处理函数，插件开发者可以通过 `onchange` 来监听状态变化
+     */
+    onchange: ((state: TKernelPluginState) => void) | null;
+}
+
+interface IKernelPluginRpcCall {
+    /**
+     * JSON-RPC 2.0 中 method 必须是 string，且插件开发者需要保证传入的方法名与内核插件绑定的方法名一致，否则可能会导致调用失败
+     */
+    method: TJsonRpcMethod;
+
+    /**
+     * JSON-RPC 2.0 中 id 可以是 string、number 或 null，但为了兼容性和实用性，插件系统中不允许使用 null 作为 id
+     * 
+     * 不设置时且 notification 不为 true 时会自动生成一个唯一的 id，设置时必须保证 id 的唯一性，否则可能会导致响应错误或混乱
+     */
+    id?: TJsonRpcId;
+
+    /**
+     * JSON-RPC 2.0 中 params 可以是 array 或 object，插件开发者需要自行保证传入参数与内核插件绑定的方法参数一致
+     */
+    params?: any[] | Record<string, any>;
+
+    /**
+     * 是否为通知，通知不会有响应，且不应传入 id
+     * @defaultValue false
+     */
+    notification?: boolean;
+}
+
+interface IKernelPluginRpcRequest extends IKernelPluginRpcCall {
+    jsonrpc: "2.0";
+}
+
+interface IKernelPluginRpcBaseResponse {
+    jsonrpc: "2.0";
+}
+
+interface IKernelPluginRpcResultResponse extends IKernelPluginRpcBaseResponse {
+    id: TJsonRpcId;
+    result?: any;
+}
+
+interface IKernelPluginRpcErrorResponse extends IKernelPluginRpcBaseResponse {
+    id: TJsonRpcId | null;
+    error?: any;
+}
+
+interface IKernelPluginRpcError {
+    code: number;
+    message: string;
+    data?: any;
+}
+
+
+
+interface IKernelPluginRpc {
+    /**
+     * 通过 {@link Proxy} 实现的动态方法调用，插件开发者可以直接调用 `call.方法名(params)` 来调用内核插件暴露的方法，无需关心 JSON-RPC 的细节
+     */
+    call: Record<TJsonRpcMethod, (...args: TJsonRpcMethodParams) => Promise<any>>;
+
+    /**
+     * 通过 {@link Proxy} 实现的动态方法调用，插件开发者可以直接调用 `notify.方法名(...args)` 来发送通知给内核插件，无需关心 JSON-RPC 的细节
+     */
+    notify: Record<TJsonRpcMethod, (...args: TJsonRpcMethodParams) => void>;
+
+    /**
+     * 批量调用方法，接受一个方法调用数组，返回一个结果数组，结果数组中的每一项对应方法调用数组中非通知的每一项，包含成功的结果或错误信息
+     */
+    batch: (...calls: IKernelPluginRpcCall[]) => Promise<IKernelPluginRpcError | (IKernelPluginRpcResultResponse | IKernelPluginRpcErrorResponse)[]>;
+
+    /**
+     * 绑定内核插件调用时的事件处理函数，插件开发者可以通过 `bind("方法名", handler)` 来监听内核插件通过 JSON-RPC 推送到客户端插件的通知
+     */
+    bind: (method: TJsonRpcMethod, handler: TJsonRpcHandler<void>) => void;
+
+    /**
+     * 解绑事件处理函数，插件开发者可以通过 `unbind("方法名", handler)` 来停止监听内核插件通过 JSON-RPC 推送到客户端插件的通知
+     */
+    unbind: (method: TJsonRpcMethod, handler: TJsonRpcHandler<void>) => void;
 }

--- a/app/src/window/closeWin.ts
+++ b/app/src/window/closeWin.ts
@@ -4,11 +4,13 @@ import { ipcRenderer } from "electron";
 
 export const closeWindow = async (app: App) => {
     for (let i = 0; i < app.plugins.length; i++) {
+        const plugin = app.plugins[i];
         try {
-            await app.plugins[i].onunload();
+            await plugin.onunload();
         } catch (e) {
             console.error(e);
         }
+        await plugin.kernel.destroy();
     }
     ipcRenderer.send(Constants.SIYUAN_CMD, "destroy");
 };

--- a/kernel/plugin/api_client.go
+++ b/kernel/plugin/api_client.go
@@ -48,25 +48,22 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 	lo.Must0(client.Set("fetch", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
-		runErr := p.worker.Run(func(rt *goja.Runtime) (_ any, err error) {
-			var path string
-			if goja.IsString(call.Argument(0)) {
-				path = call.Argument(0).String()
-			} else {
-				err = fmt.Errorf("path required")
-				return
-			}
+		var argErr error
+		var path string
+		method := "GET"
+		headers := map[string]string{}
+		var bodyString *string
+		var bodyBytes *[]byte
 
-			if !strings.HasPrefix(path, "/") {
-				err = fmt.Errorf("path must start with /")
-				return
-			}
-
-			method := "GET"
-			headers := map[string]string{}
-			var bodyString string
-			var bodyBytes []byte
-
+		if goja.IsString(call.Argument(0)) {
+			path = call.Argument(0).String()
+		} else {
+			argErr = fmt.Errorf("path required")
+		}
+		if argErr == nil && !strings.HasPrefix(path, "/") {
+			argErr = fmt.Errorf("path must start with /")
+		}
+		if argErr == nil {
 			if init := call.Argument(1); isJsValueNotNull(init) {
 				if initObj := init.ToObject(rt); initObj != nil {
 					if m := initObj.Get("method"); goja.IsString(m) {
@@ -75,25 +72,31 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 
 					if h := initObj.Get("headers"); isJsValueNotNull(h) {
 						if exportErr := rt.ExportTo(h, &headers); exportErr != nil {
-							err = fmt.Errorf("failed to export headers: %w", exportErr)
-							return
+							argErr = fmt.Errorf("failed to export headers: %w", exportErr)
 						}
 					}
 
-					if b := initObj.Get("body"); isJsValueNotNull(b) {
-
-						if goja.IsString(b) {
-							bodyString = b.String()
-						} else {
-							body := b.Export()
-							if arrayBuffer, ok := body.(goja.ArrayBuffer); ok {
-								src := arrayBuffer.Bytes()
-								bodyBytes = make([]byte, len(src))
-								copy(bodyBytes, src)
+					if argErr == nil {
+						if b := initObj.Get("body"); isJsValueNotNull(b) {
+							if goja.IsString(b) {
+								bodyString = lo.ToPtr(b.String())
+							} else {
+								body := b.Export()
+								if arrayBuffer, ok := body.(goja.ArrayBuffer); ok {
+									src := arrayBuffer.Bytes()
+									bodyBytes = lo.ToPtr(src)
+								}
 							}
 						}
 					}
 				}
+			}
+		}
+
+		runErr := p.worker.Run(func(rt *goja.Runtime) (_ any, err error) {
+			if argErr != nil {
+				err = argErr
+				return
 			}
 
 			go func() {
@@ -120,10 +123,10 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 				}
 				r.SetHeader(model.XAuthTokenKey, p.token)
 
-				if bodyString != "" {
-					r.SetBody(bodyString)
-				} else if len(bodyBytes) > 0 {
-					r.SetBody(bodyBytes)
+				if bodyString != nil {
+					r.SetBody(*bodyString)
+				} else if bodyBytes != nil {
+					r.SetBody(*bodyBytes)
 				}
 
 				resp, sendErr := r.Send(method, targetURL)
@@ -192,21 +195,19 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 	lo.Must0(client.Set("socket", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
-		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			var path string
-			if goja.IsString(call.Argument(0)) {
-				path = call.Argument(0).String()
-			} else {
-				err = fmt.Errorf("path required")
-				return
-			}
+		var argErr error
+		var path string
+		var protocols []string
 
-			if !strings.HasPrefix(path, "/") {
-				err = fmt.Errorf("path must start with /")
-				return
-			}
-
-			var protocols []string
+		if goja.IsString(call.Argument(0)) {
+			path = call.Argument(0).String()
+		} else {
+			argErr = fmt.Errorf("path required")
+		}
+		if argErr == nil && !strings.HasPrefix(path, "/") {
+			argErr = fmt.Errorf("path must start with /")
+		}
+		if argErr == nil {
 			if proto := call.Argument(1); isJsValueNotNull(proto) {
 				if protoObj := proto.ToObject(rt); protoObj != nil && protoObj.ClassName() == "Array" {
 					if arr, ok := proto.Export().([]interface{}); ok {
@@ -217,6 +218,13 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 				} else {
 					protocols = []string{proto.String()}
 				}
+			}
+		}
+
+		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
+			if argErr != nil {
+				err = argErr
+				return
 			}
 
 			var gwsConn atomic.Pointer[gws.Conn]
@@ -355,21 +363,21 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_send := rt.ToValue(func(sendCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				sendPromise, sendResolve, sendReject := rt.NewPromise()
 
-				sendRunErr := p.worker.Run(func(rt *goja.Runtime) (_ any, err error) {
-					var messageData []byte
-					var opcode gws.Opcode
-					if data := sendCall.Argument(0); isJsValueNotNull(data) {
-						if arrayBuffer, ok := data.Export().(goja.ArrayBuffer); ok {
-							opcode = gws.OpcodeBinary
-							b := arrayBuffer.Bytes()
-							messageData = make([]byte, len(b))
-							copy(messageData, b) // ArrayBuffer.Bytes() points into JS engine memory; copy before async send
-						} else {
-							opcode = gws.OpcodeText
-							messageData = []byte(data.String())
-						}
+				var messageData []byte
+				var opcode gws.Opcode
+				if data := sendCall.Argument(0); isJsValueNotNull(data) {
+					if arrayBuffer, ok := data.Export().(goja.ArrayBuffer); ok {
+						opcode = gws.OpcodeBinary
+						b := arrayBuffer.Bytes()
+						messageData = make([]byte, len(b))
+						copy(messageData, b) // ArrayBuffer.Bytes() points into JS engine memory; copy before async send
+					} else {
+						opcode = gws.OpcodeText
+						messageData = []byte(data.String())
 					}
+				}
 
+				sendRunErr := p.worker.Run(func(rt *goja.Runtime) (_ any, err error) {
 					state := WebSocketState(readyState.Load())
 					if state == WebSocketReadyStateClosing || state == WebSocketReadyStateClosed {
 						err = fmt.Errorf("WebSocket is not open (state: %d)", state)
@@ -421,11 +429,12 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_ping := rt.ToValue(func(pingCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				pingPromise, pingResolve, pingReject := rt.NewPromise()
 
+				var pingData string
+				if isJsValueNotNull(pingCall.Argument(0)) {
+					pingData = pingCall.Argument(0).String()
+				}
+
 				pingRunErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-					var pingData string
-					if isJsValueNotNull(pingCall.Argument(0)) {
-						pingData = pingCall.Argument(0).String()
-					}
 					if c := gwsConn.Load(); c != nil {
 						err = c.WritePing([]byte(pingData))
 					} else {
@@ -453,11 +462,12 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_pong := rt.ToValue(func(pongCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				pongPromise, pongResolve, pongReject := rt.NewPromise()
 
+				var pongData string
+				if isJsValueNotNull(pongCall.Argument(0)) {
+					pongData = pongCall.Argument(0).String()
+				}
+
 				pongRunErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-					var pongData string
-					if isJsValueNotNull(pongCall.Argument(0)) {
-						pongData = pongCall.Argument(0).String()
-					}
 					if c := gwsConn.Load(); c != nil {
 						err = c.WritePong([]byte(pongData))
 					} else {
@@ -485,15 +495,16 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_close := rt.ToValue(func(closeCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				closePromise, closeResolve, closeReject := rt.NewPromise()
 
+				code := uint16(1000)
+				var reason []byte
+				if isJsValueNotNull(closeCall.Argument(0)) {
+					code = uint16(closeCall.Argument(0).ToInteger())
+				}
+				if isJsValueNotNull(closeCall.Argument(1)) {
+					reason = []byte(closeCall.Argument(1).String())
+				}
+
 				closeRunErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-					code := uint16(1000)
-					var reason []byte
-					if isJsValueNotNull(closeCall.Argument(0)) {
-						code = uint16(closeCall.Argument(0).ToInteger())
-					}
-					if isJsValueNotNull(closeCall.Argument(1)) {
-						reason = []byte(closeCall.Argument(1).String())
-					}
 					if c := gwsConn.Load(); c != nil {
 						setReadyState(rt, WebSocketReadyStateClosing)
 						err = c.WriteClose(code, reason)
@@ -562,17 +573,20 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 	lo.Must0(client.Set("event", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
-		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			var path string
-			if goja.IsString(call.Argument(0)) {
-				path = call.Argument(0).String()
-			} else {
-				err = fmt.Errorf("path required")
-				return
-			}
+		var argErr error
+		var path string
+		if goja.IsString(call.Argument(0)) {
+			path = call.Argument(0).String()
+		} else {
+			argErr = fmt.Errorf("path required")
+		}
+		if argErr == nil && !strings.HasPrefix(path, "/") {
+			argErr = fmt.Errorf("path must start with /")
+		}
 
-			if !strings.HasPrefix(path, "/") {
-				err = fmt.Errorf("path must start with /")
+		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
+			if argErr != nil {
+				err = argErr
 				return
 			}
 

--- a/kernel/plugin/api_event.go
+++ b/kernel/plugin/api_event.go
@@ -39,21 +39,26 @@ func injectEvent(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err er
 	lo.Must0(event.Set("emit", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
-		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			if len(call.Arguments) < 2 {
-				err = fmt.Errorf("topic and event required")
-				return
-			}
-
-			topic := call.Argument(0).String()
+		var argErr error
+		var topic string
+		var eventData any
+		if len(call.Arguments) < 2 {
+			argErr = fmt.Errorf("topic and event required")
+		} else {
+			topic = call.Argument(0).String()
 			if topic == "" {
-				err = fmt.Errorf("topic required")
+				argErr = fmt.Errorf("topic required")
+			} else {
+				eventData = call.Argument(1).Export()
+			}
+		}
+
+		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
+			if argErr != nil {
+				err = argErr
 				return
 			}
-
-			event := call.Argument(1).Export()
-
-			p.bus.Publish(topic, event)
+			p.bus.Publish(topic, eventData)
 			return
 		}, func(rt *goja.Runtime, result any, err error) {
 			if lo.IsNil(err) {

--- a/kernel/plugin/api_logger.go
+++ b/kernel/plugin/api_logger.go
@@ -75,55 +75,26 @@ func injectLogger(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 // Logging is synchronous (in-process, no I/O), so resolve is called inline without worker.Run.
 func loggerWrapper(p *KernelPlugin, logf func(format string, args ...any)) func(goja.FunctionCall, *goja.Runtime) goja.Value {
 	return func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
-		promise, resolve, reject := rt.NewPromise()
-
-		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			parts := make([]string, 0, len(call.Arguments))
-			for _, arg := range call.Arguments {
-				if goja.IsString(arg) {
-					parts = append(parts, arg.String())
-					continue
-				}
-
-				if arg == nil {
-					parts = append(parts, "null")
-					continue
-				}
-
-				if goja.IsUndefined(arg) || goja.IsNull(arg) {
-					parts = append(parts, arg.String())
-					continue
-				}
-
-				argObj := arg.ToObject(rt)
-				if argObj != nil {
-					if argJson, marshalErr := argObj.MarshalJSON(); marshalErr == nil {
-						parts = append(parts, string(argJson))
-						continue
-					}
-				}
-
+		parts := make([]string, 0, len(call.Arguments))
+		for _, arg := range call.Arguments {
+			if goja.IsString(arg) {
 				parts = append(parts, arg.String())
+				continue
 			}
-			msg := strings.Join(parts, " ")
-
-			go print(p.Name, msg, logf)
-			return
-		}, func(rt *goja.Runtime, result any, err error) {
-			if lo.IsNil(err) {
-				if resolveErr := resolve(result); resolveErr != nil {
-					logging.LogErrorf("[plugin:%s] siyuan.logger resolve: %v", p.Name, resolveErr)
-				}
-			} else {
-				if rejectErr := reject(rt.NewGoError(err)); rejectErr != nil {
-					logging.LogErrorf("[plugin:%s] siyuan.logger reject: %v", p.Name, rejectErr)
+			if arg == nil || goja.IsUndefined(arg) || goja.IsNull(arg) {
+				parts = append(parts, arg.String())
+				continue
+			}
+			argObj := arg.ToObject(rt)
+			if argObj != nil {
+				if argJson, marshalErr := argObj.MarshalJSON(); marshalErr == nil {
+					parts = append(parts, string(argJson))
+					continue
 				}
 			}
-		})
-		if runErr != nil {
-			logging.LogErrorf("[plugin:%s] siyuan.logger worker run: %v", p.Name, runErr)
+			parts = append(parts, arg.String())
 		}
-
-		return rt.ToValue(promise)
+		go print(p.Name, strings.Join(parts, " "), logf)
+		return goja.Undefined()
 	}
 }

--- a/kernel/plugin/api_plugin.go
+++ b/kernel/plugin/api_plugin.go
@@ -34,7 +34,6 @@ func injectPlugin(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 
 	lifecycle := rt.NewObject()
 	lo.Must0(lifecycle.Set("onload", goja.Null()))
-	lo.Must0(lifecycle.Set("onloaded", goja.Null()))
 	lo.Must0(lifecycle.Set("onrunning", goja.Null()))
 	lo.Must0(lifecycle.Set("onunload", goja.Null()))
 	lo.Must0(ObjectSeal(rt, lifecycle))

--- a/kernel/plugin/api_rpc.go
+++ b/kernel/plugin/api_rpc.go
@@ -38,37 +38,41 @@ func injectRpc(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err erro
 	lo.Must0(rpc.Set("bind", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
-		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			var name string
-			var method goja.Callable
-			var descriptions []string
-
-			if len(call.Arguments) < 2 {
-				err = fmt.Errorf("method name and function required")
-				return
-			}
+		var argErr error
+		var name string
+		var method goja.Callable
+		var descriptions []string
+		if len(call.Arguments) < 2 {
+			argErr = fmt.Errorf("method name and function required")
+		} else {
 			nameArg := call.Argument(0)
 			methodArg := call.Argument(1)
 			descArgs := call.Arguments[2:]
-
 			if goja.IsString(nameArg) {
 				name = nameArg.String()
 			} else {
-				err = fmt.Errorf("first argument must be method name string")
+				argErr = fmt.Errorf("first argument must be method name string")
+			}
+			if argErr == nil {
+				if methodJs, ok := goja.AssertFunction(methodArg); ok {
+					method = methodJs
+				} else {
+					argErr = fmt.Errorf("second argument must be a function")
+				}
+			}
+			if argErr == nil {
+				descriptions = make([]string, len(descArgs))
+				for i, a := range descArgs {
+					descriptions[i] = a.String()
+				}
+			}
+		}
+
+		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
+			if argErr != nil {
+				err = argErr
 				return
 			}
-
-			if methodJs, ok := goja.AssertFunction(methodArg); ok {
-				method = methodJs
-			} else {
-				err = fmt.Errorf("second argument must be a function")
-			}
-
-			descriptions = make([]string, len(descArgs))
-			for i, a := range descArgs {
-				descriptions[i] = a.String()
-			}
-
 			err = p.bindRpcMethod(name, method, descriptions...)
 			return
 		}, func(rt *goja.Runtime, result any, err error) {
@@ -92,21 +96,21 @@ func injectRpc(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err erro
 	lo.Must0(rpc.Set("unbind", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
+		var argErr error
+		var name string
+		if len(call.Arguments) < 1 {
+			argErr = fmt.Errorf("method name required")
+		} else if nameArg := call.Argument(0); goja.IsString(nameArg) {
+			name = nameArg.String()
+		} else {
+			argErr = fmt.Errorf("first argument must be method name string")
+		}
+
 		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			var name string
-			if len(call.Arguments) < 1 {
-				err = fmt.Errorf("method name required")
+			if argErr != nil {
+				err = argErr
 				return
 			}
-
-			nameArg := call.Argument(0)
-			if goja.IsString(nameArg) {
-				name = nameArg.String()
-			} else {
-				err = fmt.Errorf("first argument must be method name string")
-				return
-			}
-
 			err = p.unbindRpcMethod(name)
 			return
 		}, func(rt *goja.Runtime, result any, err error) {
@@ -130,36 +134,40 @@ func injectRpc(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err erro
 	lo.Must0(rpc.Set("broadcast", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
-		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			if len(call.Arguments) < 1 {
-				err = fmt.Errorf("method required")
-				return
-			}
-
-			var method string
+		var argErr error
+		var method string
+		var params util.Optional[any]
+		if len(call.Arguments) < 1 {
+			argErr = fmt.Errorf("method required")
+		} else {
 			if m := call.Argument(0); goja.IsString(m) {
 				method = m.String()
 			} else {
-				err = fmt.Errorf("first argument must be method name string")
+				argErr = fmt.Errorf("first argument must be method name string")
+			}
+			if argErr == nil {
+				arg := call.Argument(1)
+				if goja.IsUndefined(arg) {
+					params.Value = nil
+					params.Exists = false
+					params.IsNull = false
+				} else if goja.IsNull(arg) {
+					params.Value = nil
+					params.Exists = true
+					params.IsNull = true
+				} else {
+					params.Value = arg.Export()
+					params.Exists = true
+					params.IsNull = false
+				}
+			}
+		}
+
+		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
+			if argErr != nil {
+				err = argErr
 				return
 			}
-
-			var params util.Optional[any]
-			arg := call.Argument(1)
-			if goja.IsUndefined(arg) {
-				params.Value = nil
-				params.Exists = false
-				params.IsNull = false
-			} else if goja.IsNull(arg) {
-				params.Value = nil
-				params.Exists = true
-				params.IsNull = true
-			} else {
-				params.Value = arg.Export()
-				params.Exists = true
-				params.IsNull = false
-			}
-
 			p.BroadcastNotification(method, params)
 			return
 		}, func(rt *goja.Runtime, result any, err error) {

--- a/kernel/plugin/api_storage.go
+++ b/kernel/plugin/api_storage.go
@@ -51,27 +51,27 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 	lo.Must0(watcher.Set("add", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
+		var argErr error
+		var path string
+		if len(call.Arguments) >= 1 && goja.IsString(call.Argument(0)) {
+			path = call.Argument(0).String()
+		} else {
+			argErr = fmt.Errorf("path required")
+		}
+
 		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			var path string
-			if len(call.Arguments) >= 1 && goja.IsString(call.Argument(0)) {
-				path = call.Argument(0).String()
-			} else {
-				err = fmt.Errorf("path required")
+			if argErr != nil {
+				err = argErr
 				return
 			}
-
 			abs, resolveErr := resolvePath(path)
 			if resolveErr != nil {
 				err = resolveErr
 				return
 			}
-
-			addErr := p.addStorageWatch(abs)
-			if addErr != nil {
+			if addErr := p.addStorageWatch(abs); addErr != nil {
 				err = fmt.Errorf("failed to add storage path to watcher: %v", addErr)
-				return
 			}
-
 			return
 		}, func(rt *goja.Runtime, result any, err error) {
 			if lo.IsNil(err) {
@@ -95,27 +95,27 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 	lo.Must0(watcher.Set("remove", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
+		var argErr error
+		var path string
+		if len(call.Arguments) >= 1 && goja.IsString(call.Argument(0)) {
+			path = call.Argument(0).String()
+		} else {
+			argErr = fmt.Errorf("path required")
+		}
+
 		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			var path string
-			if len(call.Arguments) >= 1 && goja.IsString(call.Argument(0)) {
-				path = call.Argument(0).String()
-			} else {
-				err = fmt.Errorf("path required")
+			if argErr != nil {
+				err = argErr
 				return
 			}
-
 			abs, resolveErr := resolvePath(path)
 			if resolveErr != nil {
 				err = resolveErr
 				return
 			}
-
-			addErr := p.removeStorageWatch(abs)
-			if addErr != nil {
-				err = fmt.Errorf("failed to remove storage path from watcher: %v", addErr)
-				return
+			if removeErr := p.removeStorageWatch(abs); removeErr != nil {
+				err = fmt.Errorf("failed to remove storage path from watcher: %v", removeErr)
 			}
-
 			return
 		}, func(rt *goja.Runtime, result any, err error) {
 			if lo.IsNil(err) {
@@ -143,15 +143,19 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 	lo.Must0(storage.Set("get", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
+		var argErr error
+		var path string
+		if len(call.Arguments) >= 1 && goja.IsString(call.Argument(0)) {
+			path = call.Argument(0).String()
+		} else {
+			argErr = fmt.Errorf("path required")
+		}
+
 		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			var path string
-			if len(call.Arguments) >= 1 && goja.IsString(call.Argument(0)) {
-				path = call.Argument(0).String()
-			} else {
-				err = fmt.Errorf("path required")
+			if argErr != nil {
+				err = argErr
 				return
 			}
-
 			abs, resolveErr := resolvePath(path)
 			if resolveErr != nil {
 				err = resolveErr
@@ -216,18 +220,25 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 	lo.Must0(storage.Set("put", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
+		var argErr error
+		var path, content string
+		if len(call.Arguments) < 2 {
+			argErr = fmt.Errorf("path and content required")
+		} else {
+			path = call.Argument(0).String()
+			content = call.Argument(1).String()
+		}
+
 		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
+			if argErr != nil {
+				err = argErr
+				return
+			}
 			if util.ReadOnly {
 				err = fmt.Errorf("The current kernel is in read-only mode, storage.put is not allowed")
 				return
 			}
 
-			if len(call.Arguments) < 2 {
-				err = fmt.Errorf("path and content required")
-				return
-			}
-			path := call.Argument(0).String()
-			content := call.Argument(1).String()
 			abs, resolveErr := resolvePath(path)
 			if resolveErr != nil {
 				err = resolveErr
@@ -284,17 +295,24 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 	lo.Must0(storage.Set("remove", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
+		var argErr error
+		var path string
+		if len(call.Arguments) < 1 {
+			argErr = fmt.Errorf("path required")
+		} else {
+			path = call.Argument(0).String()
+		}
+
 		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
+			if argErr != nil {
+				err = argErr
+				return
+			}
 			if util.ReadOnly {
 				err = fmt.Errorf("The current kernel is in read-only mode, storage.remove is not allowed")
 				return
 			}
 
-			if len(call.Arguments) < 1 {
-				err = fmt.Errorf("path required")
-				return
-			}
-			path := call.Argument(0).String()
 			abs, resolveErr := resolvePath(path)
 			if resolveErr != nil {
 				err = resolveErr
@@ -351,12 +369,19 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 	lo.Must0(storage.Set("list", rt.ToValue(func(call goja.FunctionCall, rt *goja.Runtime) goja.Value {
 		promise, resolve, reject := rt.NewPromise()
 
+		var argErr error
+		var path string
+		if len(call.Arguments) < 1 {
+			argErr = fmt.Errorf("path required")
+		} else {
+			path = call.Argument(0).String()
+		}
+
 		runErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-			if len(call.Arguments) < 1 {
-				err = fmt.Errorf("path required")
+			if argErr != nil {
+				err = argErr
 				return
 			}
-			path := call.Argument(0).String()
 			abs, resolveErr := resolvePath(path)
 			if resolveErr != nil {
 				err = resolveErr

--- a/kernel/plugin/manager.go
+++ b/kernel/plugin/manager.go
@@ -51,9 +51,10 @@ type PluginManager struct {
 }
 
 type PluginInfo struct {
-	Name    string           `json:"name"`
-	State   string           `json:"state"`
-	Methods []*RpcMethodInfo `json:"methods"`
+	Name      string           `json:"name"`
+	State     string           `json:"state"`
+	StateCode int              `json:"stateCode"`
+	Methods   []*RpcMethodInfo `json:"methods"`
 }
 
 var (
@@ -312,9 +313,10 @@ func (m *PluginManager) GetLoadedPlugin(name string) (plugin *PluginInfo, found 
 	p := m.GetPlugin(name)
 	if p != nil {
 		return &PluginInfo{
-			Name:    p.Name,
-			State:   p.State().String(),
-			Methods: p.GetRpcMethodsInfo(),
+			Name:      p.Name,
+			State:     p.State().String(),
+			StateCode: int(p.State()),
+			Methods:   p.GetRpcMethodsInfo(),
 		}, true
 	}
 	return nil, false
@@ -325,9 +327,10 @@ func (m *PluginManager) GetLoadedPluginsInfo() (plugins []*PluginInfo) {
 	m.plugins.Range(func(key, value any) bool {
 		p := value.(*KernelPlugin)
 		plugins = append(plugins, &PluginInfo{
-			Name:    p.Name,
-			State:   p.State().String(),
-			Methods: p.GetRpcMethodsInfo(),
+			Name:      p.Name,
+			State:     p.State().String(),
+			StateCode: int(p.State()),
+			Methods:   p.GetRpcMethodsInfo(),
 		})
 		return true
 	})

--- a/kernel/plugin/manager.go
+++ b/kernel/plugin/manager.go
@@ -349,12 +349,11 @@ func (m *PluginManager) addPluginSourceWatch(name string) {
 }
 
 // removePluginSourceWatch removes the plugin's base directory from the fsnotify watcher when the plugin is stopped.
-func (m *PluginManager) removePluginSourceWatch(name string) {
+func (m *PluginManager) removePluginSourceWatch(name string) (err error) {
 	if m.watcher == nil {
 		return
 	}
 	path := filepath.Join(m.pluginsDir, name)
-	if err := m.watcher.Remove(path); err != nil {
-		logging.LogErrorf("failed to remove kernel plugin source path [%s] from watcher: %s", path, err)
-	}
+	err = m.watcher.Remove(path)
+	return
 }

--- a/kernel/plugin/plugin.go
+++ b/kernel/plugin/plugin.go
@@ -63,7 +63,6 @@ const (
 const (
 	PluginStateReady PluginState = iota
 	PluginStateLoading
-	PluginStateLoaded
 	PluginStateRunning
 	PluginStateStopping
 	PluginStateStopped
@@ -76,8 +75,6 @@ func (s PluginState) String() string {
 		return "ready"
 	case PluginStateLoading:
 		return "loading"
-	case PluginStateLoaded:
-		return "loaded"
 	case PluginStateRunning:
 		return "running"
 	case PluginStateStopping:
@@ -264,8 +261,6 @@ func (p *KernelPlugin) start() (err error) {
 	go p.startStorageWatch()
 
 	p.onLoad()
-	p.updateState(PluginStateLoaded)
-	p.onLoaded()
 	p.updateState(PluginStateRunning)
 	p.onRunning()
 
@@ -321,13 +316,6 @@ func (p *KernelPlugin) stop() (ok bool, err error) {
 func (p *KernelPlugin) onLoad() {
 	if p.State() == PluginStateLoading {
 		p.invokeHook("onload")
-	}
-}
-
-// onLoaded is called after plugin loaded.
-func (p *KernelPlugin) onLoaded() {
-	if p.State() == PluginStateLoaded {
-		p.invokeHook("onloaded")
 	}
 }
 

--- a/kernel/plugin/plugin.go
+++ b/kernel/plugin/plugin.go
@@ -148,7 +148,7 @@ func NewKernelPlugin(ctx context.Context, petal *model.Petal) *KernelPlugin {
 		sockets: make(map[*gws.Conn]bool),
 	}
 
-	plugin.state.Store(int64(PluginStateReady))
+	plugin.updateState(PluginStateReady)
 	return plugin
 }
 
@@ -164,6 +164,12 @@ func createEventMessage(eventType string, detail any) R {
 // State returns the current plugin state (safe for concurrent reads).
 func (p *KernelPlugin) State() PluginState {
 	return PluginState(p.state.Load())
+}
+
+// updateState updates the plugin state atomically and pushes the new state to the frontend via util.PushKernelPluginState.
+func (p *KernelPlugin) updateState(state PluginState) {
+	p.state.Store(int64(state))
+	util.PushKernelPluginState(p.Name, int(state))
 }
 
 // InitRuntime initializes the goja runtime and evaluates kernel.js.
@@ -226,7 +232,7 @@ func (p *KernelPlugin) error() {
 		logging.LogErrorf("[plugin:%s] failed to close runtime during error handling: %v", p.Name, err)
 	}
 
-	p.state.Store(int64(PluginStateError))
+	p.updateState(PluginStateError)
 }
 
 // start creates the goja runtime, injects sandbox globals, and evaluates kernel.js.
@@ -238,7 +244,7 @@ func (p *KernelPlugin) start() (err error) {
 		}
 	}()
 
-	p.state.Store(int64(PluginStateLoading))
+	p.updateState(PluginStateLoading)
 
 	baseDir := filepath.Join(util.DataDir, "storage", "petal", p.Name)
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
@@ -258,9 +264,9 @@ func (p *KernelPlugin) start() (err error) {
 	go p.startStorageWatch()
 
 	p.onLoad()
-	p.state.Store(int64(PluginStateLoaded))
+	p.updateState(PluginStateLoaded)
 	p.onLoaded()
-	p.state.Store(int64(PluginStateRunning))
+	p.updateState(PluginStateRunning)
 	p.onRunning()
 
 	p.bus.Publish(EventBusTopicRuntime, createEventMessage("start", nil))
@@ -286,7 +292,7 @@ func (p *KernelPlugin) stop() (ok bool, err error) {
 
 	p.bus.Publish(EventBusTopicRuntime, createEventMessage("stop", nil))
 
-	p.state.Store(int64(PluginStateStopping))
+	p.updateState(PluginStateStopping)
 
 	p.onUnload()
 
@@ -303,7 +309,7 @@ func (p *KernelPlugin) stop() (ok bool, err error) {
 	p.unsubscribeEventHandlers()
 
 	p.close()
-	p.state.Store(int64(PluginStateStopped))
+	p.updateState(PluginStateStopped)
 
 	logging.LogDebugf("[plugin:%s] stopped", p.Name)
 

--- a/kernel/util/websocket.go
+++ b/kernel/util/websocket.go
@@ -367,6 +367,10 @@ func PushReloadEmojiConf() {
 	BroadcastByType("main", "reloadEmojiConf", 0, "", nil)
 }
 
+func PushKernelPluginState(name string, state int) {
+	BroadcastByType("main", "updateKernelPluginState", 0, "", map[string]any{"name": name, "state": state})
+}
+
 func PushDownloadProgress(id string, percent float32) {
 	evt := NewCmdResult("downloadProgress", 0, PushModeBroadcast)
 	evt.Data = map[string]any{


### PR DESCRIPTION
REL:
- [ ] https://github.com/siyuan-note/petal/pull/52
- [ ] https://github.com/siyuan-note/plugin-sample/pull/45

## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->


This pull request introduces a comprehensive kernel plugin state management system that synchronizes plugin states between the backend (Go) and frontend (TypeScript). It ensures that state changes in kernel plugins are broadcasted to the frontend, where each plugin instance maintains and reacts to its own state. The changes also implement proper initialization and cleanup of kernel plugin resources during plugin load and unload cycles.

Key changes include:

**Frontend: Kernel Plugin State Management**

* Added a new `Kernel` class (`app/src/plugin/kernel.ts`) that encapsulates kernel plugin state, RPC communication (including JSON-RPC over WebSocket), and state change handling. Each `Plugin` instance now owns a `kernel` property for managing its state and RPC. [[1]](diffhunk://#diff-70e22264aa9dddf85870ffc1b3546eec9e50720c383b678d124f8f54b969068eR1-R282) [[2]](diffhunk://#diff-eff091fa9a8eb9c3906aa01d9af686c4418717e28b6213c09df68da7c449d445R22-R27) [[3]](diffhunk://#diff-eff091fa9a8eb9c3906aa01d9af686c4418717e28b6213c09df68da7c449d445R76)
* On plugin load, the kernel is initialized to sync its state with the backend; on plugin unload or app close, the kernel is properly destroyed to clean up resources. [[1]](diffhunk://#diff-6efee8f02897fcc3a42ce85b8fedf386c7cd00e9a6f488897334de3568f4b9e8R72) [[2]](diffhunk://#diff-c607fe5749fa9cdb6312f3325d3cfdf2a31043c055ffa7ad7740b0b305d4b0c5R20) [[3]](diffhunk://#diff-fd5f1ba090c33aab2c9b868573392d13279e357fc7ee1ba5bb6ed8387d15a4c3R7-R13)
* The app now listens for `"updateKernelPluginState"` events from the backend, updating the corresponding plugin's kernel state in real time.

**Backend: Plugin State Broadcasting and Tracking**

* The backend `KernelPlugin` now uses an `updateState` method that atomically updates state and broadcasts the new state to the frontend via the new `PushKernelPluginState` utility function. All state changes (loading, running, stopping, error, etc.) now trigger frontend updates. [[1]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL151-R151) [[2]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eR169-R174) [[3]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL229-R235) [[4]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL241-R247) [[5]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL261-R269) [[6]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL289-R295) [[7]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL306-R312) [[8]](diffhunk://#diff-78181cb2aabfc61ef371e0128b0294470a914850f7f01a1a67383b1fcc2625baR370-R373)
* The plugin manager and info structures now include a numeric `StateCode` in addition to the string state, allowing the frontend to track state transitions precisely. [[1]](diffhunk://#diff-39936571e8c2f1e28e8fd5cddd2620617171f52c6944ab42898e4cf0123438d9R56) [[2]](diffhunk://#diff-39936571e8c2f1e28e8fd5cddd2620617171f52c6944ab42898e4cf0123438d9R318) [[3]](diffhunk://#diff-39936571e8c2f1e28e8fd5cddd2620617171f52c6944ab42898e4cf0123438d9R332)

These changes establish a robust, real-time state synchronization mechanism for kernel plugins, improving reliability and observability of plugin lifecycle events across the application.

---

**Frontend: Kernel Plugin State Management**
- Added `Kernel` class to manage plugin state, RPC, and notifications; each `Plugin` now owns a `kernel` instance (`app/src/plugin/kernel.ts`, `app/src/plugin/index.ts`) [[1]](diffhunk://#diff-70e22264aa9dddf85870ffc1b3546eec9e50720c383b678d124f8f54b969068eR1-R282) [[2]](diffhunk://#diff-eff091fa9a8eb9c3906aa01d9af686c4418717e28b6213c09df68da7c449d445R22-R27) [[3]](diffhunk://#diff-eff091fa9a8eb9c3906aa01d9af686c4418717e28b6213c09df68da7c449d445R76)
- Kernel plugin state is initialized on load and destroyed on unload or app close for proper resource management (`app/src/plugin/loader.ts`, `app/src/plugin/uninstall.ts`, `app/src/window/closeWin.ts`) [[1]](diffhunk://#diff-6efee8f02897fcc3a42ce85b8fedf386c7cd00e9a6f488897334de3568f4b9e8R72) [[2]](diffhunk://#diff-c607fe5749fa9cdb6312f3325d3cfdf2a31043c055ffa7ad7740b0b305d4b0c5R20) [[3]](diffhunk://#diff-fd5f1ba090c33aab2c9b868573392d13279e357fc7ee1ba5bb6ed8387d15a4c3R7-R13)
- App listens for `"updateKernelPluginState"` events and updates plugin state accordingly (`app/src/index.ts`)

**Backend: Plugin State Broadcasting and Tracking**
- All kernel plugin state changes now trigger broadcasts to the frontend via `PushKernelPluginState`, ensuring real-time synchronization (`kernel/plugin/plugin.go`, `kernel/util/websocket.go`) [[1]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL151-R151) [[2]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eR169-R174) [[3]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL229-R235) [[4]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL241-R247) [[5]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL261-R269) [[6]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL289-R295) [[7]](diffhunk://#diff-c7e00f7cc130c3a1b6f8d138eb175b965f11338d9414427ade0e19ef7b48da8eL306-R312) [[8]](diffhunk://#diff-78181cb2aabfc61ef371e0128b0294470a914850f7f01a1a67383b1fcc2625baR370-R373)
- Added numeric `StateCode` to plugin info structures and API responses for precise frontend state tracking (`kernel/plugin/manager.go`) [[1]](diffhunk://#diff-39936571e8c2f1e28e8fd5cddd2620617171f52c6944ab42898e4cf0123438d9R56) [[2]](diffhunk://#diff-39936571e8c2f1e28e8fd5cddd2620617171f52c6944ab42898e4cf0123438d9R318) [[3]](diffhunk://#diff-39936571e8c2f1e28e8fd5cddd2620617171f52c6944ab42898e4cf0123438d9R332)

## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [ ] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [x] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突