### PR TITLE
Improve status bar color parsing on mobile

### DIFF
--- a/app/src/util/assets.ts
+++ b/app/src/util/assets.ts
@@ -310,32 +310,37 @@ export const setMode = (modeElementValue: number) => {
     /// #endif
 };
 
-const rgba2hex = (rgba: string) => {
-    if (rgba.startsWith("#")) {
-        return rgba;
-    }
-    let a: any;
-    const rgb: any = rgba.replace(/\s/g, "").match(/^rgba?\((\d+),(\d+),(\d+),?([^,\s)]+)?/i);
-    const alpha = (rgb && rgb[4] || "").trim();
-    let hex = rgb ?
-        (rgb[1] | 1 << 8).toString(16).slice(1) +
-        (rgb[2] | 1 << 8).toString(16).slice(1) +
-        (rgb[3] | 1 << 8).toString(16).slice(1) : rgba;
+const padHex = (n: number) => (n | 256).toString(16).slice(1);
 
-    if (alpha !== "") {
-        a = alpha;
-    } else {
-        a = 0o1;
+const rgbaToHex = (rgba: string) => {
+    const rgb = rgba.replace(/\s/g, "").match(/^rgba?\((\d+),(\d+),(\d+)(?:,([^)]+))?\)$/i);
+    if (!rgb) {
+        return "";
     }
-    a = ((a * 255) | 1 << 8).toString(16).slice(1);
-    hex = hex + a;
-    return hex;
+    const alpha = rgb[4] !== undefined ? parseFloat(rgb[4]) : 1;
+    if (alpha === 0) {
+        return "";
+    }
+    return "#" +
+        padHex(parseInt(rgb[1], 10)) +
+        padHex(parseInt(rgb[2], 10)) +
+        padHex(parseInt(rgb[3], 10)) +
+        padHex(Math.round(alpha * 255));
+};
+
+const cssVarToRgba = (varName: string) => {
+    const probe = document.createElement("div");
+    probe.style.display = "none";
+    probe.style.backgroundColor = `var(${varName})`;
+    document.documentElement.appendChild(probe);
+    const rgba = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    return rgba;
 };
 
 const updateMobileTheme = (OSTheme: string) => {
     if (isInMobileApp()) {
         setTimeout(() => {
-            const backgroundColor = rgba2hex(getComputedStyle(document.body).getPropertyValue("--b3-theme-background").trim());
             let mode = window.siyuan.config.appearance.mode;
             if (window.siyuan.config.appearance.modeOS) {
                 if (OSTheme === "dark") {
@@ -344,8 +349,11 @@ const updateMobileTheme = (OSTheme: string) => {
                     mode = 0;
                 }
             }
+            const fallback = mode === 0 ? "#ffffffff" : "#1e1e1eff";
+            const backgroundColor = rgbaToHex(cssVarToRgba("--b3-theme-background")) || fallback;
+            // 统一传 #RRGGBBAA：iOS 按 #RRGGBBAA 解析，Android / Harmony 将 #RRGGBBAA 转为 #AARRGGBB
             if (isInIOS()) {
-                window.webkit.messageHandlers.changeStatusBar.postMessage((backgroundColor || (mode === 0 ? "#fff" : "#1e1e1e")) + " " + mode);
+                window.webkit.messageHandlers.changeStatusBar.postMessage(backgroundColor + " " + mode);
             } else if (isInAndroid()) {
                 window.JSAndroid.changeStatusBarColor(backgroundColor, mode);
             } else if (isInHarmony()) {


### PR DESCRIPTION
## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

目前移动端状态栏只支持 --b3-theme-background 的值为 rgb 或者 hex，给主题开发带来不便。本 PR 改进为任何浏览器支持的颜色都能解析。

配套的移动端原生代码更改如下，但我没有环境进行测试，不知道有没有改对：

harmony

```diff
Index: entry/src/main/ets/pages/JSHarmony.ets
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/entry/src/main/ets/pages/JSHarmony.ets b/entry/src/main/ets/pages/JSHarmony.ets
--- a/entry/src/main/ets/pages/JSHarmony.ets	(revision 8b6e336001f84e9d67a1242839dd0c3e8a34ed7e)
+++ b/entry/src/main/ets/pages/JSHarmony.ets	(date 1783124760595)
@@ -380,24 +380,14 @@
   private parseColor(color: string): string {
     try {
       color = color.trim();
-      if (color.toLowerCase().includes("rgb")) {
-        const splitStr = color.substring(color.indexOf('(') + 1, color.indexOf(')'));
-        const splitString = splitStr.split(",");
-        const colorValues = splitString.map(value => parseInt(value.trim(), 10));
-        return `rgb(${colorValues[0]}, ${colorValues[1]}, ${colorValues[2]})`;
+      if (color.length !== 9 || color.charAt(0) !== '#') {
+        throw new Error("invalid color format");
       }
-      if (color.length < 7) {
-        // Convert 3-digit hex colors to 6-digit
-        color = color.replace(new RegExp("#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])"), "#$1$1$2$2$3$3");
-      }
-      if (color.length === 9 && color.charAt(0) === '#') {
-        // Convert #RRGGBBAA to #AARRGGBB
-        color = "#" + color.substring(7, 9) + color.substring(1, 7);
-      }
-      return color;
+      // Convert #RRGGBBAA to #AARRGGBB
+      return "#" + color.substring(7, 9) + color.substring(1, 7);
     } catch (e) {
       hilog.error(0x0000, "siyuan", "parse color [" + color + "] failed", e);
-      return "#ffffff";
+      return "#ffffffff";
     }
   }
 

```

ios

```diff
Index: siyuan-ios/ViewController.swift
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/siyuan-ios/ViewController.swift b/siyuan-ios/ViewController.swift
--- a/siyuan-ios/ViewController.swift	(revision be27b4ecf91df2941d21260e4892aa836fad9064)
+++ b/siyuan-ios/ViewController.swift	(date 1783124758305)
@@ -528,45 +528,28 @@
 
 extension UIColor {
   convenience init?(hexString: String?, isDarkMode: Bool) {
-    var input: String! = (hexString ?? "")
+    let input = (hexString ?? "")
       .replacingOccurrences(of: "#", with: "")
       .uppercased()
     var alpha: CGFloat = 1.0
     var red: CGFloat = 0
-    var blue: CGFloat = 0
     var green: CGFloat = 0
-    switch input.count {
-    case 3 /* #RGB */:
-      red = Self.colorComponent(from: input, start: 0, length: 1)
-      green = Self.colorComponent(from: input, start: 1, length: 1)
-      blue = Self.colorComponent(from: input, start: 2, length: 1)
-      break
-    case 4 /* #ARGB */:
-      alpha = Self.colorComponent(from: input, start: 0, length: 1)
-      red = Self.colorComponent(from: input, start: 1, length: 1)
-      green = Self.colorComponent(from: input, start: 2, length: 1)
-      blue = Self.colorComponent(from: input, start: 3, length: 1)
-      break
-    case 6 /* #RRGGBB */:
+    var blue: CGFloat = 0
+    if input.count == 8 /* #RRGGBBAA */ {
       red = Self.colorComponent(from: input, start: 0, length: 2)
       green = Self.colorComponent(from: input, start: 2, length: 2)
       blue = Self.colorComponent(from: input, start: 4, length: 2)
-      break
-    case 8 /* #AARRGGBB */:
-      alpha = Self.colorComponent(from: input, start: 0, length: 2)
-      red = Self.colorComponent(from: input, start: 2, length: 2)
-      green = Self.colorComponent(from: input, start: 4, length: 2)
-      blue = Self.colorComponent(from: input, start: 6, length: 2)
-      break
-    default:
+      alpha = Self.colorComponent(from: input, start: 6, length: 2)
+    } else {
+      let fallback: String
       if isDarkMode {
-        input = "ffffff"
+        fallback = "ffffff"
       } else {
-        input = "1e1e1e"
+        fallback = "1e1e1e"
       }
-      red = Self.colorComponent(from: input, start: 0, length: 2)
-      green = Self.colorComponent(from: input, start: 2, length: 2)
-      blue = Self.colorComponent(from: input, start: 4, length: 2)
+      red = Self.colorComponent(from: fallback, start: 0, length: 2)
+      green = Self.colorComponent(from: fallback, start: 2, length: 2)
+      blue = Self.colorComponent(from: fallback, start: 4, length: 2)
     }
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }

```

android

```diff
Index: app/src/main/java/org/b3log/siyuan/JSAndroid.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/org/b3log/siyuan/JSAndroid.java b/app/src/main/java/org/b3log/siyuan/JSAndroid.java
--- a/app/src/main/java/org/b3log/siyuan/JSAndroid.java	(revision ed1060a481dce1446cec92a8a32ff44cdf52a2dd)
+++ b/app/src/main/java/org/b3log/siyuan/JSAndroid.java	(date 1783124753883)
@@ -461,25 +461,11 @@
     private int parseColor(String str) {
         try {
             str = str.trim();
-            if (str.toLowerCase().contains("rgb")) {
-                String splitStr = str.substring(str.indexOf('(') + 1, str.indexOf(')'));
-                String[] splitString = splitStr.split(",");
-
-                final int[] colorValues = new int[splitString.length];
-                for (int i = 0; i < splitString.length; i++) {
-                    colorValues[i] = Integer.parseInt(splitString[i].trim());
-                }
-                return Color.rgb(colorValues[0], colorValues[1], colorValues[2]);
+            if (9 != str.length() || '#' != str.charAt(0)) {
+                throw new IllegalArgumentException("invalid color format");
             }
-            if (7 > str.length()) {
-                // https://stackoverflow.com/questions/10230331/how-to-convert-3-digit-html-hex-colors-to-6-digit-flex-hex-colors
-                str = str.replaceAll("#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])", "#$1$1$2$2$3$3");
-            }
-            if (9 == str.length() && '#' == str.charAt(0)) {
-                // The status bar color on Android is incorrect https://github.com/siyuan-note/siyuan/issues/10278
-                // 将 #RRGGBBAA 转换为 #AARRGGBB
-                str = "#" + str.substring(7, 9) + str.substring(1, 7);
-            }
+            // 将 #RRGGBBAA 转换为 #AARRGGBB
+            str = "#" + str.substring(7, 9) + str.substring(1, 7);
             return Color.parseColor(str);
         } catch (final Exception e) {
             Utils.logError("js", "parse color [" + str + "] failed", e);

```

## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [ ] Bug fix
      缺陷修复
- [x] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突