### PR TITLE
Guard IME composition in the agent session rename input

### DIFF
--- a/app/src/layout/dock/agent/AgentSessionPanel.ts
+++ b/app/src/layout/dock/agent/AgentSessionPanel.ts
@@ -272,6 +272,9 @@ export class AgentSessionPanel {
             this.finishRename(id, input.value, input, titleEl);
         });
         input.addEventListener("keydown", (e: KeyboardEvent) => {
+            if (e.isComposing) {
+                return;
+            }
             if (e.key === "Enter") {
                 input.blur();
             }


### PR DESCRIPTION
When you rename a session in the agent dock, the rename input commits on Enter and reverts on Escape. Its keydown handler does not check `event.isComposing`, so a composition-confirming Enter from an IME can reach the handler and blur the input, committing the rename with a half-composed title.

The search input in this same component already returns early on `event.isComposing` in its keydown handler. This change applies the same guard to the rename input so both inputs handle composition the same way. The check is a no-op when no IME is active.
