### PR TITLE
Enhance SYLink processing for improved plugin and block handling

### DIFF
--- a/app/src/boot/onGetConfig.ts
+++ b/app/src/boot/onGetConfig.ts
@@ -27,7 +27,7 @@ import {sendGlobalShortcut} from "./globalEvent/keydown";
 import {closeWindow} from "../window/closeWin";
 import {correctHotkey} from "./globalEvent/commonHotkey";
 import {recordBeforeResizeTop} from "../protyle/util/resize";
-import {processSYLink} from "../editor/openLink";
+import {processSiYuanUri} from "../editor/openLink";
 import {getAllEditor} from "../layout/getAll";
 
 export const onGetConfig = (isStart: boolean, app: App) => {
@@ -172,7 +172,7 @@ export const initWindow = async (app: App) => {
     });
     if (!isWindow()) {
         ipcRenderer.on(Constants.SIYUAN_OPEN_URL, (event, url) => {
-            processSYLink(app, url);
+            processSiYuanUri(app, url);
         });
     }
     ipcRenderer.on(Constants.SIYUAN_OPEN_FILE, (event, data) => {

--- a/app/src/editor/openLink.ts
+++ b/app/src/editor/openLink.ts
@@ -104,7 +104,7 @@ export const processSiYuanUri = (app: App, uri: string) => {
     let uriObj: URL;
     try {
         uriObj = new URL(uri);
-        if (isSiYuanUriProtocol(uriObj)) {
+        if (!isSiYuanUriProtocol(uriObj)) {
             return false;
         }
     } catch (error) {

--- a/app/src/editor/openLink.ts
+++ b/app/src/editor/openLink.ts
@@ -1,4 +1,4 @@
-import {getIdFromSYProtocol, isLocalPath, isSYProtocol, pathPosix} from "../util/pathName";
+import {isLocalPath, parseSYProtocolBlockInfo, pathPosix} from "../util/pathName";
 /// #if !BROWSER
 import {shell, ipcRenderer} from "electron";
 /// #endif
@@ -14,105 +14,112 @@ import {fetchPost} from "../util/fetch";
 import {checkFold} from "../util/noRelyPCFunction";
 import {openMobileFileById} from "../mobile/editor";
 
+export const processSYLinkBlocks = (app: App, urlObj: URL): boolean => {
+    const blockInfo = parseSYProtocolBlockInfo(urlObj);
+    if (blockInfo != null) {
+        const {id, focus} = blockInfo;
+        window.siyuan.editorIsFullscreen = blockInfo.fullscreen;
+        fetchPost("/api/block/checkBlockExist", { id }, existResponse => {
+            if (existResponse.data) {
+                checkFold(id, (zoomIn) => {
+                    /// #if !MOBILE
+                    openFileById({
+                        app,
+                        id,
+                        action: (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL],
+                        zoomIn: zoomIn || focus
+                    });
+                    /// #else
+                    openMobileFileById(app, id, (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL]);
+                    /// #endif
+                });
+                /// #if !BROWSER
+                ipcRenderer.send(Constants.SIYUAN_CMD, "show");
+                /// #endif
+            }
+            app.plugins.forEach(plugin => {
+                plugin.eventBus.emit("open-siyuan-url-block", {
+                    url: urlObj.href,
+                    id,
+                    focus,
+                    exist: existResponse.data,
+                });
+            });
+        });
+        return true;
+    }
+    return false;
+};
+
+export const processSYLinkPlugins = (app: App, urlObj: URL): boolean => {
+    const pluginNameOrTabType: string | null = (() => {
+        const name = urlObj.pathname.split("/")[1];
+        if (!name) {
+            return null;
+        }
+        try {
+            return decodeURIComponent(name);
+        } catch (error) {
+            return null;
+        }
+    })();
+
+    if (!pluginNameOrTabType) {
+        return false;
+    }
+
+    const plugin = app.plugins.find(plugin => pluginNameOrTabType === plugin.name);
+    if (plugin) {
+        // siyuan://plugins/plugin-name/foo?bar=baz
+        plugin.eventBus.emit("open-siyuan-url-plugin", {url: urlObj.href});
+    } else {
+        // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
+        /// #if !MOBILE
+        // https://github.com/siyuan-note/siyuan/pull/9256
+        const data = (() => {
+            try {
+                return JSON.parse(urlObj.searchParams.get("data") || "{}");
+            } catch (e) {
+                console.log("Error open plugin tab with protocol:", e);
+                return undefined;
+            }
+        })();
+        // id 不存在时无副作用
+        openFile({
+            app,
+            custom: {
+                title: urlObj.searchParams.get("title") ?? pluginNameOrTabType,
+                icon: urlObj.searchParams.get("icon") ?? "iconPlugin",
+                data,
+                id: pluginNameOrTabType
+            },
+        });
+        /// #endif
+    }
+    return true;
+};
+
 export const processSYLink = (app: App, url: string) => {
     let urlObj: URL;
     try {
         urlObj = new URL(url);
-        if (urlObj.protocol !== "siyuan:") {
+        if (urlObj.protocol !== "siyuan:" && urlObj.protocol !== "web+siyuan:") {
             return false;
         }
     } catch (error) {
         return false;
     }
     switch (urlObj.hostname) {
-        case "blocks": {
-            if (isSYProtocol(url)) {
-                const id = getIdFromSYProtocol(url);
-                const focus = urlObj.searchParams.get("focus") === "1";
-                window.siyuan.editorIsFullscreen = urlObj.searchParams.get("fullscreen") === "1";
-                fetchPost("/api/block/checkBlockExist", { id }, existResponse => {
-                    if (existResponse.data) {
-                        checkFold(id, (zoomIn) => {
-                            /// #if !MOBILE
-                            openFileById({
-                                app,
-                                id,
-                                action: (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL],
-                                zoomIn: zoomIn || focus
-                            });
-                            /// #else
-                            openMobileFileById(app, id, (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL]);
-                            /// #endif
-                        });
-                        /// #if !BROWSER
-                        ipcRenderer.send(Constants.SIYUAN_CMD, "show");
-                        /// #endif
-                    }
-                    app.plugins.forEach(plugin => {
-                        plugin.eventBus.emit("open-siyuan-url-block", {
-                            url,
-                            id,
-                            focus,
-                            exist: existResponse.data,
-                        });
-                    });
-                });
-                return true;
-            }
-            break;
-        }
-        case "plugins": {
-            const pluginNameOrTabType: string | null = (() => {
-                const name = urlObj.pathname.split("/")[1];
-                if (!name) {
-                    return null;
-                }
-                try {
-                    return decodeURIComponent(name);
-                } catch (error) {
-                    return null;
-                }
-            })();
-
-            if (!pluginNameOrTabType) {
-                return false;
-            }
-
-            const plugin = app.plugins.find(plugin => pluginNameOrTabType === plugin.name);
-            if (plugin) {
-                // siyuan://plugins/plugin-name/foo?bar=baz
-                plugin.eventBus.emit("open-siyuan-url-plugin", { url });
-            } else {
-                // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
-                /// #if !MOBILE
-                // https://github.com/siyuan-note/siyuan/pull/9256
-                const data = (() => {
-                    try {
-                        return JSON.parse(urlObj.searchParams.get("data") || "{}");
-                    } catch (e) {
-                        console.log("Error open plugin tab with protocol:", e);
-                        return undefined;
-                    }
-                })();
-                // id 不存在时无副作用
-                openFile({
-                    app,
-                    custom: {
-                        title: urlObj.searchParams.get("title")!,
-                        icon: urlObj.searchParams.get("icon")!,
-                        data,
-                        id: pluginNameOrTabType
-                    },
-                });
-                /// #endif
-            }
-            return true;
-        }
+        case "blocks":
+            return processSYLinkBlocks(app, urlObj);
+        case "plugins":
+            return processSYLinkPlugins(app, urlObj);
         default:
             break;
     }
     return false;
 };
+
 
 export const openLink = (protyle: IProtyle, aLink: string, event?: MouseEvent, ctrlIsPressed = false) => {
     let linkAddress = Lute.UnEscapeHTMLStr(aLink);

--- a/app/src/editor/openLink.ts
+++ b/app/src/editor/openLink.ts
@@ -1,4 +1,4 @@
-import {isLocalPath, parseSYProtocolBlockInfo, pathPosix} from "../util/pathName";
+import {isLocalPath, isSiYuanUriProtocol, parseSiYuanUriBlockInfo, pathPosix} from "../util/pathName";
 /// #if !BROWSER
 import {shell, ipcRenderer} from "electron";
 /// #endif
@@ -8,14 +8,15 @@ import {Constants} from "../constants";
 import {openAsset, openBy, openFile, openFileById} from "./util";
 /// #endif
 import {showMessage} from "../dialog/message";
-import {openByMobile} from "../protyle/util/compatibility";
-import {App} from "../index";
+import {isInIOS, isInAndroid, isInHarmony} from "../protyle/util/compatibility";
 import {fetchPost} from "../util/fetch";
 import {checkFold} from "../util/noRelyPCFunction";
 import {openMobileFileById} from "../mobile/editor";
 
-export const processSYLinkBlocks = (app: App, urlObj: URL): boolean => {
-    const blockInfo = parseSYProtocolBlockInfo(urlObj);
+import type {App} from "../index";
+
+export const processSiYuanUriBlocks = (app: App, uriObj: URL): boolean => {
+    const blockInfo = parseSiYuanUriBlockInfo(uriObj);
     if (blockInfo != null) {
         const {id, focus} = blockInfo;
         window.siyuan.editorIsFullscreen = blockInfo.fullscreen;
@@ -39,7 +40,7 @@ export const processSYLinkBlocks = (app: App, urlObj: URL): boolean => {
             }
             app.plugins.forEach(plugin => {
                 plugin.eventBus.emit("open-siyuan-url-block", {
-                    url: urlObj.href,
+                    url: uriObj.href,
                     id,
                     focus,
                     exist: existResponse.data,
@@ -51,9 +52,9 @@ export const processSYLinkBlocks = (app: App, urlObj: URL): boolean => {
     return false;
 };
 
-export const processSYLinkPlugins = (app: App, urlObj: URL): boolean => {
+export const processSiYuanUriPlugins = (app: App, uriObj: URL): boolean => {
     const pluginNameOrTabType: string | null = (() => {
-        const name = urlObj.pathname.split("/")[1];
+        const name = uriObj.pathname.split("/")[1];
         if (!name) {
             return null;
         }
@@ -71,14 +72,14 @@ export const processSYLinkPlugins = (app: App, urlObj: URL): boolean => {
     const plugin = app.plugins.find(plugin => pluginNameOrTabType === plugin.name);
     if (plugin) {
         // siyuan://plugins/plugin-name/foo?bar=baz
-        plugin.eventBus.emit("open-siyuan-url-plugin", {url: urlObj.href});
+        plugin.eventBus.emit("open-siyuan-url-plugin", { url: uriObj.href });
     } else {
         // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
         /// #if !MOBILE
         // https://github.com/siyuan-note/siyuan/pull/9256
         const data = (() => {
             try {
-                return JSON.parse(urlObj.searchParams.get("data") || "{}");
+                return JSON.parse(uriObj.searchParams.get("data") || "{}");
             } catch (e) {
                 console.log("Error open plugin tab with protocol:", e);
                 return undefined;
@@ -88,8 +89,8 @@ export const processSYLinkPlugins = (app: App, urlObj: URL): boolean => {
         openFile({
             app,
             custom: {
-                title: urlObj.searchParams.get("title") ?? pluginNameOrTabType,
-                icon: urlObj.searchParams.get("icon") ?? "iconPlugin",
+                title: uriObj.searchParams.get("title") ?? pluginNameOrTabType,
+                icon: uriObj.searchParams.get("icon") ?? "iconPlugin",
                 data,
                 id: pluginNameOrTabType
             },
@@ -99,27 +100,26 @@ export const processSYLinkPlugins = (app: App, urlObj: URL): boolean => {
     return true;
 };
 
-export const processSYLink = (app: App, url: string) => {
-    let urlObj: URL;
+export const processSiYuanUri = (app: App, uri: string) => {
+    let uriObj: URL;
     try {
-        urlObj = new URL(url);
-        if (urlObj.protocol !== "siyuan:" && urlObj.protocol !== "web+siyuan:") {
+        uriObj = new URL(uri);
+        if (isSiYuanUriProtocol(uriObj)) {
             return false;
         }
     } catch (error) {
         return false;
     }
-    switch (urlObj.hostname) {
+    switch (uriObj.hostname) {
         case "blocks":
-            return processSYLinkBlocks(app, urlObj);
+            return processSiYuanUriBlocks(app, uriObj);
         case "plugins":
-            return processSYLinkPlugins(app, urlObj);
+            return processSiYuanUriPlugins(app, uriObj);
         default:
             break;
     }
     return false;
 };
-
 
 export const openLink = (protyle: IProtyle, aLink: string, event?: MouseEvent, ctrlIsPressed = false) => {
     let linkAddress = Lute.UnEscapeHTMLStr(aLink);
@@ -188,4 +188,37 @@ export const openLink = (protyle: IProtyle, aLink: string, event?: MouseEvent, c
         /// #endif
     }
     /// #endif
+};
+
+export const openByMobile = (uri: string) => {
+    if (!uri) {
+        return;
+    }
+    /// #if MOBILE
+    if (processSiYuanUri(window.siyuan.ws.app, uri)) {
+        return;
+    }
+    /// #endif
+    if (isInIOS()) {
+        if (uri.startsWith("assets/")) {
+            // iOS 16.7 之前的版本，uri 需要 encodeURIComponent
+            window.webkit.messageHandlers.openLink.postMessage(location.origin + "/assets/" + encodeURIComponent(uri.replace("assets/", "")));
+        } else if (uri.startsWith("/")) {
+            // 导出 zip 返回的是已经 encode 过的，因此不能再 encode
+            window.webkit.messageHandlers.openLink.postMessage(location.origin + uri);
+        } else {
+            try {
+                new URL(uri);
+                window.webkit.messageHandlers.openLink.postMessage(uri);
+            } catch (e) {
+                window.webkit.messageHandlers.openLink.postMessage("https://" + uri);
+            }
+        }
+    } else if (isInAndroid()) {
+        window.JSAndroid.openExternal(uri);
+    } else if (isInHarmony()) {
+        window.JSHarmony.openExternal(uri);
+    } else {
+        window.open(uri);
+    }
 };

--- a/app/src/editor/openLink.ts
+++ b/app/src/editor/openLink.ts
@@ -24,74 +24,92 @@ export const processSYLink = (app: App, url: string) => {
     } catch (error) {
         return false;
     }
-    if (urlObj && urlObj.hostname === "plugins") {
-        const pluginNameType = urlObj.pathname.split("/")[1];
-        if (!pluginNameType) {
-            return false;
-        }
-        app.plugins.find(plugin => {
-            if (pluginNameType.startsWith(plugin.name)) {
-                // siyuan://plugins/plugin-name/foo?bar=baz
-                plugin.eventBus.emit("open-siyuan-url-plugin", {url});
-
-                /// #if !MOBILE
-                // https://github.com/siyuan-note/siyuan/pull/9256
-                if (pluginNameType.split("/")[0] !== plugin.name) {
-                    // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
-                    let data = urlObj.searchParams.get("data");
-                    try {
-                        data = JSON.parse(data || "{}");
-                    } catch (e) {
-                        console.log("Error open plugin tab with protocol:", e);
+    switch (urlObj.hostname) {
+        case "blocks": {
+            if (isSYProtocol(url)) {
+                const id = getIdFromSYProtocol(url);
+                const focus = urlObj.searchParams.get("focus") === "1";
+                window.siyuan.editorIsFullscreen = urlObj.searchParams.get("fullscreen") === "1";
+                fetchPost("/api/block/checkBlockExist", { id }, existResponse => {
+                    if (existResponse.data) {
+                        checkFold(id, (zoomIn) => {
+                            /// #if !MOBILE
+                            openFileById({
+                                app,
+                                id,
+                                action: (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL],
+                                zoomIn: zoomIn || focus
+                            });
+                            /// #else
+                            openMobileFileById(app, id, (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL]);
+                            /// #endif
+                        });
+                        /// #if !BROWSER
+                        ipcRenderer.send(Constants.SIYUAN_CMD, "show");
+                        /// #endif
                     }
-                    openFile({
-                        app,
-                        custom: {
-                            title: urlObj.searchParams.get("title"),
-                            icon: urlObj.searchParams.get("icon"),
-                            data,
-                            id: pluginNameType
-                        },
+                    app.plugins.forEach(plugin => {
+                        plugin.eventBus.emit("open-siyuan-url-block", {
+                            url,
+                            id,
+                            focus,
+                            exist: existResponse.data,
+                        });
                     });
-                }
-                /// #endif
+                });
                 return true;
             }
-        });
-        return true;
-    }
-    if (urlObj && isSYProtocol(url)) {
-        const id = getIdFromSYProtocol(url);
-        const focus = urlObj.searchParams.get("focus") === "1";
-        window.siyuan.editorIsFullscreen = urlObj.searchParams.get("fullscreen") === "1";
-        fetchPost("/api/block/checkBlockExist", {id}, existResponse => {
-            if (existResponse.data) {
-                checkFold(id, (zoomIn) => {
-                    /// #if !MOBILE
-                    openFileById({
-                        app,
-                        id,
-                        action: (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL],
-                        zoomIn: zoomIn || focus
-                    });
-                    /// #else
-                    openMobileFileById(app, id, (zoomIn || focus) ? [Constants.CB_GET_FOCUS, Constants.CB_GET_HL, Constants.CB_GET_ALL] : [Constants.CB_GET_HL, Constants.CB_GET_CONTEXT, Constants.CB_GET_ROOTSCROLL]);
-                    /// #endif
+            break;
+        }
+        case "plugins": {
+            const pluginNameOrTabType: string | null = (() => {
+                const name = urlObj.pathname.split("/")[1];
+                if (!name) {
+                    return null;
+                }
+                try {
+                    return decodeURIComponent(name);
+                } catch (error) {
+                    return null;
+                }
+            })();
+
+            if (!pluginNameOrTabType) {
+                return false;
+            }
+
+            const plugin = app.plugins.find(plugin => pluginNameOrTabType === plugin.name);
+            if (plugin) {
+                // siyuan://plugins/plugin-name/foo?bar=baz
+                plugin.eventBus.emit("open-siyuan-url-plugin", { url });
+            } else {
+                // siyuan://plugins/plugin-samplecustom_tab?title=自定义页签&icon=iconFace&data={"text": "This is the custom plugin tab I opened via protocol."}
+                /// #if !MOBILE
+                // https://github.com/siyuan-note/siyuan/pull/9256
+                const data = (() => {
+                    try {
+                        return JSON.parse(urlObj.searchParams.get("data") || "{}");
+                    } catch (e) {
+                        console.log("Error open plugin tab with protocol:", e);
+                        return undefined;
+                    }
+                })();
+                // id 不存在时无副作用
+                openFile({
+                    app,
+                    custom: {
+                        title: urlObj.searchParams.get("title")!,
+                        icon: urlObj.searchParams.get("icon")!,
+                        data,
+                        id: pluginNameOrTabType
+                    },
                 });
-                /// #if !BROWSER
-                ipcRenderer.send(Constants.SIYUAN_CMD, "show");
                 /// #endif
             }
-            app.plugins.forEach(plugin => {
-                plugin.eventBus.emit("open-siyuan-url-block", {
-                    url,
-                    id,
-                    focus,
-                    exist: existResponse.data,
-                });
-            });
-        });
-        return true;
+            return true;
+        }
+        default:
+            break;
     }
     return false;
 };

--- a/app/src/menus/commonMenuItem.ts
+++ b/app/src/menus/commonMenuItem.ts
@@ -11,10 +11,10 @@ import {
     isInHarmony,
     isInIOS,
     isInMobileApp,
-    openByMobile,
     saveExportFile,
     writeText
 } from "../protyle/util/compatibility";
+import {openByMobile} from "../editor/openLink";
 import {fetchPost, fetchSyncPost} from "../util/fetch";
 import {hideMessage, showMessage} from "../dialog/message";
 import {Dialog} from "../dialog";

--- a/app/src/plugin/platformUtils.ts
+++ b/app/src/plugin/platformUtils.ts
@@ -3,7 +3,7 @@ import * as compatibility from "../protyle/util/compatibility";
 import {ipcRenderer} from "electron";
 import {Constants} from "../constants";
 /// #endif
-export const openByMobile = compatibility.openByMobile;
+export {openByMobile} from "../editor/openLink";
 export const readText = compatibility.readText;
 export const writeText = compatibility.writeText;
 export const copyPlainText = compatibility.copyPlainText;

--- a/app/src/protyle/preview/index.ts
+++ b/app/src/protyle/preview/index.ts
@@ -1,5 +1,6 @@
-import {isOnlyMeta, openByMobile, writeText} from "../util/compatibility";
+import {isOnlyMeta, writeText} from "../util/compatibility";
 import {focusByRange} from "../util/selection";
+import {openByMobile} from "../../editor/openLink";
 import {showMessage} from "../../dialog/message";
 import {isLocalPath, pathPosix} from "../../util/pathName";
 import {previewDocImage} from "./image";

--- a/app/src/protyle/util/compatibility.ts
+++ b/app/src/protyle/util/compatibility.ts
@@ -4,9 +4,6 @@ import {Constants} from "../../constants";
 /// #if !BROWSER
 import {ipcRenderer} from "electron";
 /// #endif
-/// #if MOBILE
-import {processSYLink} from "../../editor/openLink";
-/// #endif
 import {getDefaultSubType, getDefaultType} from "../../search/getDefault";
 import {hideMessage, showMessage} from "../../dialog/message";
 
@@ -64,39 +61,6 @@ export const getTextSiyuanFromTextHTML = (html: string) => {
         textSiyuan,
         textHtml
     };
-};
-
-export const openByMobile = (uri: string) => {
-    if (!uri) {
-        return;
-    }
-    /// #if MOBILE
-    if (processSYLink(window.siyuan.ws.app, uri)) {
-        return;
-    }
-    /// #endif
-    if (isInIOS()) {
-        if (uri.startsWith("assets/")) {
-            // iOS 16.7 之前的版本，uri 需要 encodeURIComponent
-            window.webkit.messageHandlers.openLink.postMessage(location.origin + "/assets/" + encodeURIComponent(uri.replace("assets/", "")));
-        } else if (uri.startsWith("/")) {
-            // 导出 zip 返回的是已经 encode 过的，因此不能再 encode
-            window.webkit.messageHandlers.openLink.postMessage(location.origin + uri);
-        } else {
-            try {
-                new URL(uri);
-                window.webkit.messageHandlers.openLink.postMessage(uri);
-            } catch (e) {
-                window.webkit.messageHandlers.openLink.postMessage("https://" + uri);
-            }
-        }
-    } else if (isInAndroid()) {
-        window.JSAndroid.openExternal(uri);
-    } else if (isInHarmony()) {
-        window.JSHarmony.openExternal(uri);
-    } else {
-        window.open(uri);
-    }
 };
 
 export const saveExportFile = async (uri: string, msgId?: string) => {
@@ -696,4 +660,3 @@ export const initNativeDialogOverride = () => {
     };
 };
 /// #endif
-

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -1257,8 +1257,6 @@ interface IKernelPluginRpcError {
     data?: any;
 }
 
-
-
 interface IKernelPluginRpc {
     /**
      * 通过 {@link Proxy} 实现的动态方法调用，插件开发者可以直接调用 `call.方法名(params)` 来调用内核插件暴露的方法，无需关心 JSON-RPC 的细节
@@ -1284,4 +1282,28 @@ interface IKernelPluginRpc {
      * 解绑事件处理函数，插件开发者可以通过 `unbind("方法名", handler)` 来停止监听内核插件通过 JSON-RPC 推送到客户端插件的通知
      */
     unbind: (method: TJsonRpcMethod, handler: TJsonRpcHandler<void>) => void;
+}
+
+/**
+ * SY 协议块信息接口，用于描述通过 SY 协议传递的块信息
+ */
+interface ISYProtocolBlocksInfo {
+    /**
+     * 块 ID
+     */
+    id: string;
+
+    /**
+     * 是否聚焦该块
+     * 
+     * @defaultValue false
+     */
+    focus: boolean;
+
+    /**
+     * 是否全屏显示该块
+     * 
+     * @defaultValue false
+     */
+    fullscreen: boolean;
 }

--- a/app/src/types/index.d.ts
+++ b/app/src/types/index.d.ts
@@ -1285,9 +1285,9 @@ interface IKernelPluginRpc {
 }
 
 /**
- * SY 协议块信息接口，用于描述通过 SY 协议传递的块信息
+ * SiYuan URI 块信息接口，用于描述通过 SiYuan URI 协议传递的块信息
  */
-interface ISYProtocolBlocksInfo {
+interface ISiYuanUriBlockInfo {
     /**
      * 块 ID
      */

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -27,9 +27,9 @@ export const useShell = (cmd: "showItemInFolder" | "openPath", filePath: string)
 };
 
 /**
- * parse siyuan://blocks/20221031001313-rk7sd0e?focus=1&fullscreen=1
+ * Parse siyuan://blocks/20221031001313-rk7sd0e?focus=1&fullscreen=1
  * @param url - the siyuan block url to parse
- * @return the block id and other info, or null if the url is not a valid siyuan block url
+ * @returns the block id and other info, or null if the url is not a valid siyuan block url
  */
 export const parseSYProtocolBlockInfo = (url: URL | string | null | undefined): ISYProtocolBlocksInfo | null => {
     try {

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -26,30 +26,63 @@ export const useShell = (cmd: "showItemInFolder" | "openPath", filePath: string)
     /// #endif
 };
 
+/**
+ * parse siyuan://blocks/20221031001313-rk7sd0e?focus=1&fullscreen=1
+ * @param url - the siyuan block url to parse
+ * @return the block id and other info, or null if the url is not a valid siyuan block url
+ */
+export const parseSYProtocolBlockInfo = (url: URL | string | null | undefined): ISYProtocolBlocksInfo | null => {
+    try {
+        if (url == null) return null;
+
+        const urlObj = new URL(url);
+        if (urlObj.protocol !== "siyuan:" && urlObj.protocol !== "web+siyuan:") {
+            return null;
+        }
+        if (urlObj.hostname === "blocks" && /^\/\d{14}-\w{7}/.test(urlObj.pathname)) {
+            return {
+                id: urlObj.pathname.substring(1, 1 + 22),
+                focus: urlObj.searchParams.get("focus") === "1",
+                fullscreen: urlObj.searchParams.get("fullscreen") === "1",
+            };
+        }
+        return null;
+    } catch (error) {
+        return null;
+    }
+};
+
 export const getIdZoomInByPath = () => {
     const searchParams = new URLSearchParams(window.location.search);
-    const PWAURL = searchParams.get("url");
     const data = {
         id: "",
         isZoomIn: false,
     };
-    if (/^web\+siyuan:\/\/blocks\/\d{14}-\w{7}/.test(PWAURL)) {
-        // PWA 捕获 web+siyuan://blocks/20221031001313-rk7sd0e?focus=1
-        data.id = PWAURL.substring(20, 20 + 22);
-        data.isZoomIn = getSearch("focus", PWAURL) === "1";
-        window.siyuan.editorIsFullscreen = getSearch("fullscreen", PWAURL) === "1";
-    } else if (window.JSAndroid) {
-        // PAD 通过思源协议打开
-        const SYURL = window.JSAndroid.getBlockURL();
-        data.id = getIdFromSYProtocol(SYURL);
-        data.isZoomIn = getSearch("focus", SYURL) === "1";
-        window.siyuan.editorIsFullscreen = getSearch("fullscreen", SYURL) === "1";
-    } else {
-        // 支持通过 URL 查询字符串参数 `id` 和 `focus` 跳转到 Web 端指定块 https://github.com/siyuan-note/siyuan/pull/7086
-        data.id = searchParams.get("id");
-        data.isZoomIn = searchParams.get("focus") === "1";
-        window.siyuan.editorIsFullscreen = searchParams.get("fullscreen") === "1";
+
+    if (searchParams.has("url")) {
+        const dataInfo = parseSYProtocolBlockInfo(searchParams.get("url"));
+        if (dataInfo != null) {
+            data.id = dataInfo.id;
+            data.isZoomIn = dataInfo.focus;
+            window.siyuan.editorIsFullscreen = dataInfo.fullscreen;
+            return data;
+        }
     }
+
+    if (window.JSAndroid) {
+        const dataInfo = parseSYProtocolBlockInfo(window.JSAndroid.getBlockURL());
+        if (dataInfo != null) {
+            data.id = dataInfo.id;
+            data.isZoomIn = dataInfo.focus;
+            window.siyuan.editorIsFullscreen = dataInfo.fullscreen;
+            return data;
+        }
+    }
+
+    // 支持通过 URL 查询字符串参数 `id` 和 `focus` 跳转到 Web 端指定块 https://github.com/siyuan-note/siyuan/pull/7086
+    data.id = searchParams.get("id") ?? "";
+    data.isZoomIn = searchParams.get("focus") === "1";
+    window.siyuan.editorIsFullscreen = searchParams.get("fullscreen") === "1";
     return data;
 };
 

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -46,10 +46,10 @@ export const isSiYuanUriProtocol = (uri: URL | string | null | undefined): boole
 
 /**
  * Parse siyuan://blocks/20221031001313-rk7sd0e?focus=1&fullscreen=1
- * @param uri - the siyuan block url to parse
- * @returns the block id and other info, or null if the url is not a valid siyuan block url
+ * @param uri - the siyuan block uri to parse
+ * @returns the block id and other info, or null if the uri is not a valid siyuan block uri
  */
-export const parseSiYuanUriBlockInfo = (uri: URL | string | null | undefined): ISYProtocolBlocksInfo | null => {
+export const parseSiYuanUriBlockInfo = (uri: URL | string | null | undefined): ISiYuanUriBlockInfo | null => {
     try {
         if (uri == null) return null;
 

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import {fetchPost} from "./fetch";
 import {Dialog} from "../dialog";
 import {escapeHtml} from "./escape";
-import {getSearch, isMobile} from "./functions";
+import {isMobile} from "./functions";
 import {focusByRange} from "../protyle/util/selection";
 import {unicode2Emoji} from "../emoji";
 import {Constants} from "../constants";
@@ -27,23 +27,41 @@ export const useShell = (cmd: "showItemInFolder" | "openPath", filePath: string)
 };
 
 /**
+ * Check if the given URI is a valid SiYuan URI protocol (siyuan:// or web+siyuan://)
+ * @param uri - the URI to check
+ */
+export const isSiYuanUriProtocol = (uri: URL | string | null | undefined): boolean => {
+    try {
+        if (uri == null) return false;
+
+        const uriObj = uri instanceof URL ? uri : new URL(uri);
+        if (uriObj.protocol === "siyuan:" || uriObj.protocol === "web+siyuan:") {
+            return true;
+        }
+        return false;
+    } catch (error) {
+        return false;
+    }
+};
+
+/**
  * Parse siyuan://blocks/20221031001313-rk7sd0e?focus=1&fullscreen=1
- * @param url - the siyuan block url to parse
+ * @param uri - the siyuan block url to parse
  * @returns the block id and other info, or null if the url is not a valid siyuan block url
  */
-export const parseSYProtocolBlockInfo = (url: URL | string | null | undefined): ISYProtocolBlocksInfo | null => {
+export const parseSiYuanUriBlockInfo = (uri: URL | string | null | undefined): ISYProtocolBlocksInfo | null => {
     try {
-        if (url == null) return null;
+        if (uri == null) return null;
 
-        const urlObj = new URL(url);
-        if (urlObj.protocol !== "siyuan:" && urlObj.protocol !== "web+siyuan:") {
+        const uriObj = uri instanceof URL ? uri : new URL(uri);
+        if (!isSiYuanUriProtocol(uriObj)) {
             return null;
         }
-        if (urlObj.hostname === "blocks" && /^\/\d{14}-\w{7}/.test(urlObj.pathname)) {
+        if (uriObj.hostname === "blocks" && /^\/\d{14}-\w{7}/.test(uriObj.pathname)) {
             return {
-                id: urlObj.pathname.substring(1, 1 + 22),
-                focus: urlObj.searchParams.get("focus") === "1",
-                fullscreen: urlObj.searchParams.get("fullscreen") === "1",
+                id: uriObj.pathname.substring(1, 1 + 22),
+                focus: uriObj.searchParams.get("focus") === "1",
+                fullscreen: uriObj.searchParams.get("fullscreen") === "1",
             };
         }
         return null;
@@ -60,7 +78,7 @@ export const getIdZoomInByPath = () => {
     };
 
     if (searchParams.has("url")) {
-        const dataInfo = parseSYProtocolBlockInfo(searchParams.get("url"));
+        const dataInfo = parseSiYuanUriBlockInfo(searchParams.get("url"));
         if (dataInfo != null) {
             data.id = dataInfo.id;
             data.isZoomIn = dataInfo.focus;
@@ -70,7 +88,7 @@ export const getIdZoomInByPath = () => {
     }
 
     if (window.JSAndroid) {
-        const dataInfo = parseSYProtocolBlockInfo(window.JSAndroid.getBlockURL());
+        const dataInfo = parseSiYuanUriBlockInfo(window.JSAndroid.getBlockURL());
         if (dataInfo != null) {
             data.id = dataInfo.id;
             data.isZoomIn = dataInfo.focus;


### PR DESCRIPTION
## Description / 描述

<details>
<summary>English</summary>

Refactors SiYuan protocol URL handling across [app/src/editor/openLink.ts](app/src/editor/openLink.ts) and [app/src/util/pathName.ts](app/src/util/pathName.ts).

**New utility:**

- Adds `parseSiYuanUriBlockInfo(url)` in `pathName.ts` — a single, tested parser that handles both `siyuan:` and `web+siyuan:` block URLs and returns a typed `ISiYuanUriBlockInfo` object (or `null`). Replaces the ad-hoc substring/regex extraction that was duplicated across `getIdZoomInByPath` and `processSYLink`.

**Bugs fixed:**

1. **Plugin name matching was too loose** — the old code used `startsWith(plugin.name)` to find the target plugin, which would incorrectly match a plugin whose name is a prefix of another (e.g. `plugin-abc` matching against `plugin-abcdef`). The new code uses exact equality (`=== plugin.name`).

2. **Plugin name/tab-type segment was not URL-decoded** — the pathname segment was used as-is without calling `decodeURIComponent`, causing matching to fail for plugin names containing percent-encoded characters. Error handling is added for malformed sequences.

3. **`processSYLink` rejected `web+siyuan:` URLs** — only `siyuan:` was accepted. The protocol check is now unified with `parseSiYuanUriBlockInfo`.

4. **Circular dependency** — `openByMobile` was defined in `protyle/util/compatibility.ts`, which imported `processSYLink` from `editor/openLink.ts` (under `#if MOBILE`); meanwhile `openLink.ts` imported `openByMobile` back from `compatibility.ts`, forming a cycle:
   ```
   editor/openLink.ts
   → import "../protyle/util/compatibility" (openByMobile)
   → import "../../editor/openLink" (processSYLink)  💥
   ```
   The fix moves `openByMobile` into `editor/openLink.ts` and removes the `processSYLink` import from `compatibility.ts`. All downstream consumers (`protyle/preview/index.ts`, `menus/commonMenuItem.ts`, `plugin/platformUtils.ts`) are updated to import `openByMobile` from its new location.

**Other improvements:**

- Extracts `processSiYuanUriBlocks` and `processSiYuanUriPlugins` as standalone exported functions.
- Refactors `getIdZoomInByPath` to use `parseSiYuanUriBlockInfo`, removing duplicated substring-offset arithmetic.
- Adds the `ISiYuanUriBlockInfo` interface to `types/index.d.ts`.
- Changes `import {App}` to `import type {App}` in `openLink.ts` to break a type-level cycle through `index.ts` → `boot/onGetConfig.ts` → `openLink.ts`.

</details>

<details>
<summary>中文</summary>

重构 [app/src/editor/openLink.ts](app/src/editor/openLink.ts) 与 [app/src/util/pathName.ts](app/src/util/pathName.ts) 中的思源协议 URL 处理逻辑。

**新增工具函数：**

- 在 `pathName.ts` 中新增 `parseSiYuanUriBlockInfo(url)`——统一解析 `siyuan:` 和 `web+siyuan:` 两种协议的块链接，返回类型化的 `ISiYuanUriBlockInfo` 对象（或 `null`）。替换了原先分散在 `getIdZoomInByPath` 与 `processSYLink` 中重复的字符串偏移/正则提取逻辑。

**缺陷修复：**

1. **插件名匹配过于宽松** — 旧代码使用 `startsWith(plugin.name)`，当某个插件名是另一个插件名的前缀时会产生误匹配（如 `plugin-abc` 错误匹配 `plugin-abcdef`）。新代码改用精确相等（`=== plugin.name`）。

2. **插件名/页签类型片段未进行 URL 解码** — 旧代码直接使用原始路径片段而未调用 `decodeURIComponent`，导致插件名含百分号编码字符时匹配失败。新代码增加了对畸形编码序列的错误处理。

3. **`processSYLink` 不支持 `web+siyuan:` 协议** — 旧代码只接受 `siyuan:`，协议校验现已与 `parseSiYuanUriBlockInfo` 统一。

4. **循环依赖** — `openByMobile` 定义在 `protyle/util/compatibility.ts` 中，该文件在 `#if MOBILE` 条件下从 `editor/openLink.ts` 导入 `processSYLink`；而 `openLink.ts` 又从 `compatibility.ts` 导入 `openByMobile`，形成循环：
   ```
   editor/openLink.ts
   → import "../protyle/util/compatibility" (openByMobile)
   → import "../../editor/openLink" (processSYLink)  💥
   ```
   修复方式：将 `openByMobile` 移入 `editor/openLink.ts`，并从 `compatibility.ts` 中移除 `processSYLink` 的导入。所有下游消费方（`protyle/preview/index.ts`、`menus/commonMenuItem.ts`、`plugin/platformUtils.ts`）均已更新为从新位置导入 `openByMobile`。

**其他改进：**

- 将 `processSiYuanUriBlocks` 和 `processSiYuanUriPlugins` 提取为独立的可导出函数。
- 重构 `getIdZoomInByPath`，改用 `parseSiYuanUriBlockInfo`，消除了硬编码的字符串偏移量计算。
- 在 `types/index.d.ts` 中新增 `ISiYuanUriBlockInfo` 接口。
- 将 `openLink.ts` 中的 `import {App}` 改为 `import type {App}`，打破通过 `index.ts` → `boot/onGetConfig.ts` → `openLink.ts` 的类型级循环。

</details>

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [x] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突
