### PR TITLE
Improve the creation of new documents

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
   "packageManager": "pnpm@11.9.0",
   "scripts": {
     "lint": "eslint . --fix --cache",
+    "test": "node --import tsx --test",
     "dev": "webpack --mode development",
     "dev:mobile": "webpack --mode development --config webpack.mobile.js",
     "dev:desktop": "webpack --mode development --config webpack.desktop.js",
@@ -87,6 +88,7 @@
     "safer-buffer": "^2.1.2",
     "sass": "^1.89.2",
     "sass-loader": "^16.0.5",
+    "tsx": "^4.22.4",
     "typescript": "^4.9.5",
     "webpack": "^5.104.1",
     "webpack-bundle-analyzer": "^4.5.0",

--- a/app/src/boot/globalEvent/command/global.ts
+++ b/app/src/boot/globalEvent/command/global.ts
@@ -435,10 +435,7 @@ export const globalCommand = (command: string, app: App) => {
             lockScreen(app);
             return true;
         case "newFile":
-            newFile({
-                app,
-                useSavePath: true
-            });
+            newFile(app);
             return true;
         case "riffCard":
             openCard(app);

--- a/app/src/boot/globalEvent/keydown.ts
+++ b/app/src/boot/globalEvent/keydown.ts
@@ -1395,10 +1395,7 @@ export const windowKeyDown = (app: App, event: KeyboardEvent) => {
         return;
     }
     if (matchHotKey(window.siyuan.config.keymap.general.newFile.custom, event)) {
-        newFile({
-            app,
-            useSavePath: true
-        });
+        newFile(app);
         event.preventDefault();
         return;
     }

--- a/app/src/boot/globalEvent/searchKeydown.ts
+++ b/app/src/boot/globalEvent/searchKeydown.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import {matchHotKey} from "../../protyle/util/hotKey";
 import {fetchPost} from "../../util/fetch";
 import {Constants} from "../../constants";
-import {newFileByName} from "../../util/newFile";
+import {newFile} from "../../util/newFile";
 import {App} from "../../index";
 import {Dialog} from "../../dialog";
 import {getAllModels} from "../../layout/getAll";
@@ -62,7 +62,7 @@ export const searchKeydown = (app: App, event: KeyboardEvent) => {
     const searchInputElement = element.querySelector("#searchInput") as HTMLInputElement;
     if (searchType === "doc" && matchHotKey(window.siyuan.config.keymap.general.newFile.custom, event)) {
         if (config.method === 0) {
-            newFileByName(app, searchInputElement.value);
+            newFile(app, searchInputElement.value);
         }
         return true;
     }
@@ -90,7 +90,7 @@ export const searchKeydown = (app: App, event: KeyboardEvent) => {
     }
     if (currentList.getAttribute("data-type") === "search-new") {
         if (event.key === "Enter" && config.method === 0) {
-            newFileByName(app, searchInputElement.value);
+            newFile(app, searchInputElement.value);
             return true;
         }
         return false;

--- a/app/src/layout/Wnd.ts
+++ b/app/src/layout/Wnd.ts
@@ -135,10 +135,7 @@ export class Wnd {
             while (target && !target.isEqualNode(this.headersElement)) {
                 if (target.classList.contains("block__icon") && target.getAttribute("data-type") === "new") {
                     setPanelFocus(this.headersElement.parentElement.parentElement);
-                    newFile({
-                        app,
-                        useSavePath: true
-                    });
+                    newFile(app);
                     break;
                 } else if (target.classList.contains("block__icon") && target.getAttribute("data-type") === "more") {
                     this.renderTabList(target);

--- a/app/src/layout/dock/Files.ts
+++ b/app/src/layout/dock/Files.ts
@@ -5,7 +5,7 @@ import {setPanelFocus} from "../util";
 import {getDockByType} from "../tabUtil";
 import {Constants} from "../../constants";
 import {getDocDisplayName, pathPosix, setNoteBook} from "../../util/pathName";
-import {newFile} from "../../util/newFile";
+import {newFileInTree} from "../../util/newFile";
 import {initFileMenu, initNavigationMenu, sortMenu} from "../../menus/navigation";
 import {MenuItem} from "../../menus/Menu";
 import {showMessage} from "../../dialog/message";
@@ -244,13 +244,7 @@ export class Files extends Model {
                         const pathString = target.parentElement.getAttribute("data-path");
                         if (!window.siyuan.config.readonly) {
                             if (type === "new") {
-                                newFile({
-                                    app: options.app,
-                                    notebookId,
-                                    currentPath: pathString,
-                                    useSavePath: false,
-                                    listDocTree: true,
-                                });
+                                newFileInTree(options.app, notebookId, pathString);
                             } else if (type === "more-root") {
                                 initNavigationMenu(options.app, target.parentElement).popup({
                                     x: event.clientX,
@@ -1299,13 +1293,7 @@ data-type="navigation-root" data-path="/">
             app: Constants.SIYUAN_APPID,
         }, response => {
             if (response.data.path === "/" && response.data.files.length === 0) {
-                newFile({
-                    app: this.app,
-                    notebookId,
-                    currentPath: "/",
-                    useSavePath: false,
-                    listDocTree: true,
-                });
+                newFileInTree(this.app, notebookId, "/");
                 return;
             }
             this.onLsHTML(response.data);

--- a/app/src/layout/tabUtil.ts
+++ b/app/src/layout/tabUtil.ts
@@ -309,10 +309,7 @@ export const newCenterEmptyTab = (app: App) => {
                         event.preventDefault();
                         break;
                     } else if (target.id === "editorEmptyFile") {
-                        newFile({
-                            app,
-                            useSavePath: true
-                        });
+                        newFile(app);
                         event.stopPropagation();
                         event.preventDefault();
                         break;

--- a/app/src/menus/navigation.ts
+++ b/app/src/menus/navigation.ts
@@ -15,7 +15,7 @@ import {closePanel} from "../mobile/util/closePanel";
 import {popSearch} from "../mobile/menu/search";
 /// #endif
 import {Constants} from "../constants";
-import {newFile} from "../util/newFile";
+import {newFileInTree} from "../util/newFile";
 import {hasClosestByTag, hasTopClosestByTag} from "../protyle/util/hasClosest";
 import {deleteFiles} from "../editor/deleteFile";
 import {getDockByType} from "../layout/tabUtil";
@@ -451,14 +451,7 @@ export const initFileMenu = (app: App, notebookId: string, pathString: string, l
                             paths.push(item.getAttribute("data-path"));
                         }
                     });
-                    newFile({
-                        app,
-                        notebookId,
-                        currentPath: pathPosix().dirname(pathString),
-                        paths,
-                        useSavePath: false,
-                        listDocTree: true,
-                    });
+                    newFileInTree(app, notebookId, pathPosix().dirname(pathString), paths);
                 }
             }).element);
             window.siyuan.menus.menu.append(new MenuItem({
@@ -475,14 +468,7 @@ export const initFileMenu = (app: App, notebookId: string, pathString: string, l
                             }
                         }
                     });
-                    newFile({
-                        app,
-                        notebookId,
-                        currentPath: pathPosix().dirname(pathString),
-                        paths,
-                        useSavePath: false,
-                        listDocTree: true,
-                    });
+                    newFileInTree(app, notebookId, pathPosix().dirname(pathString), paths);
                 }
             }).element);
             window.siyuan.menus.menu.append(new MenuItem({id: "separator_1", type: "separator"}).element);

--- a/app/src/mobile/dock/MobileFiles.ts
+++ b/app/src/mobile/dock/MobileFiles.ts
@@ -14,7 +14,7 @@ import {genUUID} from "../../util/genID";
 import {openMobileFileById} from "../editor";
 import {unicode2Emoji} from "../../emoji";
 import {mountHelp, newNotebook} from "../../util/mount";
-import {newFile} from "../../util/newFile";
+import {newFileInTree} from "../../util/newFile";
 import {MenuItem} from "../../menus/Menu";
 import {App} from "../../index";
 import {refreshFileTree} from "../../dialog/processSystem";
@@ -184,13 +184,7 @@ export class MobileFiles extends Model {
                         const notebookId = ulElement.getAttribute("data-url");
                         if (!window.siyuan.config.readonly) {
                             if (type === "new") {
-                                newFile({
-                                    app,
-                                    notebookId,
-                                    currentPath: pathString,
-                                    useSavePath: false,
-                                    listDocTree: true,
-                                });
+                                newFileInTree(app, notebookId, pathString);
                             } else if (type === "more-root") {
                                 initNavigationMenu(app, target.parentElement);
                                 window.siyuan.menus.menu.fullscreen("bottom");
@@ -959,13 +953,7 @@ export class MobileFiles extends Model {
             app: Constants.SIYUAN_APPID,
         }, response => {
             if (response.data.path === "/" && response.data.files.length === 0) {
-                newFile({
-                    app: this.app,
-                    notebookId,
-                    currentPath: "/",
-                    useSavePath: false,
-                    listDocTree: true,
-                });
+                newFileInTree(this.app, notebookId, "/");
                 return;
             }
             this.onLsHTML(response.data);

--- a/app/src/mobile/menu/index.ts
+++ b/app/src/mobile/menu/index.ts
@@ -133,10 +133,7 @@ export const initRightMenu = (app: App) => {
                 event.stopPropagation();
                 break;
             } else if (target.id === "menuNewDoc") {
-                newFile({
-                    app,
-                    useSavePath: true
-                });
+                newFile(app);
                 closePanel();
                 event.preventDefault();
                 event.stopPropagation();

--- a/app/src/mobile/menu/search.ts
+++ b/app/src/mobile/menu/search.ts
@@ -10,7 +10,7 @@ import {getKeyByLiElement, initCriteriaMenu, moreMenu} from "../../search/menu";
 import {setStorageVal} from "../../protyle/util/compatibility";
 import {escapeHtml} from "../../util/escape";
 import {unicode2Emoji} from "../../emoji";
-import {newFileByName} from "../../util/newFile";
+import {newFile} from "../../util/newFile";
 import {showMessage} from "../../dialog/message";
 import {reloadProtyle} from "../../protyle/util/reload";
 import {activeBlur} from "../util/keyboardToolbar";
@@ -670,7 +670,7 @@ const initSearchEvent = (app: App, element: Element, config: Config.IUILayoutTab
                 break;
             } else if (target.classList.contains("b3-list-item")) {
                 if (target.getAttribute("data-type") === "search-new") {
-                    newFileByName(app, searchInputElement.value);
+                    newFile(app, searchInputElement.value);
                 } else if (target.getAttribute("data-type") === "search-item") {
                     const id = target.getAttribute("data-node-id");
                     if (id) {
@@ -830,7 +830,7 @@ export const popSearch = (app: App, searchConfig?: Config.IUILayoutTabSearchConf
 </div>`,
         bindEvent(element) {
             document.querySelector("#toolbarSearchNew").addEventListener("click", () => {
-                newFileByName(app, (document.querySelector("#toolbarSearch") as HTMLInputElement).value);
+                newFile(app, (document.querySelector("#toolbarSearch") as HTMLInputElement).value);
             });
             const historyElement = document.querySelector('.toolbar [data-type="history"]');
             historyElement.addEventListener("click", () => {

--- a/app/src/mobile/util/setEmpty.ts
+++ b/app/src/mobile/util/setEmpty.ts
@@ -53,10 +53,7 @@ export const setEmpty = (app: App) => {
                 event.preventDefault();
                 break;
             } else if (target.id === "emptyNewFile") {
-                newFile({
-                    app,
-                    useSavePath: true
-                });
+                newFile(app);
                 event.stopPropagation();
                 event.preventDefault();
                 break;

--- a/app/src/protyle/hint/index.ts
+++ b/app/src/protyle/hint/index.ts
@@ -15,7 +15,7 @@ import {
     getSelectionPosition,
 } from "../util/selection";
 import {genHintItemHTML, hintEmbed, hintRef, hintSlash} from "./extend";
-import {getSavePath, newFile} from "../../util/newFile";
+import {getRefCreateSavePath, newFileInProtyle} from "../../util/newFile";
 import {isAbnormalItem, upDownHint} from "../../util/upDownHint";
 import {setPosition} from "../../util/setPosition";
 import {getContenteditableElement, hasNextSibling, hasPreviousSibling} from "../wysiwyg/getBlock";
@@ -479,10 +479,10 @@ ${genHintItemHTML(item)}
                 const realFileName = fileNames.length === 1 ? fileNames[0] : fileNames[1];
                 const newID = Lute.NewNodeID();
                 rowElement.dataset.id = newID;
-                getSavePath(protyle.path, protyle.notebookId, (pathString, targetNotebookId) => {
+                getRefCreateSavePath(protyle.notebookId, protyle.path, (targetNotebookId, hPath) => {
                     fetchPost("/api/filetree/createDocWithMd", {
                         notebook: targetNotebookId,
-                        path: pathPosix().join(pathString, realFileName),
+                        path: pathPosix().join(hPath, realFileName),
                         parentID: protyle.notebookId === targetNotebookId ? protyle.block.rootID : "",
                         markdown: "",
                         id: newID,
@@ -578,10 +578,10 @@ ${genHintItemHTML(item)}
         if (Constants.BLOCK_HINT_KEYS.includes(this.splitChar) && value.startsWith("((newFile ") && value.endsWith(`${Lute.Caret}'))`)) {
             const fileNames = value.substring(11, value.length - 4).split(`"${Constants.ZWSP}'`);
             const realFileName = fileNames.length === 1 ? fileNames[0] : fileNames[1];
-            getSavePath(protyle.path, protyle.notebookId, (pathString, targetNotebookId) => {
+            getRefCreateSavePath(protyle.notebookId, protyle.path, (targetNotebookId, hPath) => {
                 fetchPost("/api/filetree/createDocWithMd", {
                     notebook: targetNotebookId,
-                    path: pathPosix().join(pathString, realFileName),
+                    path: pathPosix().join(hPath, realFileName),
                     parentID: protyle.notebookId === targetNotebookId ? protyle.block.rootID : "",
                     markdown: ""
                 }, response => {
@@ -696,14 +696,8 @@ ${genHintItemHTML(item)}
                 return;
             } else if (value === Constants.ZWSP + 4) {
                 // 新建文档
-                newFile({
-                    app: protyle.app,
-                    notebookId: protyle.notebookId,
-                    useSavePath: true,
-                    currentPath: protyle.path,
-                    afterCB: (createDocId, createDocTitle) => {
-                        insertHTML(`<span data-type="block-ref" data-id="${createDocId}" data-subtype="d">${createDocTitle}</span>`, protyle);
-                    }
+                newFileInProtyle(protyle, (createDocId, createDocTitle) => {
+                    insertHTML(`<span data-type="block-ref" data-id="${createDocId}" data-subtype="d">${createDocTitle}</span>`, protyle);
                 });
                 return;
             } else if (value === Constants.ZWSP + 6) {

--- a/app/src/protyle/hint/index.ts
+++ b/app/src/protyle/hint/index.ts
@@ -15,7 +15,7 @@ import {
     getSelectionPosition,
 } from "../util/selection";
 import {genHintItemHTML, hintEmbed, hintRef, hintSlash} from "./extend";
-import {getRefCreateSavePath, newFileInProtyle} from "../../util/newFile";
+import {newFileByRefHint, newFileInProtyle} from "../../util/newFile";
 import {isAbnormalItem, upDownHint} from "../../util/upDownHint";
 import {setPosition} from "../../util/setPosition";
 import {getContenteditableElement, hasNextSibling, hasPreviousSibling} from "../wysiwyg/getBlock";
@@ -479,29 +479,21 @@ ${genHintItemHTML(item)}
                 const realFileName = fileNames.length === 1 ? fileNames[0] : fileNames[1];
                 const newID = Lute.NewNodeID();
                 rowElement.dataset.id = newID;
-                getRefCreateSavePath(protyle.notebookId, protyle.path, (targetNotebookId, hPath) => {
-                    fetchPost("/api/filetree/createDocWithMd", {
-                        notebook: targetNotebookId,
-                        path: pathPosix().join(hPath, realFileName),
-                        parentID: protyle.notebookId === targetNotebookId ? protyle.block.rootID : "",
-                        markdown: "",
-                        id: newID,
-                    }, () => {
-                        transaction(protyle, [{
-                            action: "replaceAttrViewBlock",
-                            avID,
-                            previousID,
-                            nextID: newID,
-                            isDetached: false,
-                        }], [{
-                            action: "replaceAttrViewBlock",
-                            avID,
-                            previousID: newID,
-                            nextID: previousID,
-                            isDetached: true,
-                        }]);
-                    });
-                });
+                newFileByRefHint(protyle, realFileName, () => {
+                    transaction(protyle, [{
+                        action: "replaceAttrViewBlock",
+                        avID,
+                        previousID,
+                        nextID: newID,
+                        isDetached: false,
+                    }], [{
+                        action: "replaceAttrViewBlock",
+                        avID,
+                        previousID: newID,
+                        nextID: previousID,
+                        isDetached: true,
+                    }]);
+                }, newID);
                 updateAttrViewCellAnimation(cellElement, {
                     type: "block",
                     isDetached: false,
@@ -578,24 +570,17 @@ ${genHintItemHTML(item)}
         if (Constants.BLOCK_HINT_KEYS.includes(this.splitChar) && value.startsWith("((newFile ") && value.endsWith(`${Lute.Caret}'))`)) {
             const fileNames = value.substring(11, value.length - 4).split(`"${Constants.ZWSP}'`);
             const realFileName = fileNames.length === 1 ? fileNames[0] : fileNames[1];
-            getRefCreateSavePath(protyle.notebookId, protyle.path, (targetNotebookId, hPath) => {
-                fetchPost("/api/filetree/createDocWithMd", {
-                    notebook: targetNotebookId,
-                    path: pathPosix().join(hPath, realFileName),
-                    parentID: protyle.notebookId === targetNotebookId ? protyle.block.rootID : "",
-                    markdown: ""
-                }, response => {
-                    // https://github.com/siyuan-note/siyuan/issues/10133
-                    protyle.toolbar.range = range;
-                    const refElement = protyle.toolbar.setInlineMark(protyle, "block-ref", "range", {
-                        type: "id",
-                        color: `${response.data}${Constants.ZWSP}${refIsS ? "s" : "d"}${Constants.ZWSP}${(refIsS ? fileNames[0] : realFileName).substring(0, window.siyuan.config.editor.blockRefDynamicAnchorTextMaxLen)}`
-                    });
-                    if (refElement[0]) {
-                        protyle.toolbar.range.setEnd(refElement[0].lastChild, refElement[0].lastChild.textContent.length);
-                    }
-                    protyle.toolbar.range.collapse(false);
+            newFileByRefHint(protyle, realFileName, (id) => {
+                // https://github.com/siyuan-note/siyuan/issues/10133
+                protyle.toolbar.range = range;
+                const refElement = protyle.toolbar.setInlineMark(protyle, "block-ref", "range", {
+                    type: "id",
+                    color: `${id}${Constants.ZWSP}${refIsS ? "s" : "d"}${Constants.ZWSP}${(refIsS ? fileNames[0] : realFileName).substring(0, window.siyuan.config.editor.blockRefDynamicAnchorTextMaxLen)}`
                 });
+                if (refElement[0]) {
+                    protyle.toolbar.range.setEnd(refElement[0].lastChild, refElement[0].lastChild.textContent.length);
+                }
+                protyle.toolbar.range.collapse(false);
             });
             return;
         }

--- a/app/src/protyle/wysiwyg/keydown.ts
+++ b/app/src/protyle/wysiwyg/keydown.ts
@@ -67,7 +67,7 @@ import {countBlockWord} from "../../layout/status";
 import {moveToDown, moveToUp} from "./move";
 import {beforePaste, pasteAsPlainText} from "../util/paste";
 import {preventScroll} from "../scroll/preventScroll";
-import {getSavePath, newFileBySelect} from "../../util/newFile";
+import {getRefCreateSavePath, newFileBySelect} from "../../util/newFile";
 import {removeSearchMark} from "../toolbar/util";
 import {avKeydown} from "../render/av/keydown";
 import {checkFold} from "../../util/noRelyPCFunction";
@@ -1252,8 +1252,8 @@ export const keydown = (protyle: IProtyle, editorElement: HTMLElement) => {
                         newFileBySelect(protyle, selectText, nodeElement, response.data, protyle.notebookId);
                     });
                 } else {
-                    getSavePath(protyle.path, protyle.notebookId, (pathString, targetNotebookId) => {
-                        newFileBySelect(protyle, selectText, nodeElement, pathString, targetNotebookId);
+                    getRefCreateSavePath(protyle.notebookId, protyle.path, (targetNotebookId, hPath) => {
+                        newFileBySelect(protyle, selectText, nodeElement, hPath, targetNotebookId);
                     });
                 }
             }

--- a/app/src/search/util.ts
+++ b/app/src/search/util.ts
@@ -17,7 +17,7 @@ import {getIconByType} from "../editor/getIcon";
 import {unicode2Emoji} from "../emoji";
 import {hasClosestBlock, hasClosestByClassName, hasClosestByTag} from "../protyle/util/hasClosest";
 import {isIPad, isNotCtrl, setStorageVal, updateHotkeyTip} from "../protyle/util/compatibility";
-import {newFileByName} from "../util/newFile";
+import {newFile} from "../util/newFile";
 import {
     filterMenu,
     getKeyByLiElement,
@@ -799,7 +799,7 @@ export const genSearch = (app: App, config: Config.IUILayoutTabSearchConfig, ele
                 const searchAssetInputElement = element.querySelector("#searchAssetInput") as HTMLInputElement;
                 if (type === "search-new") {
                     if (config.method == 0) {
-                        newFileByName(app, searchInputElement.value);
+                        newFile(app, searchInputElement.value);
                     }
                 } else if (type === "search-item") {
                     const searchType = target.dataset.id ? "asset" : (unRefPanelElement.classList.contains("fn__none") ? "doc" : "unRef");

--- a/app/src/util/mergePathSegments.ts
+++ b/app/src/util/mergePathSegments.ts
@@ -1,0 +1,16 @@
+/**
+ * 将相对路径段合并进已有段数组：`..` 向上一级（已在根时不再上移），`.` 与空段忽略。
+ * 会就地修改 `pathSegments` 并返回同一数组。
+ */
+export const mergePathSegments = (pathSegments: string[], segments: string[]): string[] => {
+    for (const segment of segments) {
+        if (segment === "..") {
+            if (pathSegments.length > 0) {
+                pathSegments.pop();
+            }
+        } else if (segment && segment !== ".") {
+            pathSegments.push(segment);
+        }
+    }
+    return pathSegments;
+};

--- a/app/src/util/newFile.ts
+++ b/app/src/util/newFile.ts
@@ -1,10 +1,10 @@
 import {showMessage} from "../dialog/message";
-import {getAllModels} from "../layout/getAll";
-import {hasClosestByClassName, hasTopClosestByTag} from "../protyle/util/hasClosest";
-import {getDockByType} from "../layout/tabUtil";
+import {hasTopClosestByTag} from "../protyle/util/hasClosest";
 /// #if !MOBILE
 import {Files} from "../layout/dock/Files";
+import {Editor} from "../editor";
 import {openFileById} from "../editor/util";
+import {getActiveTab, getDockByType} from "../layout/tabUtil";
 /// #endif
 import {fetchPost} from "./fetch";
 import {getDisplayName, getOpenNotebookCount, pathPosix} from "./pathName";
@@ -13,235 +13,64 @@ import {replaceFileName, validateName} from "../editor/rename";
 import {hideElements} from "../protyle/ui/hideElements";
 import {openMobileFileById} from "../mobile/editor";
 import {App} from "../index";
+import {NewDocTargetByHPath, NewDocTargetSubDoc, getNewDocTargetFromSavePath, getNewDocTargetFromTree} from "./parseNewDocTarget";
 
-export const getNewFilePath = (useSavePath: boolean) => {
-    let notebookId = "";
-    let currentPath = "";
-    /// #if !MOBILE
-    getAllModels().editor.find((item) => {
-        const currentElement = item.parent.headElement;
-        if (currentElement.classList.contains("item--focus")) {
-            notebookId = item.editor.protyle.notebookId;
-            if (useSavePath) {
-                currentPath = item.editor.protyle.path;
-            } else {
-                currentPath = pathPosix().dirname(item.editor.protyle.path);
-            }
-            if (hasClosestByClassName(currentElement, "layout__wnd--active")) {
-                return true;
-            }
-        }
-    });
-    if (!notebookId) {
-        const fileModel = getDockByType("file").data.file;
-        if (fileModel instanceof Files) {
-            const currentElement = fileModel.element.querySelector(".b3-list-item--focus");
-            if (currentElement) {
-                const topElement = hasTopClosestByTag(currentElement, "UL");
-                if (topElement) {
-                    notebookId = topElement.getAttribute("data-url");
-                }
-                const selectPath = currentElement.getAttribute("data-path");
-                if (useSavePath) {
-                    currentPath = selectPath;
-                } else {
-                    currentPath = pathPosix().dirname(selectPath);
-                }
-            }
-        }
-    }
-    /// #else
-    if (window.siyuan.mobile.editor && document.getElementById("empty").classList.contains("fn__none")) {
-        notebookId = window.siyuan.mobile.editor.protyle.notebookId;
-        if (useSavePath) {
-            currentPath = window.siyuan.mobile.editor.protyle.path;
-        } else {
-            currentPath = pathPosix().dirname(window.siyuan.mobile.editor.protyle.path);
-        }
-    }
-    /// #endif
-    if (!notebookId) {
-        window.siyuan.notebooks.find(item => {
-            if (!item.closed) {
-                notebookId = item.id;
-                currentPath = "/";
-                return true;
-            }
-        });
-    }
-    return {notebookId, currentPath};
+type NewDocRequest = {
+    app: App;
+    notebookId: string;
+    currentPath: string;
+    /** 是否有来自编辑器或文件树选中项的焦点目标 */
+    hasFocusTarget: boolean;
+    name?: string;
+    paths?: string[];
+    listDocTree?: boolean;
+    onCreated?: (id: string, title: string) => void;
 };
 
-export const newFile = (optios: {
-    app: App,
-    notebookId?: string,
-    currentPath?: string,
-    paths?: string[],
-    useSavePath: boolean,
-    name?: string,
-    afterCB?: (id: string, title: string) => void
-    listDocTree?: boolean
-}) => {
+/** 按配置路径创建文档；从聚焦编辑器或文件树推断上下文；可选 name 指定文档名 */
+export const newFile = (app: App, name?: string) => {
     if (getOpenNotebookCount() === 0) {
         showMessage(window.siyuan.languages.newFileTip);
         return;
     }
-    if (!optios.notebookId) {
-        const resultData = getNewFilePath(optios.useSavePath);
-        optios.notebookId = resultData.notebookId;
-        optios.currentPath = resultData.currentPath;
+    const {notebookId, currentPath, hasFocusTarget} = getNewFilePath();
+    if (name === undefined) {
+        runNewDoc({
+            app,
+            notebookId,
+            currentPath,
+            hasFocusTarget,
+        });
+    } else {
+        runNewDoc({
+            app,
+            notebookId,
+            currentPath,
+            hasFocusTarget,
+            name: replaceFileName(name.trim()),
+            onCreated: () => hideElements(["dialog"]),
+        });
     }
-    fetchPost("/api/filetree/getDocCreateSavePath", {notebook: optios.notebookId}, (data) => {
-        if (!optios.useSavePath) {
-            data.data.box = optios.notebookId;
-        }
-        const docName = optios.name || window.siyuan.languages._kernel[16];
-        const titleEmpty = !optios.name;
-        if ((data.data.path.indexOf("/") > -1 && optios.useSavePath) || optios.name) {
-            if (data.data.path.startsWith("/") || optios.currentPath === "/") {
-                const createPath = pathPosix().join(data.data.path, docName);
-                fetchPost("/api/filetree/createDocWithMd", {
-                    notebook: data.data.box,
-                    path: createPath,
-                    // 根目录时无法确定 parentID
-                    markdown: "",
-                    titleEmpty,
-                    listDocTree: optios.listDocTree
-                }, response => {
-                    if (optios.afterCB) {
-                        optios.afterCB(response.data, pathPosix().basename(createPath));
-                    }
-                    /// #if !MOBILE
-                    openFileById({
-                        app: optios.app,
-                        id: response.data,
-                        action: [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]
-                    });
-                    /// #else
-                    openMobileFileById(optios.app, response.data, [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]);
-                    /// #endif
-                });
-            } else {
-                fetchPost("/api/filetree/getHPathByPath", {
-                    notebook: data.data.box,
-                    path: optios.notebookId === data.data.box ? (optios.currentPath.endsWith(".sy") ? optios.currentPath : optios.currentPath + ".sy") : (data.data.path || "/")
-                }, (responseHPath) => {
-                    const createPath = pathPosix().join(responseHPath.data, data.data.path, docName);
-                    fetchPost("/api/filetree/createDocWithMd", {
-                        notebook: data.data.box,
-                        path: createPath,
-                        parentID: getDisplayName(optios.currentPath, true, true),
-                        markdown: "",
-                        titleEmpty,
-                        listDocTree: optios.listDocTree
-                    }, response => {
-                        if (optios.afterCB) {
-                            optios.afterCB(response.data, pathPosix().basename(createPath));
-                        }
-                        /// #if !MOBILE
-                        openFileById({
-                            app: optios.app,
-                            id: response.data,
-                            action: [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]
-                        });
-                        /// #else
-                        openMobileFileById(optios.app, response.data, [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]);
-                        /// #endif
-                    });
-                });
-            }
-        } else {
-            const title = pathPosix().basename(data.data.path);
-            if (!validateName(title)) {
-                return;
-            }
-            if (optios.notebookId !== data.data.box) {
-                const createPath = pathPosix().join(data.data.path || "/", docName);
-                fetchPost("/api/filetree/createDocWithMd", {
-                    notebook: data.data.box,
-                    path: createPath,
-                    markdown: "",
-                    titleEmpty,
-                    listDocTree: optios.listDocTree
-                }, response => {
-                    if (optios.afterCB) {
-                        optios.afterCB(response.data, pathPosix().basename(createPath));
-                    }
-                    /// #if !MOBILE
-                    openFileById({
-                        app: optios.app,
-                        id: response.data,
-                        action: [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]
-                    });
-                    /// #else
-                    openMobileFileById(optios.app, response.data, [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]);
-                    /// #endif
-                });
-                return;
-            }
+};
 
-            const id = Lute.NewNodeID();
-            const newPath = (pathPosix().join(getDisplayName(optios.currentPath, false, true), id + ".sy"));
-            if (optios.paths) {
-                optios.paths[optios.paths.indexOf(undefined)] = newPath;
-            }
-            fetchPost("/api/filetree/createDoc", {
-                notebook: data.data.box,
-                path: newPath,
-                title,
-                md: "",
-                sorts: optios.paths,
-                listDocTree: optios.listDocTree
-            }, () => {
-                if (optios.afterCB) {
-                    optios.afterCB(id, title);
-                }
-                /// #if !MOBILE
-                openFileById({app: optios.app, id, action: [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]});
-                /// #else
-                openMobileFileById(optios.app, id, [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]);
-                /// #endif
-            });
-        }
+export const newFileInProtyle = (protyle: IProtyle, onCreated: (id: string, title: string) => void) => {
+    runNewDoc({
+        app: protyle.app,
+        notebookId: protyle.notebookId,
+        currentPath: protyle.path,
+        hasFocusTarget: true,
+        onCreated,
     });
 };
 
-export const getSavePath = (pathString: string, notebookId: string, cb: (p: string, notebookId: string) => void) => {
-    fetchPost("/api/filetree/getRefCreateSavePath", {
-        notebook: notebookId
-    }, (data) => {
-        let targetPath = pathString;
-        if (notebookId !== data.data.box) {
-            targetPath = data.data.path || "/";
-        }
-        if (data.data.path) {
-            if (data.data.path.startsWith("/")) {
-                cb(getDisplayName(data.data.path, false, true), data.data.box);
-            } else {
-                fetchPost("/api/filetree/getHPathByPath", {
-                    notebook: data.data.box,
-                    path: targetPath
-                }, (response) => {
-                    cb(getDisplayName(pathPosix().join(response.data, data.data.path), false, true), data.data.box);
-                });
-            }
-        } else {
-            fetchPost("/api/filetree/getHPathByPath", {
-                notebook: data.data.box,
-                path: targetPath
-            }, (response) => {
-                cb(getDisplayName(response.data, false, true), data.data.box);
-            });
-        }
-    });
-};
-
-export const newFileByName = (app: App, value: string) => {
-    hideElements(["dialog"]);
-    newFile({
+export const newFileInTree = (app: App, notebookId: string, currentPath: string, paths?: string[]) => {
+    runNewDocInTree({
         app,
-        useSavePath: true,
-        name: replaceFileName(value.trim())
+        notebookId,
+        currentPath,
+        hasFocusTarget: true,
+        paths,
+        listDocTree: true,
     });
 };
 
@@ -281,3 +110,179 @@ export const newFileBySelect = (protyle: IProtyle, selectText: string, nodeEleme
         hideElements(["toolbar"], protyle);
     });
 };
+
+export const getRefCreateSavePath = (notebookId: string, currentPath: string, cb: (targetNotebookId: string, hPath: string) => void) => {
+    fetchPost("/api/filetree/getRefCreateSavePath", {
+        notebook: notebookId
+    }, (data) => {
+        let targetPath = currentPath;
+        if (notebookId !== data.data.box) {
+            targetPath = data.data.path || "/";
+        }
+        if (data.data.path) {
+            if (data.data.path.startsWith("/")) {
+                cb(data.data.box, getDisplayName(data.data.path, false, true));
+            } else {
+                fetchPost("/api/filetree/getHPathByPath", {
+                    notebook: data.data.box,
+                    path: targetPath
+                }, (response) => {
+                    cb(data.data.box, getDisplayName(pathPosix().join(response.data, data.data.path), false, true));
+                });
+            }
+        } else {
+            fetchPost("/api/filetree/getHPathByPath", {
+                notebook: data.data.box,
+                path: targetPath
+            }, (response) => {
+                cb(data.data.box, getDisplayName(response.data, false, true));
+            });
+        }
+    });
+};
+
+function getNewFilePath(): Pick<NewDocRequest, "notebookId" | "currentPath" | "hasFocusTarget"> {
+    let notebookId = "";
+    let currentPath = "";
+    let hasFocusTarget = false;
+    /// #if !MOBILE
+    const tab = getActiveTab(false);
+    if (tab?.model instanceof Editor) {
+        notebookId = tab.model.editor.protyle.notebookId;
+        currentPath = tab.model.editor.protyle.path;
+        hasFocusTarget = true;
+    }
+    if (!notebookId) {
+        const fileModel = getDockByType("file").data.file;
+        if (fileModel instanceof Files) {
+            const currentElement = fileModel.element.querySelector(".b3-list-item--focus");
+            if (currentElement) {
+                const topElement = hasTopClosestByTag(currentElement, "UL");
+                if (topElement) {
+                    notebookId = topElement.getAttribute("data-url");
+                }
+                currentPath = currentElement.getAttribute("data-path");
+                hasFocusTarget = true;
+            }
+        }
+    }
+    /// #else
+    if (window.siyuan.mobile.editor && document.getElementById("empty").classList.contains("fn__none")) {
+        notebookId = window.siyuan.mobile.editor.protyle.notebookId;
+        currentPath = window.siyuan.mobile.editor.protyle.path;
+        hasFocusTarget = true;
+    }
+    /// #endif
+    if (!notebookId) {
+        const openNotebook = window.siyuan.notebooks.find(item => !item.closed);
+        if (openNotebook) {
+            notebookId = openNotebook.id;
+            currentPath = "/";
+        }
+    }
+    return {notebookId, currentPath, hasFocusTarget};
+}
+
+function runNewDoc(request: NewDocRequest) {
+    fetchPost("/api/filetree/getDocCreateSavePath", {notebook: request.notebookId}, (savePathResponse) => {
+        const templatePath = savePathResponse.data.path as string;
+        const targetNotebookId = savePathResponse.data.box as string;
+        getNewDocHPath(request, targetNotebookId, (hPath) => {
+            createNewDoc(request, templatePath, targetNotebookId, hPath);
+        });
+    });
+}
+
+function getNewDocHPath(request: NewDocRequest, targetNotebookId: string, callback: (hPath: string) => void) {
+    if (targetNotebookId !== request.notebookId) {
+        // 跨笔记本时当前文档路径在目标笔记本中不存在，直接按目标笔记本根路径解析
+        callback("/");
+        return;
+    }
+    fetchPost("/api/filetree/getHPathByPath", {
+        notebook: targetNotebookId,
+        path: request.currentPath,
+    }, (hPathResponse) => {
+        callback(hPathResponse.data);
+    });
+}
+
+function createNewDoc(request: NewDocRequest, templatePath: string, targetNotebookId: string, hPath: string) {
+    const target = getNewDocTargetFromSavePath({
+        templatePath,
+        hPath: hPath || "/",
+        targetNotebookId,
+        currentNotebookId: request.notebookId,
+        name: request.name,
+        hasFocusTarget: request.hasFocusTarget,
+        currentPath: request.currentPath,
+    });
+    if (target.kind === "hPath") {
+        createNewDocByHPath(request, target);
+    } else if (target.kind === "subDoc") {
+        createNewDocAsSubDoc(request, target);
+    }
+}
+
+function runNewDocInTree(request: NewDocRequest) {
+    fetchPost("/api/filetree/getDocCreateSavePath", {notebook: request.notebookId}, (savePathResponse) => {
+        const target = getNewDocTargetFromTree({
+            templatePath: savePathResponse.data.path as string,
+            currentNotebookId: request.notebookId,
+            currentPath: request.currentPath,
+            name: request.name,
+        });
+        createNewDocAsSubDoc(request, target);
+    });
+}
+
+function createNewDocByHPath(request: NewDocRequest, target: NewDocTargetByHPath) {
+    if (target.title && !validateName(target.title)) {
+        return;
+    }
+    const parentID = request.hasFocusTarget && request.notebookId === target.targetNotebookId && request.currentPath !== "/"
+        ? getDisplayName(request.currentPath, true, true)
+        : undefined;
+    fetchPost("/api/filetree/createDocWithMd", {
+        notebook: target.targetNotebookId,
+        path: target.hPath,
+        parentID,
+        markdown: "",
+        titleEmpty: !target.title,
+    }, (response) => {
+        openCreatedDoc(request.app, response.data, request.onCreated, target.title);
+    });
+}
+
+function createNewDocAsSubDoc(request: NewDocRequest, target: NewDocTargetSubDoc) {
+    const id = Lute.NewNodeID();
+    const newPath = pathPosix().join(getDisplayName(target.parentPath, false, true), id + ".sy");
+    if (request.paths) {
+        request.paths[request.paths.indexOf(undefined)] = newPath;
+    }
+    fetchPost("/api/filetree/createDoc", {
+        notebook: target.targetNotebookId,
+        path: newPath,
+        title: target.title,
+        md: "",
+        sorts: request.paths,
+        listDocTree: request.listDocTree,
+    }, () => {
+        openCreatedDoc(request.app, id, request.onCreated, target.title);
+    });
+}
+
+function openCreatedDoc(app: App, id: string, onCreated?: (id: string, title: string) => void, title?: string) {
+    if (onCreated) {
+        onCreated(id, title || "");
+    }
+    /// #if !MOBILE
+    openFileById({
+        app,
+        id,
+        action: [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]
+    });
+    /// #else
+    openMobileFileById(app, id, [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]);
+    /// #endif
+}

--- a/app/src/util/newFile.ts
+++ b/app/src/util/newFile.ts
@@ -187,21 +187,21 @@ function runNewDoc(request: NewDocRequest) {
     fetchPost("/api/filetree/getDocCreateSavePath", {notebook: request.notebookId}, (savePathResponse) => {
         const templatePath = savePathResponse.data.path as string;
         const targetNotebookId = savePathResponse.data.box as string;
-        getNewDocHPath(request, targetNotebookId, (hPath) => {
+        getNewDocHPath(targetNotebookId, request.notebookId, request.currentPath, (hPath) => {
             createNewDoc(request, templatePath, targetNotebookId, hPath);
         });
     });
 }
 
-function getNewDocHPath(request: NewDocRequest, targetNotebookId: string, callback: (hPath: string) => void) {
-    if (targetNotebookId !== request.notebookId) {
+function getNewDocHPath(targetNotebookId: string, currentNotebookId: string, currentPath: string, callback: (hPath: string) => void) {
+    if (targetNotebookId !== currentNotebookId) {
         // 跨笔记本时当前文档路径在目标笔记本中不存在，直接按目标笔记本根路径解析
         callback("/");
         return;
     }
     fetchPost("/api/filetree/getHPathByPath", {
         notebook: targetNotebookId,
-        path: request.currentPath,
+        path: currentPath,
     }, (hPathResponse) => {
         callback(hPathResponse.data);
     });
@@ -236,13 +236,18 @@ function runNewDocInTree(request: NewDocRequest) {
     });
 }
 
+/** 同笔记本 + 有聚焦 + 非根路径 时取当前文档 ID */
+function getCreateDocParentID(hasFocusTarget: boolean, notebookId: string, currentPath: string, targetNotebookId: string): string | undefined {
+    return hasFocusTarget && notebookId === targetNotebookId && currentPath !== "/"
+        ? getDisplayName(currentPath, true, true)
+        : undefined;
+}
+
 function createNewDocByHPath(request: NewDocRequest, target: NewDocTargetByHPath) {
     if (target.title && !validateName(target.title)) {
         return;
     }
-    const parentID = request.hasFocusTarget && request.notebookId === target.targetNotebookId && request.currentPath !== "/"
-        ? getDisplayName(request.currentPath, true, true)
-        : undefined;
+    const parentID = getCreateDocParentID(request.hasFocusTarget, request.notebookId, request.currentPath, target.targetNotebookId);
     fetchPost("/api/filetree/createDocWithMd", {
         notebook: target.targetNotebookId,
         path: target.hPath,
@@ -285,4 +290,78 @@ function openCreatedDoc(app: App, id: string, onCreated?: (id: string, title: st
     /// #else
     openMobileFileById(app, id, [Constants.CB_GET_CONTEXT, Constants.CB_GET_OPENNEW]);
     /// #endif
+}
+
+/**
+ * 块引新建文档。
+ * 
+ * 与 `newFile` 入口路径解析规则对齐；创建后仅回调插入引用，不打开新文档页签。
+ * 独立于 `runNewDoc` 编排，避免给通用入口引入块引专用参数。
+ */
+export const newFileByRefHint = (
+    protyle: IProtyle,
+    name: string,
+    onCreated?: (id: string, title: string) => void,
+    presetId?: string,
+) => {
+    const requestName = replaceFileName(name.trim());
+    fetchPost("/api/filetree/getRefCreateSavePath", {notebook: protyle.notebookId}, (savePathResponse) => {
+        const templatePath = savePathResponse.data.path as string;
+        const targetNotebookId = savePathResponse.data.box as string;
+        getNewDocHPath(targetNotebookId, protyle.notebookId, protyle.path, (hPath) => {
+            const target = getNewDocTargetFromSavePath({
+                templatePath,
+                hPath: hPath || "/",
+                targetNotebookId,
+                currentNotebookId: protyle.notebookId,
+                name: requestName,
+                hasFocusTarget: true,
+                currentPath: protyle.path,
+            });
+            if (target.kind === "hPath") {
+                createRefDocByHPath(protyle, target, onCreated, presetId);
+            } else {
+                createRefDocAsSubDoc(target, onCreated, presetId);
+            }
+        });
+    });
+};
+
+function createRefDocByHPath(
+    protyle: IProtyle,
+    target: NewDocTargetByHPath,
+    onCreated?: (id: string, title: string) => void,
+    presetId?: string,
+) {
+    if (target.title && !validateName(target.title)) {
+        return;
+    }
+    const parentID = getCreateDocParentID(true, protyle.notebookId, protyle.path, target.targetNotebookId);
+    fetchPost("/api/filetree/createDocWithMd", {
+        notebook: target.targetNotebookId,
+        path: target.hPath,
+        parentID,
+        markdown: "",
+        titleEmpty: !target.title,
+        id: presetId,
+    }, (response) => {
+        onCreated?.(response.data, target.title || "");
+    });
+}
+
+function createRefDocAsSubDoc(
+    target: NewDocTargetSubDoc,
+    onCreated?: (id: string, title: string) => void,
+    presetId?: string,
+) {
+    const id = presetId || Lute.NewNodeID();
+    const newPath = pathPosix().join(getDisplayName(target.parentPath, false, true), id + ".sy");
+    fetchPost("/api/filetree/createDoc", {
+        notebook: target.targetNotebookId,
+        path: newPath,
+        title: target.title,
+        md: "",
+    }, () => {
+        onCreated?.(id, target.title || "");
+    });
 }

--- a/app/src/util/parseNewDocTarget.test.ts
+++ b/app/src/util/parseNewDocTarget.test.ts
@@ -1,0 +1,399 @@
+import {describe, it} from "node:test";
+import * as assert from "node:assert/strict";
+import {getNewDocTargetFromSavePath, getNewDocTargetFromTree, NewDocTarget} from "./parseNewDocTarget";
+
+const assertSubDoc = (target: NewDocTarget, expected: {
+    targetNotebookId?: string;
+    parentPath: string;
+    title: string;
+}) => {
+    assert.equal(target.kind, "subDoc");
+    if (target.kind === "subDoc") {
+        if (expected.targetNotebookId !== undefined) {
+            assert.equal(target.targetNotebookId, expected.targetNotebookId);
+        }
+        assert.equal(target.parentPath, expected.parentPath);
+        assert.equal(target.title, expected.title);
+    }
+};
+
+const assertHPath = (target: NewDocTarget, expected: {
+    targetNotebookId?: string;
+    hPath: string;
+    title: string;
+}) => {
+    assert.equal(target.kind, "hPath");
+    if (target.kind === "hPath") {
+        if (expected.targetNotebookId !== undefined) {
+            assert.equal(target.targetNotebookId, expected.targetNotebookId);
+        }
+        assert.equal(target.hPath, expected.hPath);
+        assert.equal(target.title, expected.title);
+    }
+};
+
+describe("getNewDocTargetFromSavePath", () => {
+    // 聚焦嵌套文档：内核路径与人类路径成对出现
+    const nestedDocPath = "/20260628041644-ndcuikw/20260628040939-kkaajwr.sy";
+    const nestedHPath = "/parent1/parent2/docName";
+    // 聚焦根级文档
+    const rootDocPath = "/20260628041702-kqfrg7p.sy";
+    const rootHPath = "/docName";
+    const notebookId = "nb";
+
+    const nestedContext = {
+        hPath: nestedHPath,
+        targetNotebookId: notebookId,
+        currentNotebookId: notebookId,
+        hasFocusTarget: true,
+        currentPath: nestedDocPath,
+    };
+
+    describe("空模板", () => {
+        it("有页签/选中 + 无 name → 当前文档下子文档", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: ""});
+            assertSubDoc(target, {targetNotebookId: notebookId, parentPath: nestedDocPath, title: ""});
+        });
+
+        it("有页签/选中 + 显式标题 → 当前 hPath 下按名称新建", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "", name: "docName2"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/docName2", title: "docName2"});
+        });
+
+        it("聚焦根级文档 + 无 name → 子文档", () => {
+            const target = getNewDocTargetFromSavePath({
+                ...nestedContext,
+                templatePath: "",
+                hPath: rootHPath,
+                currentPath: rootDocPath,
+            });
+            assertSubDoc(target, {parentPath: rootDocPath, title: ""});
+        });
+
+        it("聚焦根级文档 + 显式标题 → 当前 hPath 下按名称新建", () => {
+            const target = getNewDocTargetFromSavePath({
+                ...nestedContext,
+                templatePath: "",
+                hPath: rootHPath,
+                currentPath: rootDocPath,
+                name: "docName2",
+            });
+            assertHPath(target, {hPath: "/docName/docName2", title: "docName2"});
+        });
+
+        it("选中笔记本根（currentPath=/）+ 无 name → 子文档", () => {
+            const target = getNewDocTargetFromSavePath({
+                ...nestedContext,
+                templatePath: "",
+                hPath: "/",
+                currentPath: "/",
+            });
+            assertSubDoc(target, {parentPath: "/", title: ""});
+        });
+
+        it("无页签无选中 → 笔记本根", () => {
+            const target = getNewDocTargetFromSavePath({
+                ...nestedContext,
+                templatePath: "",
+                hasFocusTarget: false,
+                hPath: "/",
+                currentPath: "/",
+            });
+            assertHPath(target, {hPath: "/", title: ""});
+        });
+
+        it("无页签无选中 + 显式标题 → 笔记本根下按名称新建", () => {
+            const target = getNewDocTargetFromSavePath({
+                ...nestedContext,
+                templatePath: "",
+                hasFocusTarget: false,
+                hPath: "/",
+                name: "docName2",
+            });
+            assertHPath(target, {hPath: "/docName2", title: "docName2"});
+        });
+    });
+
+    describe("容器路径（尾 /）", () => {
+        it("绝对 /parent3/", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "/parent3/"});
+            assertHPath(target, {hPath: "/parent3/", title: ""});
+        });
+
+        it("绝对 /parent3/ + 显式标题", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "/parent3/", name: "docName2"});
+            assertHPath(target, {hPath: "/parent3/docName2", title: "docName2"});
+        });
+
+        it("绝对 /", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "/", hPath: "/"});
+            assertHPath(target, {hPath: "/", title: ""});
+        });
+
+        it("绝对 /parent1/parent2/", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "/parent1/parent2/"});
+            assertHPath(target, {hPath: "/parent1/parent2/", title: ""});
+        });
+
+        it("相对 parent3/", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "parent3/"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/parent3/", title: ""});
+        });
+
+        it("相对 parent3/parent4/", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "parent3/parent4/"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/parent3/parent4/", title: ""});
+        });
+
+        it("相对 ../", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../"});
+            assertHPath(target, {hPath: "/parent1/parent2/", title: ""});
+        });
+
+        it("相对 ../ + 显式标题", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../", name: "docName2"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName2", title: "docName2"});
+        });
+
+        it("相对 ../../", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../../"});
+            assertHPath(target, {hPath: "/parent1/", title: ""});
+        });
+
+        it("相对 ../parent3/", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../parent3/"});
+            assertHPath(target, {hPath: "/parent1/parent2/parent3/", title: ""});
+        });
+
+        it("相对 ../../parent3/parent4/", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../../parent3/parent4/"});
+            assertHPath(target, {hPath: "/parent1/parent3/parent4/", title: ""});
+        });
+
+        it("已在根时 ../", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../", hPath: "/"});
+            assertHPath(target, {hPath: "/", title: ""});
+        });
+
+        it("模板首尾空白 trim", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "  parent3/  "});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/parent3/", title: ""});
+        });
+    });
+
+    describe("文档名路径", () => {
+        it("相对 docName2", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "docName2"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/docName2", title: "docName2"});
+        });
+
+        it("相对 docName2 + 显式标题替换末段", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "docName2", name: "docName3"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/docName3", title: "docName3"});
+        });
+
+        it("模板首尾空白 trim", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "  docName2  "});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/docName2", title: "docName2"});
+        });
+
+        it("绝对 /docName2", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "/docName2"});
+            assertHPath(target, {hPath: "/docName2", title: "docName2"});
+        });
+
+        it("绝对 /docName2 + 显式标题替换末段", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "/docName2", name: "docName3"});
+            assertHPath(target, {hPath: "/docName3", title: "docName3"});
+        });
+
+        it("相对 parent3/docName2", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "parent3/docName2"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName/parent3/docName2", title: "docName2"});
+        });
+
+        it("绝对 /parent3/docName2", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "/parent3/docName2"});
+            assertHPath(target, {hPath: "/parent3/docName2", title: "docName2"});
+        });
+
+        it("相对 ../docName2", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../docName2"});
+            assertHPath(target, {hPath: "/parent1/parent2/docName2", title: "docName2"});
+        });
+
+        it("相对 ../../docName2", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../../docName2"});
+            assertHPath(target, {hPath: "/parent1/docName2", title: "docName2"});
+        });
+
+        it("相对 ../parent3/docName2", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../parent3/docName2"});
+            assertHPath(target, {hPath: "/parent1/parent2/parent3/docName2", title: "docName2"});
+        });
+
+        it("已在根时 ../docName2（.. 在根无效）", () => {
+            const target = getNewDocTargetFromSavePath({...nestedContext, templatePath: "../docName2", hPath: "/"});
+            assertHPath(target, {hPath: "/docName2", title: "docName2"});
+        });
+    });
+
+    describe("跨笔记本", () => {
+        const crossNotebook = {
+            ...nestedContext,
+            targetNotebookId: "box-b",
+            currentNotebookId: "box-a",
+            hPath: "/",
+            currentPath: nestedDocPath,
+        };
+
+        it("相对 docName2 → 补 / 后按目标笔记本根解析", () => {
+            const target = getNewDocTargetFromSavePath({...crossNotebook, templatePath: "docName2"});
+            assertHPath(target, {targetNotebookId: "box-b", hPath: "/docName2", title: "docName2"});
+        });
+
+        it("相对 parent3/parent4/ → 补 / 后按目标笔记本根解析", () => {
+            const target = getNewDocTargetFromSavePath({...crossNotebook, templatePath: "parent3/parent4/"});
+            assertHPath(target, {targetNotebookId: "box-b", hPath: "/parent3/parent4/", title: ""});
+        });
+
+        it("相对 ../docName2 → 补 / 后 .. 在根无效", () => {
+            const target = getNewDocTargetFromSavePath({...crossNotebook, templatePath: "../docName2"});
+            assertHPath(target, {targetNotebookId: "box-b", hPath: "/docName2", title: "docName2"});
+        });
+
+        it("绝对 /parent3/docName2 不受影响", () => {
+            const target = getNewDocTargetFromSavePath({...crossNotebook, templatePath: "/parent3/docName2"});
+            assertHPath(target, {targetNotebookId: "box-b", hPath: "/parent3/docName2", title: "docName2"});
+        });
+
+        it("空模板 + 无页签无选中 + 显式标题 → 目标笔记本根下按名称新建", () => {
+            const target = getNewDocTargetFromSavePath({
+                ...crossNotebook,
+                templatePath: "",
+                hasFocusTarget: false,
+                name: "docName2",
+            });
+            assertHPath(target, {targetNotebookId: "box-b", hPath: "/docName2", title: "docName2"});
+        });
+
+        it("空模板 + 有聚焦 + 无 name → 回退到目标笔记本根空标题文档", () => {
+            const target = getNewDocTargetFromSavePath({...crossNotebook, templatePath: ""});
+            assertHPath(target, {targetNotebookId: "box-b", hPath: "/", title: ""});
+        });
+
+        it("空模板 + 有聚焦 + 显式标题 → 目标笔记本根下按名称新建（跨笔记本 hPath 基点为 /）", () => {
+            const target = getNewDocTargetFromSavePath({...crossNotebook, templatePath: "", name: "docName2"});
+            assertHPath(target, {targetNotebookId: "box-b", hPath: "/docName2", title: "docName2"});
+        });
+    });
+});
+
+describe("getNewDocTargetFromTree", () => {
+    const notebookId = "nb";
+    // 文档树 data-path：带 .sy 的内核路径
+    const parentDocPath = "/20260628041644-ndcuikw.sy";
+    const nestedDocPath = "/20260628041644-ndcuikw/20260628040939-kkaajwr.sy";
+    // pathPosix().dirname()：同级插入时传入的父目录（无 .sy、无尾斜杠）
+    const parentDirPath = "/20260628041644-ndcuikw";
+    const rootPath = "/";
+
+    describe("文档树 + 新建子文档（currentPath 为 data-path）", () => {
+        const treeContext = {currentNotebookId: notebookId, currentPath: parentDocPath};
+
+        it("空模板", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: ""});
+            assertSubDoc(target, {targetNotebookId: notebookId, parentPath: parentDocPath, title: ""});
+        });
+
+        it("空模板 + 显式标题", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "", name: "docName2"});
+            assertSubDoc(target, {parentPath: parentDocPath, title: "docName2"});
+        });
+
+        it("单段模板 docName2", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "docName2"});
+            assertSubDoc(target, {parentPath: parentDocPath, title: "docName2"});
+        });
+
+        it("单段模板 docName2 + 显式标题", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "docName2", name: "docName3"});
+            assertSubDoc(target, {parentPath: parentDocPath, title: "docName3"});
+        });
+
+        it("多段模板 parent3/docName2（仅取末段为标题，父路径不变）", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "parent3/docName2"});
+            assertSubDoc(target, {parentPath: parentDocPath, title: "docName2"});
+        });
+
+        it("绝对模板 /docName2（落点仍为 currentPath，仅影响标题）", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "/docName2"});
+            assertSubDoc(target, {parentPath: parentDocPath, title: "docName2"});
+        });
+
+        it("容器模板 docName2/（树入口不解析容器链，无 name 时空标题）", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "docName2/"});
+            assertSubDoc(target, {parentPath: parentDocPath, title: ""});
+        });
+
+        it("容器模板 docName2/ + 显式标题", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "docName2/", name: "docName2"});
+            assertSubDoc(target, {parentPath: parentDocPath, title: "docName2"});
+        });
+
+        it("模板首尾空白 trim", () => {
+            const target = getNewDocTargetFromTree({...treeContext, templatePath: "  docName2  "});
+            assertSubDoc(target, {parentPath: parentDocPath, title: "docName2"});
+        });
+
+        it("嵌套文档下新建子文档", () => {
+            const target = getNewDocTargetFromTree({
+                currentNotebookId: notebookId,
+                currentPath: nestedDocPath,
+                templatePath: "docName2",
+            });
+            assertSubDoc(target, {parentPath: nestedDocPath, title: "docName2"});
+        });
+    });
+
+    describe("同级插入（currentPath 为 dirname，无 .sy）", () => {
+        it("嵌套文档的同级插入", () => {
+            const target = getNewDocTargetFromTree({
+                currentNotebookId: notebookId,
+                currentPath: parentDirPath,
+                templatePath: "docName2",
+            });
+            assertSubDoc(target, {parentPath: parentDirPath, title: "docName2"});
+        });
+
+        it("根级文档的同级插入（dirname 为 /）", () => {
+            const target = getNewDocTargetFromTree({
+                currentNotebookId: notebookId,
+                currentPath: rootPath,
+                templatePath: "",
+            });
+            assertSubDoc(target, {parentPath: rootPath, title: ""});
+        });
+    });
+
+    describe("笔记本根（currentPath 为 /）", () => {
+        it("空模板", () => {
+            const target = getNewDocTargetFromTree({
+                currentNotebookId: notebookId,
+                currentPath: rootPath,
+                templatePath: "",
+            });
+            assertSubDoc(target, {parentPath: rootPath, title: ""});
+        });
+
+        it("单段模板 + 显式标题", () => {
+            const target = getNewDocTargetFromTree({
+                currentNotebookId: notebookId,
+                currentPath: rootPath,
+                templatePath: "docName2",
+                name: "docName3",
+            });
+            assertSubDoc(target, {parentPath: rootPath, title: "docName3"});
+        });
+    });
+});

--- a/app/src/util/parseNewDocTarget.ts
+++ b/app/src/util/parseNewDocTarget.ts
@@ -1,0 +1,140 @@
+/**
+ * 新建文档路径解析。输入为内核渲染后的路径模板。
+ *
+ * 调用方先采集 `path`，再转为 `hPath` 传入；跨笔记本时 `hPath` 固定为 `/`。
+ *
+ * 标题优先级：`name` > 路径末段（文档名模式）> 空。`name` 替换末段，非拼接。
+ *
+ * 三种形态：
+ * - 尾 `/` → 父文档路径：路径为父文档链，新文档建在最内层父文档内；未传 `name` 时空标题
+ * - 非尾 `/` → 文档名：末段为标题，其余为父路径
+ * - 空 → 同笔记本 + 有上下文则当前文档子文档；跨笔记本或无上下文则目标笔记本根路径
+ *
+ * `/` 开头从根解析，否则相对 `hPath`；`..` 向上一级，已在根则停在 `/`。
+ * 跨笔记本时相对路径在开头补 `/`，按目标笔记本根解析；空路径也回退到目标笔记本根路径。
+ */
+
+import {mergePathSegments} from "./mergePathSegments";
+
+/** 内核 `createDocsByHPath` 按 HPath 逐级创建 */
+export type NewDocTargetByHPath = {
+    kind: "hPath";
+    targetNotebookId: string;
+    hPath: string;
+    title: string;
+};
+
+/** 在已知父路径下创建子文档 */
+export type NewDocTargetSubDoc = {
+    kind: "subDoc";
+    targetNotebookId: string;
+    parentPath: string;
+    title: string;
+};
+
+export type NewDocTarget = NewDocTargetByHPath | NewDocTargetSubDoc;
+
+/** 按保存路径配置解析新建目标 */
+export const getNewDocTargetFromSavePath = (request: {
+    templatePath: string;
+    hPath: string;
+    targetNotebookId: string;
+    currentNotebookId: string;
+    name?: string;
+    hasFocusTarget: boolean;
+    currentPath?: string;
+}): NewDocTarget => {
+    const {targetNotebookId} = request;
+
+    let templatePath = request.templatePath.trim();
+    let isAbsolute = templatePath.startsWith("/");
+    if (targetNotebookId !== request.currentNotebookId && templatePath && !isAbsolute) {
+        // 跨笔记本时相对路径无锚点，在开头补 `/` 按目标笔记本根路径解析
+        templatePath = "/" + templatePath;
+        isAbsolute = true;
+    }
+
+    // 空路径 + 同笔记本 + 有上下文 + 无 name：在已知父路径下建空标题子文档
+    // 跨笔记本时 currentPath 属于当前笔记本，在目标笔记本中无效，落到下方 hPath 逻辑回退到目标笔记本根
+    if (!templatePath && request.hasFocusTarget && !request.name
+        && targetNotebookId === request.currentNotebookId) {
+        return {
+            kind: "subDoc",
+            targetNotebookId,
+            parentPath: request.currentPath || "/",
+            title: "",
+        };
+    }
+
+    let parentTemplate: string;
+    let title = "";
+    if (!templatePath) {
+        // 空路径 + 有上下文 → 当前路径下；空路径 + 无上下文 → 笔记本根
+        parentTemplate = request.hasFocusTarget ? "" : "/";
+        title = request.name || "";
+    } else if (templatePath.endsWith("/")) {
+        // 尾部有 `/`：解析父文档链，在最内层父文档内新建
+        parentTemplate = templatePath;
+        title = request.name || "";
+    } else {
+        const segments = templatePath.split("/").filter(Boolean);
+        if (segments.length <= 1) {
+            // 文档名
+            parentTemplate = isAbsolute ? "/" : "";
+        } else {
+            // 路径：去掉末段（文档名），余下段拼成父路径模板
+            const parentSegmentPath = segments.slice(0, -1).join("/");
+            parentTemplate = isAbsolute ? "/" + parentSegmentPath : parentSegmentPath;
+        }
+        title = request.name || segments[segments.length - 1];
+    }
+
+    // 将路径模板合并进 hPath
+    const templateSegments = parentTemplate.split("/").filter(Boolean);
+    let parentPathSegments: string[];
+    if (parentTemplate.startsWith("/")) {
+        // 绝对路径：从笔记本根起算
+        parentPathSegments = mergePathSegments([], templateSegments);
+    } else {
+        // 相对路径：从当前 hPath 起算
+        parentPathSegments = mergePathSegments(request.hPath.split("/").filter(Boolean), templateSegments);
+    }
+
+    let hPath: string;
+    if (title) {
+        hPath = "/" + [...parentPathSegments, title].join("/");
+    } else {
+        // 空标题时保留尾 `/` 使 hPath 末段为空，内核按父文档链在其内新建子文档
+        hPath = parentPathSegments.length === 0 ? "/" : "/" + parentPathSegments.join("/") + "/";
+    }
+
+    return {
+        kind: "hPath",
+        targetNotebookId,
+        hPath,
+        title,
+    };
+};
+
+/** 文件树指定位置：在 `currentPath` 下建子文档，标题规则同保存路径 */
+export const getNewDocTargetFromTree = (request: {
+    templatePath: string;
+    currentNotebookId: string;
+    currentPath: string;
+    name?: string;
+}): NewDocTargetSubDoc => {
+    const templatePath = request.templatePath.trim();
+    let title = "";
+    if (request.name) {
+        title = request.name;
+    } else if (templatePath && !templatePath.endsWith("/")) {
+        const segments = templatePath.split("/").filter(Boolean);
+        title = segments[segments.length - 1];
+    }
+    return {
+        kind: "subDoc",
+        targetNotebookId: request.currentNotebookId,
+        parentPath: request.currentPath || "/",
+        title,
+    };
+};

--- a/app/src/util/pathName.ts
+++ b/app/src/util/pathName.ts
@@ -16,6 +16,7 @@ import {isOnlyMeta, isWindows, setStorageVal, updateHotkeyTip} from "../protyle/
 import {matchHotKey} from "../protyle/util/hotKey";
 import {Menu} from "../plugin/Menu";
 import {hasClosestByClassName} from "../protyle/util/hasClosest";
+import {mergePathSegments} from "./mergePathSegments";
 
 export const useShell = (cmd: "showItemInFolder" | "openPath", filePath: string) => {
     /// #if !BROWSER
@@ -777,16 +778,7 @@ export const setNoteBook = (cb?: (notebook: INotebook[]) => void, flashcard = fa
  * @returns 规范化后的相对路径（使用 /），若路径非法则返回替换后的合法路径
  */
 export const normalizeStoragePath = (storageName: string): string | null => {
-    const parts = storageName.replace(/\\/g, "/").split("/");
-    const resolved: string[] = [];
-    for (const part of parts) {
-        if (part === "..") {
-            if (resolved.length > 0) {
-                resolved.pop();
-            }
-        } else if (part && part !== ".") {
-            resolved.push(part);
-        }
-    }
-    return resolved.length > 0 ? resolved.join("/") : storageName.replace(/[\/\\]+/g, "");
+    const segments = storageName.replace(/\\/g, "/").split("/");
+    const merged = mergePathSegments([], segments);
+    return merged.length > 0 ? merged.join("/") : storageName.replace(/[\/\\]+/g, "");
 };

--- a/kernel/api/notebook.go
+++ b/kernel/api/notebook.go
@@ -370,12 +370,9 @@ func setNotebookConf(c *gin.Context) {
 		return
 	}
 
+	boxConf.DocCreateSavePath = util.TrimSpaceInPath(boxConf.DocCreateSavePath)
+
 	boxConf.RefCreateSavePath = util.TrimSpaceInPath(boxConf.RefCreateSavePath)
-	if "" != boxConf.RefCreateSavePath {
-		if !strings.HasSuffix(boxConf.RefCreateSavePath, "/") {
-			boxConf.RefCreateSavePath += "/"
-		}
-	}
 
 	boxConf.DailyNoteSavePath = util.TrimSpaceInPath(boxConf.DailyNoteSavePath)
 	if "" != boxConf.DailyNoteSavePath {
@@ -398,8 +395,6 @@ func setNotebookConf(c *gin.Context) {
 			boxConf.DailyNoteTemplatePath = "/" + boxConf.DailyNoteTemplatePath
 		}
 	}
-
-	boxConf.DocCreateSavePath = util.TrimSpaceInPath(boxConf.DocCreateSavePath)
 
 	box.SaveConf(boxConf)
 	ret.Data = boxConf

--- a/kernel/api/setting.go
+++ b/kernel/api/setting.go
@@ -476,14 +476,9 @@ func setFiletree(c *gin.Context) {
 		return
 	}
 
-	fileTree.RefCreateSavePath = util.TrimSpaceInPath(fileTree.RefCreateSavePath)
-	if "" != fileTree.RefCreateSavePath {
-		if !strings.HasSuffix(fileTree.RefCreateSavePath, "/") {
-			fileTree.RefCreateSavePath += "/"
-		}
-	}
-
 	fileTree.DocCreateSavePath = util.TrimSpaceInPath(fileTree.DocCreateSavePath)
+
+	fileTree.RefCreateSavePath = util.TrimSpaceInPath(fileTree.RefCreateSavePath)
 
 	fileTree.ShorthandSavePath = util.TrimSpaceInPath(fileTree.ShorthandSavePath)
 	if "" != fileTree.ShorthandSavePath {


### PR DESCRIPTION
## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

fix https://github.com/siyuan-note/siyuan/issues/11915 https://github.com/siyuan-note/siyuan/issues/17200 https://github.com/siyuan-note/siyuan/issues/17790

改进与统一了新建文档和新建块引文档的路径解析、拆分函数优化可读性、新增路径解析单元测试

## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [ ] Bug fix
      缺陷修复
- [x] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突

---

规则草稿：

````
# 新建文档路径规则

本文档描述通过 **设置 → 文件树 → 新建文档**（及笔记本级同名设置）配置路径模板后，`Ctrl+N` 等「遵循保存路径」入口的新建文档行为。

「文档名为空」指文档处于 `custom-sy-title-empty="true"` 状态（内核 `titleEmpty: true`），界面上不显示标题，而非回退为「未命名」等占位文案。

## 配置项

| 配置 | 说明 |
| --- | --- |
| 新建文档存储笔记本 | 「当前笔记本」或指定笔记本 ID；指定笔记本未打开时回退为当前笔记本 |
| 新建文档存储路径 | Go 模板字符串，渲染后再按本文规则解析 |

路径模板支持 Go 模板变量（如 `{{now | date "2006-01-02"}}`），**先渲染模板，再应用下文规则**。

## 「当前路径」如何确定

在应用路径模板之前，先解析 **当前路径**（`currentPath`）与 **当前笔记本**（`notebookId`）：

1. 若有聚焦的编辑器页签 → 当前笔记本为该文档所在笔记本，`currentPath` 为该文档路径
2. 否则若文档树有选中项 → 当前笔记本为选中项所在笔记本；`currentPath` 为选中项路径（选中笔记本时为 `/`，选中文档时为其 `data-path`）
3. 否则（文档树无选中项）→ 当前笔记本为第一个未关闭的笔记本，`currentPath` 为 `/`

以下规则中的「当前路径」均指上述结果。

## 显式文档名（`name` 参数）

部分入口会传入显式文档名（如搜索框新建、按名称新建）。优先级：

**`name` 参数 > 路径末段（文档名模式）> 空（容器模式）**

| 路径模式 | 未传 `name` | 传入 `name` |
| --- | --- | --- |
| 以 `/` 结尾（容器） | 文档名为空 | 文档名为 `name` |
| 以非 `/` 结尾（文档名） | 文档名为路径末段 | 文档名为 `name`（**替换**路径末段，而非拼接） |
| 路径为空 | 文档名为空 | 文档名为 `name` |

## 路径解析：三种形态

根据渲染后的路径字符串形态，分为三类。

### 1. 路径以 `/` 结尾 → 容器路径（父文档）

路径表示 **父文档链**，不在路径中指定新文档名称；新文档创建在容器末尾所指的文档内部。

| 模板示例 | 落点 | 未传 `name` 时文档名 | 传入 `name` 时文档名 |
| --- | --- | --- | --- |
| `/` | 笔记本根（`/`） | 空 | `name` |
| `/aa/` | 笔记本根下名为 `aa` 的文档内（不存在则先创建 `aa`） | 空 | `name` |
| `aa/` | 当前路径下名为 `aa` 的文档内（不存在则先创建） | 空 | `name` |
| `/2026/06/` | 根下逐级确保 `2026`、`2026/06` 父文档存在，在最内层文档内新建 | 空 | `name` |
| `inbox/aa/` | 当前路径下 `inbox`，再其下 `aa`，在 `aa` 内新建 | 空 | `name` |
| `../` | 当前文档的父文档内 | 空 | `name` |
| `../../` | 向上两级的父文档内 | 空 | `name` |
| `../inbox/` | 父文档下名为 `inbox` 的文档内（不存在则先创建） | 空 | `name` |

**Leading `/` 与相对路径：**

- 以 `/` 开头：从 **笔记本根**（`/`）解析路径
- 不以 `/` 开头：从 **当前路径** 解析相对路径
- 路径段 `..` 表示向 **父文档** 上一级；可多段连用（如 `../../`）

中间段不存在的父文档由内核按 HPath 逐级创建。

**边界：** 当前路径已在笔记本根（`/`）时，`../` 无法继续向上，回退到笔记本根（`/`）。

### 2. 路径以非 `/` 字符结尾 → 文档名路径

路径末段即为新文档名称（可被 `name` 参数覆盖）；路径其余部分（若有）表示父路径。

| 模板示例 | 落点 | 未传 `name` 时文档名 | 传入 `name` 时文档名 |
| --- | --- | --- | --- |
| `bb` | 当前路径下 | `bb` | `name`（替换 `bb`） |
| `/bb` | 笔记本根下 | `bb` | `name` |
| `inbox/bb` | 当前路径下 `inbox` 子文档内 | `bb` | `name` |
| `/inbox/bb` | 笔记本根下 `inbox` 子文档内 | `bb` | `name` |
| `{{now \| date "2006-01-02"}}` | 当前路径下 | 渲染后的日期字符串 | `name` |
| `../bb` | 当前文档的父文档内 | `bb` | `name` |
| `../../bb` | 向上两级的父文档内 | `bb` | `name` |
| `../inbox/bb` | 父文档下 `inbox` 子文档内 | `bb` | `name` |

**Leading `/` 与相对路径** 规则同容器模式。

### 3. 路径为空

不通过模板指定路径结构；落点由上下文决定，文档名由 `name` 决定或为空。

| 条件 | 落点 | 未传 `name` 时文档名 | 传入 `name` 时文档名 |
| --- | --- | --- | --- |
| 有打开的编辑器页签，或文档树有选中项 | 作为当前路径对应文档的 **子文档** | 空 | `name` |
| 无打开页签且文档树无选中 | 笔记本根（`/`） | 空 | `name` |

**跨笔记本时的空路径：** 当配置的存储笔记本不是当前笔记本时，「有上下文」这一行的落点回退为 **目标笔记本根**（`/`）。原因：当前路径属于当前笔记本，在目标笔记本中不存在，无法作为父路径；此时与「无上下文」行行为一致。

## 存储笔记本与相对路径

当 **配置的存储笔记本** 不是 **当前笔记本** 时，不以 `/` 开头的相对路径 **没有有效的当前文档锚点**，实现上自动在路径前补 `/`，按目标笔记本根下的绝对路径解析（与 #10671 动机一致）。

空路径同样回退到目标笔记本根：跨笔记本时当前路径在目标笔记本中不存在，无法作为父路径，因此「有上下文 + 空路径」不再走子文档，而是在目标笔记本根下新建（与无上下文一致）。

以 `/` 开头的路径不受此影响，始终在目标笔记本根下解析。

## 适用入口

以下入口应统一遵循本文规则（`useSavePath: true` 或等价逻辑）：

- `Ctrl+N` / 命令面板「新建文档」
- 页签栏 `+` 按钮
- 编辑器空状态页的「新建文档」
- 块引 `((newFile "名称"` 提示新建文档（走 `newFileByRefHint` → `getNewDocTargetFromSavePath`，使用「块引时新建文档存储路径」配置）
- 其他调用 `newFile` / `newFileInProtyle` / `newFileByRefHint` 的入口

文件树右键「新建子文档」等传入固定 `currentPath` 的入口走更简的语义：始终在 `currentPath` 下建子文档（`subDoc`），模板**仅用于推导标题**，不解析绝对/相对路径、`..` 或容器链。标题规则与保存路径一致：`name` > 模板末段（非尾 `/`）> 空（尾 `/` 或空模板）。`currentPath` 由操作目标文档决定，而非 `getNewFilePath` 的默认解析。

## 规则速查表

| 路径模板 | 落点 | 未指定名 | 指定 `name` |
| --- | --- | --- | --- |
| （空） | 有上下文 → 子文档；否则 → 笔记本根 | 空 | `name` |
| `bb` | 当前路径下 | `bb` | `name` |
| `/bb` | 笔记本根 | `bb` | `name` |
| `bb/` | 当前路径下 `bb` 文档内 | 空 | `name` |
| `/bb/` | 笔记本根下 `bb` 文档内 | 空 | `name` |
| `/` | 笔记本根 | 空 | `name` |
| `../` | 父文档内 | 空 | `name` |
| `../bb` | 父文档内 | `bb` | `name` |

## 示例

### 日记：按日落盘到固定笔记本

- 存储笔记本：收集箱
- 路径模板：`/daily/{{now | date "2006/01/02"}}/`
- 效果：在收集箱根下按日期建父文档链，每日新建文档标题为空，由用户自行填写

### 快速记录：空路径

- 存储笔记本：当前笔记本
- 路径模板：（空）
- 在文档中 `Ctrl+N`：当前文档下新建空标题子文档
- 关闭所有页签后 `Ctrl+N`：笔记本根新建空标题文档

### 固定名称草稿

- 路径模板：`草稿`
- 在任意文档中 `Ctrl+N`：当前文档下名为「草稿」的子文档

### 笔记本根固定名称

- 路径模板：`/草稿`
- 任意上下文 `Ctrl+N`：目标笔记本根下名为「草稿」的文档

### 父文档层级：`../`

假设当前正在编辑文档 `项目/本周/笔记`（`笔记` 为 `本周` 的子文档）：

| 路径模板 | 效果 |
| --- | --- |
| `../` | 在 `本周` 内新建空标题文档（与 `笔记` 同级） |
| `../待办` | 在 `本周` 内新建名为「待办」的文档 |
| `../../` | 在 `项目` 内新建空标题文档 |
| `../../归档/笔记/` | 自 `项目` 向下经 `归档`、`笔记` 定位容器，在其内新建空标题文档 |
| `../inbox/` | 在 `本周` 下名为 `inbox` 的文档内新建（不存在则先创建 `inbox`） |

当前路径为笔记本根（`/`）时，`../` 回退到笔记本根。

## 与旧行为的差异（实现时注意）

实现本文规则后，下列旧行为将改变，需在 changelog 中说明：

| 旧行为 | 新行为 |
| --- | --- |
| `/未命名` 可能产生 `未命名/未命名文档` 嵌套 | `/未命名` 为根下名为「未命名」的文档；若要子文档用 `/未命名/` |
| 空路径模板走 `createDoc`，标题为 `basename("")` 等边界情况 | 空路径 → 空标题或 `name`，落点按上下文 |
| 路径模式总会追加默认「未命名文档」 | 仅容器模式（尾 `/`）和空路径在未指定名时标题为空；文档名模式用路径末段 |

## 相关代码（实现参考）

| 位置 | 职责 |
| --- | --- |
| `app/src/util/parseNewDocTarget.ts` | 纯函数路径解析：`getNewDocTargetFromSavePath` / `getNewDocTargetFromTree` |
| `app/src/util/parseNewDocTarget.test.ts` | `node:test` 单元测试（`pnpm run test`） |
| `app/src/util/newFile.ts` | 上下文采集、`runNewDoc` / `runNewDocInTree`、`executeNewDocTarget` |
| `kernel/api/filetree.go` → `getDocCreateSavePath` | 模板渲染、跨笔记本路径补全 |
| `kernel/model/path.go` → `createDocsByHPath` | 按 HPath 逐级创建父文档与新文档 |

## 相关 Issue

- [#10671](https://github.com/siyuan-note/siyuan/issues/10671) 指定新建文档存储笔记本
- [#17895](https://github.com/siyuan-note/siyuan/pull/17895) 空标题文档
````

经过手工测试：

````
# 新建文档路径手工 UI 测试计划

本文档用于在界面上手工验证 `parseNewDocTarget.ts` + `newFile.ts` 的端到端行为。规则详见 [new-document-path.zh-CN.md](./new-document-path.zh-CN.md)，单元测试见 `app/src/util/parseNewDocTarget.test.ts`。

## 前置准备

1. 至少两个未关闭的笔记本：`A`、`B`
2. 在笔记本 `A` 下手工创建：
  - 嵌套文档 `/parent1/parent2/docName`（即 `parent1` → `parent2` → `docName` 三级）
  - 根级文档 `/docName`
3. 打开「设置 → 文件树」，确认存在「新建文档存储笔记本」「新建文档存储路径」两项；每个用例开始前按表格设置。

## 入口


| 入口                    | 调用                                  | 说明                                                      |
| --------------------- | ----------------------------------- | ------------------------------------------------------- |
| `Ctrl+N` / 命令面板「新建文档」 | `newFile` → `runNewDoc`             | 走 `getNewDocTargetFromSavePath`，受路径模板影响                 |
| 页签栏 `+` 按钮            | 同上                                  | 同上                                                      |
| 编辑器空状态「新建文档」          | 同上                                  | 同上                                                      |
| 文件树右键「新建子文档」          | `newFileInTree` → `runNewDocInTree` | 走 `getNewDocTargetFromTree`，模板**仅推导标题**，不解析 `..` / 绝对路径 |


## 通用验证要点

- **落点**：在文件树展开核对新建文档所在父文档。
- **标题**：空标题指 `custom-sy-title-empty="true"`（界面不显示标题），**不是**「未命名」。
- **笔记本**：跨笔记本时确认确实落在目标笔记本。
- 每个用例后建议撤销（删除新建文档）以保持环境干净。

## 一、空模板

设置：存储笔记本 = 当前笔记本，存储路径 = （空）。


| #   | 操作                                     | 预期落点         | 预期标题 |
| --- | -------------------------------------- | ------------ | ---- |
| 1   | 聚焦 `/parent1/parent2/docName`，`Ctrl+N` | `docName` 下  | 空    |
| 2   | 聚焦根级文档 `/docName`，`Ctrl+N`             | `/docName` 下 | 空    |
| 3   | 文档树选中笔记本 `A` 根，`Ctrl+N`                | 笔记本 `A` 根    | 空    |
| 4   | 关闭所有页签且文档树无选中，`Ctrl+N`                 | 第一个未关闭笔记本根   | 空    |


## 二、容器路径（尾 `/`）

设置：存储笔记本 = 当前笔记本。聚焦 `/parent1/parent2/docName`。


| #   | 存储路径                            | 预期落点                        | 预期标题 |
| --- | ------------------------------- | --------------------------- | ---- |
| 5   | `/parent3/`                     | 笔记本根下 `parent3` 内           | 空    |
| 6   | `/parent3/` 且传入名称 `x`（命令面板按名新建） | 笔记本根下 `parent3` 内           | `x`  |
| 7   | `/`                             | 笔记本根                        | 空    |
| 8   | `parent3/`（相对）                  | `docName` 下 `parent3` 内     | 空    |
| 9   | `../`                           | `parent2` 内（与 `docName` 同级） | 空    |
| 10  | `../../`                        | `parent1` 内                 | 空    |
| 11  | `../`，聚焦改为根级文档 `/docName`       | 笔记本根（`..` 在根无效）             | 空    |
| 12  | `parent3/` （首尾空格）               | 同 #8                        | 空    |


## 三、文档名路径

设置：存储笔记本 = 当前笔记本。聚焦 `/parent1/parent2/docName`。


| #   | 存储路径                        | 预期落点              | 预期标题       |
| --- | --------------------------- | ----------------- | ---------- |
| 13  | `bb`                        | `docName` 下       | `bb`       |
| 14  | `bb` 且传入名称 `cc`             | `docName` 下       | `cc`（替换末段） |
| 15  | `/bb`                       | 笔记本根下             | `bb`       |
| 16  | `inbox/bb`                  | `docName/inbox` 下 | `bb`       |
| 17  | `../bb`                     | `parent2` 下       | `bb`       |
| 18  | `../../bb`                  | `parent1` 下       | `bb`       |
| 19  | `../bb`，聚焦改为根级文档 `/docName` | 笔记本根下             | `bb`       |


## 四、跨笔记本

设置：存储笔记本 = `B`，当前笔记本 = `A`，聚焦 `A` 中 `/parent1/parent2/docName`。


| #   | 存储路径                    | name               | 预期落点                       | 预期标题       |
| --- | ----------------------- | ------------------ | -------------------------- | ---------- |
| 20  | `docName2`（相对）          | —                  | `B` 根下                     | `docName2` |
| 21  | `parent3/parent4/`      | —                  | `B` 根下 `parent3/parent4` 内 | 空          |
| 22  | `../docName2`           | —                  | `B` 根下（`..` 在根无效）          | `docName2` |
| 23  | `/parent3/docName2`（绝对） | —                  | `B` 根下 `parent3` 内         | `docName2` |
| 24  | （空）                     | `docName2`，且关闭所有页签 | `B` 根下                     | `docName2` |
| 25  | （空）                     | —                  | `B` 根下                     | 空          |


> #25 验证问题 1 修复：跨笔记本 + 空模板 + 有聚焦 + 无 name 时，回退到 `B` 根下建空标题文档（修复前会报 `block not found`）。

## 五、文件树右键「新建子文档」

入口：文件树右键 → 新建子文档。模板**仅用于推导标题**，落点恒为所右键的文档。


| #   | 右键目标      | 存储路径         | name | 预期落点        | 预期标题            |
| --- | --------- | ------------ | ---- | ----------- | --------------- |
| 26  | `docName` | （空）          | —    | `docName` 下 | 空               |
| 27  | `docName` | `bb`         | —    | `docName` 下 | `bb`            |
| 28  | `docName` | `parent3/bb` | —    | `docName` 下 | `bb`（仅取末段）      |
| 29  | `docName` | `/bb`        | —    | `docName` 下 | `bb`（绝对路径不影响落点） |
| 30  | `docName` | `bb/`        | —    | `docName` 下 | 空（容器模式无 name）   |
| 31  | 笔记本 `A` 根 | （空）          | —    | 笔记本 `A` 根   | 空               |


## 六、Go 模板渲染


| #   | 存储路径                                  | 预期                                       |
| --- | ------------------------------------- | ---------------------------------------- |
| 32  | `{{now \| date "2006-01-02"}}`         | 当前路径下，标题为渲染后的日期（如 `2026-06-28`）         |
| 33  | `/daily/{{now \| date "2006/01/02"}}/` | 笔记本根下按日期建父文档链（`daily/年/月/日`），空标题        |


## 回归建议

- 改动 `parseNewDocTarget.ts` 或 `newFile.ts` 后，至少跑 #1、#9、#13、#20、#25、#26、#32 七条覆盖核心分支（#25 验证跨笔记本空模板修复）。
- 同步运行 `pnpm run test`（`parseNewDocTarget.test.ts`）作为单元测试兜底。
````