### PR TITLE
ci: pin jlumbroso/free-disk-space to a full commit SHA

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -47,7 +47,7 @@ jobs:
           echo "Tag matches version: $TAG"
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB


### PR DESCRIPTION
### What

Pin `jlumbroso/free-disk-space@main` → `54081f1…` in `dockerimage.yml` (tag kept in a trailing comment).

### Why

`@main` is a moving reference — whatever it points to at run time runs in the job. This one is in the
[Docker image job](https://github.com/siyuan-note/siyuan/blob/41f2861c87575ff5ac4b50a0520b1a4fe55b4a70/.github/workflows/dockerimage.yml#L40-L65), which logs in to DockerHub (`DOCKER_HUB_PWD`) and pushes the image. If the action's `main` were
moved (compromise or an accidental change), the new code would run in a job holding registry push
credentials — the class of issue behind the 2025 `tj-actions/changed-files` incident.

### Scope / safety

- Behaviour unchanged — the SHA is the current tip of the action's `main`.
- Renovate/Dependabot can still bump a SHA pin (the tag comment keeps it readable). Signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>
