### PR TITLE
 PR 为块级多选增加文字样式栏支持。

### DIFF
--- a/app/src/protyle/toolbar/index.ts
+++ b/app/src/protyle/toolbar/index.ts
@@ -15,7 +15,7 @@ import {
 import {hasClosestBlock, hasClosestByAttribute, hasClosestByClassName, hasClosestByTag} from "../util/hasClosest";
 import {Link} from "./Link";
 import {setPosition} from "../../util/setPosition";
-import {transaction, updateTransaction} from "../wysiwyg/transaction";
+import {transaction, updateBatchTransaction, updateTransaction} from "../wysiwyg/transaction";
 import {Constants} from "../../constants";
 import {copyPlainText, openByMobile, readClipboard, setStorageVal} from "../util/compatibility";
 import {upDownHint} from "../../util/upDownHint";
@@ -240,7 +240,248 @@ export class Toolbar {
         return types;
     }
 
+    public renderSelectedBlocks(protyle: IProtyle) {
+        const selectedElements = this.getSelectedInlineStyleBlocks(protyle);
+        const targetElements = this.getInlineStyleTargetBlocks(selectedElements);
+        if (isMobile() || protyle.disabled || selectedElements.length === 0 || targetElements.length === 0 || this.hasUnsupportedInlineStyleContent(targetElements)) {
+            this.element.classList.add("fn__none");
+            return;
+        }
+        this.element.classList.remove("fn__none");
+        this.toolbarHeight = this.element.clientHeight;
+        const firstRect = selectedElements[0].getBoundingClientRect();
+        const lastRect = selectedElements[selectedElements.length - 1].getBoundingClientRect();
+        const top = Math.max(firstRect.top - this.toolbarHeight - 4, protyle.element.getBoundingClientRect().top + 30);
+        const left = Math.min(Math.max(lastRect.left, protyle.element.getBoundingClientRect().left), protyle.element.getBoundingClientRect().right - this.element.clientWidth);
+        this.element.setAttribute("data-inity", top + Constants.ZWSP + protyle.contentElement.scrollTop.toString());
+        setPosition(this.element, left, top);
+        this.element.querySelectorAll(".protyle-toolbar__item--current").forEach(item => {
+            item.classList.remove("protyle-toolbar__item--current");
+        });
+        this.getCommonInlineTypesInBlocks(targetElements).forEach(item => {
+            const itemElement = this.element.querySelector(`[data-type="${item}"]`);
+            if (itemElement) {
+                itemElement.classList.add("protyle-toolbar__item--current");
+            }
+        });
+    }
+
+    private supportBlockInlineType(type: string) {
+        return ["strong", "em", "u", "s", "mark", "sup", "sub", "code", "kbd", "clear"].includes(type);
+    }
+
+    private supportBlockType(nodeElement: HTMLElement) {
+        return ["NodeParagraph", "NodeHeading", "NodeListItem", "NodeList"].includes(nodeElement.getAttribute("data-type"));
+    }
+
+    private supportInlineStyleTargetType(nodeElement: HTMLElement) {
+        return ["NodeParagraph", "NodeHeading", "NodeListItem"].includes(nodeElement.getAttribute("data-type"));
+    }
+
+    private getSelectedInlineStyleBlocks(protyle: IProtyle) {
+        const selectedElements = Array.from(protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select")) as HTMLElement[];
+        if (selectedElements.find(item => !this.supportBlockType(item))) {
+            return [];
+        }
+        return selectedElements;
+    }
+
+    private getInlineStyleTargetBlocks(nodeElements: HTMLElement[]) {
+        const targetElements: HTMLElement[] = [];
+        nodeElements.forEach(nodeElement => {
+            if (this.supportInlineStyleTargetType(nodeElement) && !nodeElements.find(item => item !== nodeElement && item.contains(nodeElement))) {
+                targetElements.push(nodeElement);
+                return;
+            }
+            nodeElement.querySelectorAll("[data-node-id]").forEach((item: HTMLElement) => {
+                if (this.supportInlineStyleTargetType(item) && !nodeElements.find(selectedElement => selectedElement !== nodeElement && selectedElement.contains(item))) {
+                    targetElements.push(item);
+                }
+            });
+        });
+        return [...new Set(targetElements)];
+    }
+
+    private hasUnsupportedInlineStyleContent(nodeElements: HTMLElement[]) {
+        return nodeElements.some(nodeElement => {
+            const editElement = getContenteditableElement(nodeElement);
+            if (!editElement) {
+                return true;
+            }
+            return !!editElement.querySelector(".img, img, video, audio, iframe, .render-node");
+        });
+    }
+
+    private getCommonInlineTypesInBlocks(nodeElements: HTMLElement[]) {
+        return ["strong", "em", "u", "s", "mark", "sup", "sub", "code", "kbd"].filter(type => {
+            return nodeElements.every(nodeElement => this.blockHasInlineType(nodeElement, type));
+        });
+    }
+
+    private blockHasInlineType(nodeElement: HTMLElement, type: string) {
+        const editElement = getContenteditableElement(nodeElement);
+        if (!editElement) {
+            return false;
+        }
+        let hasText = false;
+        let hasAllType = true;
+        const walker = document.createTreeWalker(editElement, NodeFilter.SHOW_TEXT, {
+            acceptNode: (node: Text) => {
+                if (node.textContent.replace(Constants.ZWSP, "").trim() === "") {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                const parentElement = node.parentElement;
+                if (!parentElement || hasClosestByClassName(parentElement, "render-node") || parentElement.closest("[contenteditable='false']")) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                return NodeFilter.FILTER_ACCEPT;
+            }
+        });
+        let node = walker.nextNode();
+        while (node) {
+            hasText = true;
+            let inlineElement = node.parentElement;
+            let hasType = false;
+            while (inlineElement && inlineElement !== editElement) {
+                if ((inlineElement.getAttribute("data-type") || "").split(" ").includes(type)) {
+                    hasType = true;
+                    break;
+                }
+                inlineElement = inlineElement.parentElement;
+            }
+            if (!hasType) {
+                hasAllType = false;
+                break;
+            }
+            node = walker.nextNode();
+        }
+        return hasText && hasAllType;
+    }
+
+    private setInlineMarkForSelectedBlocks(protyle: IProtyle, selectedElements: HTMLElement[], type: string, textObj?: ITextOption) {
+        const targetElements = this.getInlineStyleTargetBlocks(selectedElements);
+        if (targetElements.length === 0 || this.hasUnsupportedInlineStyleContent(targetElements)) {
+            return;
+        }
+        const shouldRemove = type === "clear" || targetElements.every(nodeElement => this.blockHasInlineType(nodeElement, type));
+        updateBatchTransaction(targetElements, protyle, (nodeElement: HTMLElement) => {
+            if (shouldRemove) {
+                this.removeInlineTypeInBlock(nodeElement, type, textObj);
+            } else {
+                this.addInlineTypeInBlock(nodeElement, type, textObj);
+            }
+            nodeElement.setAttribute("updated", dayjs().format("YYYYMMDDHHmmss"));
+        });
+        selectedElements.forEach(nodeElement => {
+            nodeElement.classList.add("protyle-wysiwyg--select");
+        });
+        this.renderSelectedBlocks(protyle);
+    }
+
+    private addInlineTypeInBlock(nodeElement: HTMLElement, type: string, textObj?: ITextOption) {
+        const editElement = getContenteditableElement(nodeElement);
+        if (!editElement) {
+            return;
+        }
+        this.addInlineTypeInNode(editElement, type, textObj, editElement);
+        this.mergeInlineStyleElements(editElement);
+    }
+
+    private addInlineTypeInNode(node: Node, type: string, textObj: ITextOption, rootElement: Element) {
+        Array.from(node.childNodes).forEach(item => {
+            if (item.nodeType === 3) {
+                if (item.textContent.replace(Constants.ZWSP, "").trim() === "") {
+                    return;
+                }
+                const inlineElement = document.createElement("span");
+                inlineElement.setAttribute("data-type", type);
+                inlineElement.textContent = item.textContent;
+                setFontStyle(inlineElement, textObj);
+                item.replaceWith(inlineElement);
+                return;
+            }
+            const element = item as HTMLElement;
+            if (element.nodeType !== 1 || element.tagName === "BR" || element.tagName === "IMG" || element.classList.contains("img") || element.classList.contains("render-node") || element.getAttribute("contenteditable") === "false") {
+                return;
+            }
+            const types = (element.getAttribute("data-type") || "").split(" ").filter(Boolean);
+            if (element.tagName === "SPAN") {
+                if (["backslash", "virtual-block-ref", "search-mark", "inline-math", "inline-memo"].find(itemType => types.includes(itemType))) {
+                    return;
+                }
+                if (!types.includes(type)) {
+                    types.push(type);
+                }
+                element.setAttribute("data-type", [...new Set(types)].join(" "));
+                setFontStyle(element, textObj);
+            } else if (element !== rootElement) {
+                this.addInlineTypeInNode(element, type, textObj, rootElement);
+            } else {
+                this.addInlineTypeInNode(element, type, textObj, rootElement);
+            }
+        });
+    }
+
+    private removeInlineTypeInBlock(nodeElement: HTMLElement, type: string, textObj?: ITextOption) {
+        const editElement = getContenteditableElement(nodeElement);
+        if (!editElement) {
+            return;
+        }
+        editElement.querySelectorAll("span[data-type]").forEach((item: HTMLElement) => {
+            if (["backslash", "virtual-block-ref", "search-mark", "inline-math", "inline-memo"].find(itemType => (item.getAttribute("data-type") || "").split(" ").includes(itemType))) {
+                return;
+            }
+            let types = (item.getAttribute("data-type") || "").split(" ").filter(Boolean);
+            if (type === "clear") {
+                types = types.filter(itemType => !["strong", "em", "u", "s", "mark", "sup", "sub", "code", "kbd", "text"].includes(itemType));
+                if (!textObj || textObj.type === "text") {
+                    item.style.color = "";
+                    item.style.webkitTextFillColor = "";
+                    item.style.webkitTextStroke = "";
+                    item.style.textShadow = "";
+                    item.style.backgroundColor = "";
+                    item.style.fontSize = "";
+                }
+            } else {
+                types = types.filter(itemType => itemType !== type);
+            }
+            this.updateOrUnwrapInlineElement(item, types);
+        });
+        this.mergeInlineStyleElements(editElement);
+    }
+
+    private updateOrUnwrapInlineElement(element: HTMLElement, types: string[]) {
+        if (types.length === 0) {
+            element.replaceWith(...Array.from(element.childNodes));
+        } else {
+            element.setAttribute("data-type", types.join(" "));
+            if (!element.getAttribute("style")) {
+                element.removeAttribute("style");
+            }
+        }
+    }
+
+    private mergeInlineStyleElements(element: Element) {
+        Array.from(element.querySelectorAll("span[data-type]")).forEach((item: HTMLElement) => {
+            const previousElement = item.previousSibling as HTMLElement;
+            if (previousElement && previousElement.nodeType === 1 && previousElement.tagName === "SPAN" &&
+                isArrayEqual((item.getAttribute("data-type") || "").split(" "), (previousElement.getAttribute("data-type") || "").split(" ")) &&
+                hasSameTextStyle(item, previousElement)) {
+                item.textContent = previousElement.textContent + item.textContent;
+                previousElement.remove();
+            }
+        });
+    }
+
     public setInlineMark(protyle: IProtyle, type: string, action: "range" | "toolbar", textObj?: ITextOption) {
+        const selectedElements = Array.from(protyle.wysiwyg.element.querySelectorAll(".protyle-wysiwyg--select")) as HTMLElement[];
+        if (selectedElements.length > 0) {
+            const nodeElements = this.getSelectedInlineStyleBlocks(protyle);
+            if (nodeElements.length > 0 && this.supportBlockInlineType(type)) {
+                this.setInlineMarkForSelectedBlocks(protyle, nodeElements, type, textObj);
+            }
+            return;
+        }
         const nodeElement = hasClosestBlock(this.range.startContainer);
         if (!nodeElement || nodeElement.getAttribute("data-type") === "NodeCodeBlock") {
             return;

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -651,6 +651,7 @@ export class WYSIWYG {
                         } else {
                             focusBlock(selectElements[0], protyle.wysiwyg.element, false);
                         }
+                        protyle.toolbar.renderSelectedBlocks(protyle);
                     }
                     event.preventDefault();
                 }
@@ -695,6 +696,7 @@ export class WYSIWYG {
                         ids.push(item.getAttribute("data-node-id"));
                     });
                     countBlockWord(ids);
+                    protyle.toolbar.renderSelectedBlocks(protyle);
                 }
                 return;
             }
@@ -1758,6 +1760,7 @@ export class WYSIWYG {
                         if (endElement && document.activeElement.classList.contains("protyle-wysiwyg")) {
                             focusBlock(endElement);
                         }
+                        protyle.toolbar.renderSelectedBlocks(protyle);
                         return;
                     }
                     const startBlockElement = hasClosestBlock(range.startContainer);

--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -246,6 +246,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                         protyle.scroll.lastScrollTop = protyle.contentElement.scrollTop - 1;
                     }
                     focusBlock(nextElement);
+                    protyle.toolbar.renderSelectedBlocks(protyle);
                 } else if (event.key === "ArrowUp") {
                     let previousElement: HTMLElement = getPreviousBlock(selectElements[0]) as HTMLElement;
                     if (previousElement) {
@@ -287,6 +288,7 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                             protyle.scroll.lastScrollTop = protyle.contentElement.scrollTop + 1;
                         }
                         focusBlock(previousElement);
+                        protyle.toolbar.renderSelectedBlocks(protyle);
                     }
                 }
                 return;


### PR DESCRIPTION


## Description / 描述

主要改动：
- 多块选中后显示文字样式栏。
- 支持对段落、标题、列表项批量应用/取消 inline 样式。
- 样式应用后保留块选中状态和工具栏。
- 使用批量事务提交多块更新。

当前支持：
- NodeParagraph
- NodeHeading
- NodeListItem 也支持以上三种混合块编辑样式。

逻辑说明：
1、目前仅支持3种类型块，但是我觉得这3种够了。
2、样式修改逻辑：以加粗为例。
- 多个块里存在加粗和非加粗混合，处理方式：加粗未加粗文字。
- 多个块里所有文字都加粗，处理方式：取消加粗。
- 多个块里所有文字都未加错，处理方式：加粗所有。

以上逻辑是我用过的大部分软件的多段文字修改样式的逻辑。
以下为演示：
![Uploading 多块文字样式修改-compressed.gif…]()


## Type of change / 变更类型

- New feature
      新功能

关联issue：https://github.com/siyuan-note/siyuan/issues/8554?utm_source=ld246.com
关联社区文章：https://ld246.com/article/1779954740006/comment/1779955549563#comments

## Checklist / 检查清单

- I have performed a self-review of my own code
      我对自己的代码进行了自我审查
-  I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
-  PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突