### PR TITLE
Add Ren'Py code block highlighting

### DIFF
--- a/app/src/protyle/render/highlightRender.ts
+++ b/app/src/protyle/render/highlightRender.ts
@@ -32,7 +32,7 @@ export const highlightRender = (element: Element, cdn = Constants.PROTYLE_CDN, z
     setCodeTheme(cdn);
 
     addScript(`${cdn}/js/highlight.js/highlight.min.js?v=11.11.1`, "protyleHljsScript").then(() => {
-        addScript(`${cdn}/js/highlight.js/third-languages.js?v=2.0.1`, "protyleHljsThirdScript").then(() => {
+        addScript(`${cdn}/js/highlight.js/third-languages.js?v=2.0.2`, "protyleHljsThirdScript").then(() => {
             codeElements.forEach((block: HTMLElement) => {
                 if (block.getAttribute("data-render") === "true") {
                     return;

--- a/app/stage/protyle/js/highlight.js/third-languages.js
+++ b/app/stage/protyle/js/highlight.js/third-languages.js
@@ -155,6 +155,104 @@ hljs.registerLanguage("mlir",function(){"use strict";return function(e){
             className:"symbol",variants:[{begin:"%"+s+"([:#]\\d+)?"},{begin:"\\^"+s},{
                 begin:"#"+s}]},e.C_NUMBER_MODE]}}}());
 
+// https://www.renpy.org/doc/html/language_basics.html
+// https://github.com/renpy/vscode-language-renpy
+// Ren'Py script language support.
+hljs.registerLanguage("renpy", (hljs) => {
+    const IDENT = /[A-Za-z_][A-Za-z0-9_]*/;
+    const INTERPOLATION = {
+        className: "subst",
+        begin: /\[[^\]\n]+\]/
+    };
+    const TEXT_TAG = {
+        className: "subst",
+        begin: /\{\/?[A-Za-z#][^{}\n]*\}/
+    };
+    const STRING_CONTAINS = [
+        hljs.BACKSLASH_ESCAPE,
+        INTERPOLATION,
+        TEXT_TAG
+    ];
+    const QUOTE_STRING_MODE = {
+        className: "string",
+        begin: /"/,
+        end: /"/,
+        contains: STRING_CONTAINS
+    };
+    const APOS_STRING_MODE = {
+        className: "string",
+        begin: /'/,
+        end: /'/,
+        contains: STRING_CONTAINS
+    };
+    const BACKTICK_STRING_MODE = {
+        className: "string",
+        begin: /`/,
+        end: /`/,
+        contains: STRING_CONTAINS
+    };
+    const RENPY_KEYWORDS = [
+        "add", "at", "behind", "call", "camera", "centered", "contains",
+        "default", "define", "drag", "draggroup", "early", "elif", "else",
+        "event", "expression", "extend", "for", "from", "hide", "hotspot",
+        "if", "image", "init", "jump", "key", "label", "layeredimage",
+        "menu", "nvl", "on", "onlayer", "pass", "pause", "play", "python",
+        "queue", "repeat", "return", "scene", "screen", "set", "show",
+        "side", "sound", "spacing", "stop", "style", "style_prefix", "text",
+        "textbutton", "time", "timer", "transform", "translate", "use",
+        "voice", "while", "with", "window", "zorder"
+    ].join(" ");
+    const PYTHON_KEYWORDS = [
+        "and", "as", "assert", "async", "await", "break", "class",
+        "continue", "def", "del", "except", "False", "finally", "for",
+        "from", "global", "import", "in", "is", "lambda", "None",
+        "nonlocal", "not", "or", "raise", "True", "try", "yield"
+    ].join(" ");
+
+    return {
+        name: "Ren'Py",
+        aliases: ["rpy"],
+        keywords: {
+            keyword: `${RENPY_KEYWORDS} ${PYTHON_KEYWORDS}`,
+            literal: "True False None yes no",
+            built_in: "Character DynamicCharacter Solid Null Fade Dissolve MoveTransition Pause SetVariable ToggleVariable Show Hide Jump Call Return Function Play Queue Stop"
+        },
+        contains: [
+            hljs.HASH_COMMENT_MODE,
+            QUOTE_STRING_MODE,
+            APOS_STRING_MODE,
+            BACKTICK_STRING_MODE,
+            hljs.NUMBER_MODE,
+            {
+                className: "meta",
+                begin: /^\s*\$+/,
+                end: /$/,
+                contains: [
+                    hljs.HASH_COMMENT_MODE,
+                    QUOTE_STRING_MODE,
+                    APOS_STRING_MODE,
+                    BACKTICK_STRING_MODE,
+                    hljs.NUMBER_MODE
+                ]
+            },
+            {
+                className: "section",
+                begin: /^\s*(label|screen|transform|style|image|layeredimage|translate)\s+/,
+                end: /:/,
+                keywords: "label screen transform style image layeredimage translate"
+            },
+            {
+                className: "title",
+                begin: new RegExp(`^\\s*${IDENT.source}(?=\\s+["'\`])`)
+            },
+            {
+                className: "variable",
+                begin: /\[[^\]\n]+\]/
+            }
+        ]
+    };
+});
+
 // https://github.com/siyuan-note/siyuan/pull/15345
 hljs.registerLanguage('template', function (hljs) {
 


### PR DESCRIPTION
## Description / 描述

Adds Ren'Py script syntax highlighting to SiYuan code blocks by registering a `renpy` language, with `rpy` as an alias, in the bundled third-party Highlight.js language file.

Also bumps the `third-languages.js` query version from `2.0.1` to `2.0.2` so clients load the updated language bundle instead of a cached copy.

Ren'Py script files are Python-like, but they have their own script statements such as `label`, `scene`, `show`, `menu`, `jump`, `screen`, `transform`, `define`, dialogue lines, text interpolation, and text tags. Using `python` for Ren'Py code blocks produces inaccurate language metadata and incomplete highlighting.

The lightweight Highlight.js grammar is cross-checked against Ren'Py's official VS Code/TextMate grammar, which is MIT licensed: https://github.com/renpy/vscode-language-renpy

## Type of change / 变更类型

- [ ] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [x] Text updates or new language additions
      修改文案或增加新语言

## Validation

- Ran `node --check app/stage/protyle/js/highlight.js/third-languages.js`
- Loaded the bundled `highlight.min.js` and updated `third-languages.js` in a Node VM, then confirmed that `renpy` and `rpy` are registered and Ren'Py samples produce Highlight.js markup for keywords, strings, comments, titles, interpolation, text tags, and backtick strings.
- Ran `git diff --check HEAD^ HEAD`

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突

## Notes

This is a lightweight Highlight.js grammar intended for code block readability. It does not attempt to parse the full Ren'Py language.
