### PR TITLE
Fix custom select menu not clickable above app-region: drag; elements

### DIFF
--- a/app/src/assets/scss/component/_select.scss
+++ b/app/src/assets/scss/component/_select.scss
@@ -53,6 +53,7 @@
         padding: 8px;
         scrollbar-width: thin;
         scrollbar-color: var(--b3-scroll-color) transparent;
+        app-region: no-drag;
       }
 
       &::picker-icon {


### PR DESCRIPTION


## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

fix https://github.com/siyuan-note/siyuan/issues/14273 02

修复自定义 select 菜单在 app-region: drag; 元素上方无法点击

## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突