### PR TITLE
Improves kernel-plugin WebSocket client behavior and proxy networking controls

### DIFF
--- a/kernel/api/network.go
+++ b/kernel/api/network.go
@@ -344,7 +344,8 @@ func getSafeClient(timeout time.Duration) *req.Client {
 // Query params:
 //   - `u`: RawURLEncoding base64 of the target URL string.
 //   - `h`: RawURLEncoding base64 of a JSON object map[string][]string.
-func parseForwardProxyParams(c *gin.Context) (parsedURL *url.URL, headers *http.Header, err error) {
+//   - `timeout`: The timeout for the request in nanoseconds.
+func parseForwardProxyParams(c *gin.Context) (parsedURL *url.URL, headers *http.Header, timeout time.Duration, err error) {
 	uParam := c.Query("u")
 	if uParam == "" {
 		err = fmt.Errorf("missing query param [u]")
@@ -377,6 +378,18 @@ func parseForwardProxyParams(c *gin.Context) (parsedURL *url.URL, headers *http.
 		err = fmt.Errorf("parse [h] failed: %s", jsonErr.Error())
 		return
 	}
+
+	timeout = 30 * time.Second
+	tParam := c.Query("t")
+	if tParam != "" {
+		if t, parseErr := time.ParseDuration(tParam); parseErr != nil {
+			err = fmt.Errorf("parse [t] failed: %s", parseErr.Error())
+			return
+		} else {
+			timeout = t
+		}
+	}
+
 	for k, vs := range record {
 		for _, v := range vs {
 			h.Add(k, v)
@@ -403,7 +416,7 @@ func forwardResponseHeaders(dst http.Header, src http.Header) {
 // The request method and body are taken from the incoming request.
 // Target response headers are forwarded with a "Siyuan-Proxy-" prefix.
 func httpProxy(c *gin.Context) {
-	targetURL, targetHeaders, err := parseForwardProxyParams(c)
+	targetURL, targetHeaders, timeout, err := parseForwardProxyParams(c)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"code": -1, "msg": err.Error()})
 		return
@@ -415,7 +428,7 @@ func httpProxy(c *gin.Context) {
 	}
 
 	transport := &http.Transport{
-		DialContext: util.SSRFSafeDialer(30 * time.Second).DialContext,
+		DialContext: util.SSRFSafeDialer(timeout).DialContext,
 	}
 	httpClient := &http.Client{Transport: transport}
 
@@ -458,7 +471,7 @@ func httpProxy(c *gin.Context) {
 //
 // Target response headers are forwarded with a "Siyuan-Proxy-" prefix.
 func wsProxy(c *gin.Context) {
-	targetURL, targetHeaders, err := parseForwardProxyParams(c)
+	targetURL, targetHeaders, timeout, err := parseForwardProxyParams(c)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"code": -1, "msg": err.Error()})
 		return
@@ -470,8 +483,8 @@ func wsProxy(c *gin.Context) {
 	}
 
 	wsDialer := &websocket.Dialer{
-		NetDialContext:   util.SSRFSafeDialer(30 * time.Second).DialContext,
-		HandshakeTimeout: 30 * time.Second,
+		NetDialContext:   util.SSRFSafeDialer(timeout).DialContext,
+		HandshakeTimeout: timeout,
 	}
 
 	targetConn, targetResp, dialErr := wsDialer.DialContext(c.Request.Context(), targetURL.String(), *targetHeaders)
@@ -551,7 +564,7 @@ func wsProxy(c *gin.Context) {
 //
 // Target response headers are forwarded with a "Siyuan-Proxy-" prefix.
 func esProxy(c *gin.Context) {
-	targetURL, targetHeaders, err := parseForwardProxyParams(c)
+	targetURL, targetHeaders, timeout, err := parseForwardProxyParams(c)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"code": -1, "msg": err.Error()})
 		return
@@ -563,7 +576,7 @@ func esProxy(c *gin.Context) {
 	}
 
 	transport := &http.Transport{
-		DialContext: util.SSRFSafeDialer(30 * time.Second).DialContext,
+		DialContext: util.SSRFSafeDialer(timeout).DialContext,
 	}
 	httpClient := &http.Client{Transport: transport}
 

--- a/kernel/plugin/api_client.go
+++ b/kernel/plugin/api_client.go
@@ -294,62 +294,46 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_open := rt.ToValue(func(openCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				openPromise, openResolve, openReject := rt.NewPromise()
 
-				openRunErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
-					openOnce.Do(func() {
-						go func() {
-							conn, _, dialErr := gws.NewClient(h, &gws.ClientOption{
-								Addr:          wsURL,
-								RequestHeader: wsHeader,
-							})
-							if dialErr != nil {
-								p.worker.Run(func(rt *goja.Runtime) (_ any, dialErr2 error) {
-									event := rt.NewObject()
-									event.Set("type", rt.ToValue("error"))
-									event.Set("error", rt.NewGoError(dialErr))
-									invokeHook(rt, "onerror", event)
-
-									dialErr2 = dialErr
-									return
-								}, func(rt *goja.Runtime, _ any, dialErr2 error) {
-									if rejectErr := openReject(rt.NewGoError(dialErr2)); rejectErr != nil {
-										logging.LogErrorf("[plugin:%s] siyuan.client.socket.open reject: %v", p.Name, rejectErr)
-									}
-								})
-								doClose()
-								return
-							}
-							gwsConn.Store(conn)
-							go func() {
-								<-ctx.Done()
-								conn.NetConn().Close()
-							}()
-							// Resolve the open promise before starting ReadLoop so the caller
-							// can await open() and then rely on onopen for additional setup.
+				// FIXME: 兼容 open() 被调用多次的情况
+				openOnce.Do(func() {
+					go func() {
+						conn, _, dialErr := gws.NewClient(h, &gws.ClientOption{
+							Addr:          wsURL,
+							RequestHeader: wsHeader,
+						})
+						if dialErr != nil {
 							p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
-								if resolveErr := openResolve(nil); resolveErr != nil {
-									logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
+								event := rt.NewObject()
+								event.Set("type", rt.ToValue("error"))
+								event.Set("error", rt.NewGoError(dialErr))
+								invokeHook(rt, "onerror", event)
+
+								if rejectErr := openReject(rt.NewGoError(dialErr)); rejectErr != nil {
+									logging.LogErrorf("[plugin:%s] siyuan.client.socket.open reject: %v", p.Name, rejectErr)
 								}
 								return
 							}, nil)
-							conn.ReadLoop()
 							doClose()
+							return
+						}
+						gwsConn.Store(conn)
+						go func() {
+							<-ctx.Done()
+							conn.NetConn().Close()
 						}()
-					})
-					return
-				}, func(rt *goja.Runtime, result any, err error) {
-					if lo.IsNil(err) {
-						if resolveErr := openResolve(nil); resolveErr != nil {
-							logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
-						}
-					} else {
-						if rejectErr := openReject(rt.NewGoError(err)); rejectErr != nil {
-							logging.LogErrorf("[plugin:%s] siyuan.client.socket.open reject: %v", p.Name, rejectErr)
-						}
-					}
+						// Resolve the open promise before starting ReadLoop so the caller
+						// can await open() and then rely on onopen for additional setup.
+						p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
+							if resolveErr := openResolve(nil); resolveErr != nil {
+								logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
+							}
+							return
+						}, nil)
+
+						conn.ReadLoop()
+						doClose()
+					}()
 				})
-				if openRunErr != nil {
-					logging.LogErrorf("[plugin:%s] siyuan.client.socket.open worker run: %v", p.Name, openRunErr)
-				}
 
 				return rt.ToValue(openPromise)
 			})

--- a/kernel/plugin/api_client.go
+++ b/kernel/plugin/api_client.go
@@ -294,6 +294,7 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_open := rt.ToValue(func(openCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				openPromise, openResolve, openReject := rt.NewPromise()
 
+				// FIXME: ws.open() 在同一个 WebSocket 对象上被重复调用时，会因为 opening=false 分支直接 resolve，导致调用方误以为连接已建立（实际上仍处于 CONNECTING）。这会让 await open() 的语义不可靠。建议仅在 readyState=OPEN 时才 resolve；否则应 reject（或返回同一个 pending promise）。
 				openRunErr := p.worker.Run(func(rt *goja.Runtime) (opening any, err error) {
 					opening = false
 					openOnce.Do(func() {
@@ -504,6 +505,7 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 					reason = []byte(closeCall.Argument(1).String())
 				}
 
+				// FIXME: ws.close() 在连接尚未建立（gwsConn=nil）时不会更新 readyState，也不会取消 context，导致 close() 之后对象状态仍可能保持 CONNECTING。建议在未连接时也将 readyState 置为 CLOSED 并执行 doClose()，以便行为与浏览器更一致、避免悬挂状态。
 				closeRunErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
 					if c := gwsConn.Load(); c != nil {
 						setReadyState(rt, WebSocketReadyStateClosing)

--- a/kernel/plugin/api_client.go
+++ b/kernel/plugin/api_client.go
@@ -282,8 +282,37 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			h.BindOnMessage(manager)
 
 			var openOnce sync.Once
+			var openPromises []Promise
+
+			addOpenPromise := func(resolve, reject func(reason interface{}) error) {
+				// nil slice 也可以直接 append
+				openPromises = append(openPromises, Promise{Resolve: resolve, Reject: reject})
+			}
+
+			resolveOpenPromises := func(rt *goja.Runtime) {
+				if openPromises != nil {
+					for _, promise := range openPromises {
+						if resolveErr := promise.Resolve(nil); resolveErr != nil {
+							logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
+						}
+					}
+					openPromises = nil
+				}
+			}
+
+			rejectOpenPromises := func(rt *goja.Runtime, err error) {
+				if openPromises != nil {
+					for _, promise := range openPromises {
+						if rejectErr := promise.Reject(rt.NewGoError(err)); rejectErr != nil {
+							logging.LogErrorf("[plugin:%s] siyuan.client.socket.open reject: %v", p.Name, rejectErr)
+						}
+					}
+					openPromises = nil
+				}
+			}
 
 			ctx, cancel := context.WithCancel(p.context)
+
 			var closeOnce sync.Once
 			doClose := func() {
 				closeOnce.Do(func() {
@@ -294,46 +323,82 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_open := rt.ToValue(func(openCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				openPromise, openResolve, openReject := rt.NewPromise()
 
-				// FIXME: 兼容 open() 被调用多次的情况
-				openOnce.Do(func() {
-					go func() {
-						conn, _, dialErr := gws.NewClient(h, &gws.ClientOption{
-							Addr:          wsURL,
-							RequestHeader: wsHeader,
-						})
-						if dialErr != nil {
-							p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
-								event := rt.NewObject()
-								event.Set("type", rt.ToValue("error"))
-								event.Set("error", rt.NewGoError(dialErr))
-								invokeHook(rt, "onerror", event)
+				openRunErr := p.worker.Run(func(rt *goja.Runtime) (_ any, err error) {
+					state := WebSocketState(readyState.Load())
+					switch state {
+					case WebSocketReadyStateOpen:
+						if resolveErr := openResolve(nil); resolveErr != nil {
+							logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
+						}
+						return
+					case WebSocketReadyStateClosing:
+						err = fmt.Errorf("WebSocket is closing")
+						return
+					case WebSocketReadyStateClosed:
+						err = fmt.Errorf("WebSocket is closed")
+						return
+					}
 
-								if rejectErr := openReject(rt.NewGoError(dialErr)); rejectErr != nil {
-									logging.LogErrorf("[plugin:%s] siyuan.client.socket.open reject: %v", p.Name, rejectErr)
-								}
+					addOpenPromise(openResolve, openReject)
+					openOnce.Do(func() {
+						go func() {
+							conn, _, dialErr := gws.NewClient(h, &gws.ClientOption{
+								Addr:          wsURL,
+								RequestHeader: wsHeader,
+							})
+							if dialErr != nil {
+								p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
+									setReadyState(rt, WebSocketReadyStateClosed)
+
+									event := rt.NewObject()
+									event.Set("type", rt.ToValue("error"))
+									event.Set("error", rt.NewGoError(dialErr))
+									invokeHook(rt, "onerror", event)
+
+									rejectOpenPromises(rt, dialErr)
+									return
+								}, nil)
+								doClose()
+								return
+							}
+							if ctx.Err() != nil {
+								// close-before-open
+								conn.NetConn().Close()
+								p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
+									setReadyState(rt, WebSocketReadyStateClosed)
+									rejectOpenPromises(rt, ctx.Err())
+									return
+								}, nil)
+								return
+							}
+							gwsConn.Store(conn)
+							go func() {
+								<-ctx.Done()
+								conn.NetConn().Close()
+							}()
+							// Resolve the open promise before starting ReadLoop so the caller
+							// can await open() and then rely on onopen for additional setup.
+							p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
+								resolveOpenPromises(rt)
 								return
 							}, nil)
-							doClose()
-							return
-						}
-						gwsConn.Store(conn)
-						go func() {
-							<-ctx.Done()
-							conn.NetConn().Close()
-						}()
-						// Resolve the open promise before starting ReadLoop so the caller
-						// can await open() and then rely on onopen for additional setup.
-						p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
-							if resolveErr := openResolve(nil); resolveErr != nil {
-								logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
-							}
-							return
-						}, nil)
 
-						conn.ReadLoop()
-						doClose()
-					}()
+							conn.ReadLoop()
+							doClose()
+						}()
+					})
+					return
+				}, func(rt *goja.Runtime, _ any, err error) {
+					if lo.IsNil(err) {
+					} else {
+						if rejectErr := openReject(rt.NewGoError(err)); rejectErr != nil {
+							logging.LogErrorf("[plugin:%s] siyuan.client.socket.open reject: %v", p.Name, rejectErr)
+						}
+					}
 				})
+				if openRunErr != nil {
+					logging.LogErrorf("[plugin:%s] siyuan.client.socket.open worker run: %v", p.Name, openRunErr)
+				}
 
 				return rt.ToValue(openPromise)
 			})

--- a/kernel/plugin/api_client.go
+++ b/kernel/plugin/api_client.go
@@ -294,25 +294,20 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 			ws_open := rt.ToValue(func(openCall goja.FunctionCall, rt *goja.Runtime) goja.Value {
 				openPromise, openResolve, openReject := rt.NewPromise()
 
-				// FIXME: ws.open() 在同一个 WebSocket 对象上被重复调用时，会因为 opening=false 分支直接 resolve，导致调用方误以为连接已建立（实际上仍处于 CONNECTING）。这会让 await open() 的语义不可靠。建议仅在 readyState=OPEN 时才 resolve；否则应 reject（或返回同一个 pending promise）。
-				openRunErr := p.worker.Run(func(rt *goja.Runtime) (opening any, err error) {
-					opening = false
+				openRunErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
 					openOnce.Do(func() {
-						opening = true
 						go func() {
 							conn, _, dialErr := gws.NewClient(h, &gws.ClientOption{
 								Addr:          wsURL,
 								RequestHeader: wsHeader,
 							})
 							if dialErr != nil {
-								p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
+								p.worker.Run(func(rt *goja.Runtime) (_ any, dialErr2 error) {
 									event := rt.NewObject()
 									event.Set("type", rt.ToValue("error"))
 									event.Set("error", rt.NewGoError(dialErr))
 									invokeHook(rt, "onerror", event)
-									return
-								}, nil)
-								p.worker.Run(func(rt *goja.Runtime) (_ any, dialErr2 error) {
+
 									dialErr2 = dialErr
 									return
 								}, func(rt *goja.Runtime, _ any, dialErr2 error) {
@@ -343,10 +338,8 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 					return
 				}, func(rt *goja.Runtime, result any, err error) {
 					if lo.IsNil(err) {
-						if opening, ok := result.(bool); !ok || !opening {
-							if resolveErr := openResolve(nil); resolveErr != nil {
-								logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
-							}
+						if resolveErr := openResolve(nil); resolveErr != nil {
+							logging.LogErrorf("[plugin:%s] siyuan.client.socket.open resolve: %v", p.Name, resolveErr)
 						}
 					} else {
 						if rejectErr := openReject(rt.NewGoError(err)); rejectErr != nil {
@@ -505,12 +498,14 @@ func injectClient(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err e
 					reason = []byte(closeCall.Argument(1).String())
 				}
 
-				// FIXME: ws.close() 在连接尚未建立（gwsConn=nil）时不会更新 readyState，也不会取消 context，导致 close() 之后对象状态仍可能保持 CONNECTING。建议在未连接时也将 readyState 置为 CLOSED 并执行 doClose()，以便行为与浏览器更一致、避免悬挂状态。
 				closeRunErr := p.worker.Run(func(rt *goja.Runtime) (result any, err error) {
 					if c := gwsConn.Load(); c != nil {
 						setReadyState(rt, WebSocketReadyStateClosing)
 						err = c.WriteClose(code, reason)
+					} else {
+						setReadyState(rt, WebSocketReadyStateClosed)
 					}
+					doClose()
 					return
 				}, func(rt *goja.Runtime, result any, err error) {
 					if lo.IsNil(err) {

--- a/kernel/plugin/sandbox.go
+++ b/kernel/plugin/sandbox.go
@@ -53,6 +53,11 @@ var (
 	httpClient *req.Client = req.C().SetTimeout(time.Minute)
 )
 
+type Promise struct {
+	Resolve func(reason interface{}) error
+	Reject  func(reason interface{}) error
+}
+
 type FunctionResult[T any] struct {
 	Value T
 	Error error

--- a/kernel/util/net.go
+++ b/kernel/util/net.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -36,6 +37,8 @@ import (
 	"github.com/siyuan-note/httpclient"
 	"github.com/siyuan-note/logging"
 )
+
+var auditedAddresses sync.Map // 用于记录已审计的 SSRF 地址，避免重复日志输出
 
 // GetPrivateIPv4s 获取本地所有的私有 IPv4 地址（排除虚拟网卡）
 func GetPrivateIPv4s() (ret []string) {
@@ -130,7 +133,12 @@ func SSRFSafeDialer(timeout time.Duration) *net.Dialer {
 				return err
 			}
 			if ip := net.ParseIP(host); ip != nil && isPrivateIP(ip) {
-				return fmt.Errorf("ip address [%s] is prohibited", host)
+				if _, loaded := auditedAddresses.LoadOrStore(address, struct{}{}); !loaded {
+					logging.LogWarnf("Establishing a connection to the private network [address=%s, network=%s]", address, network)
+				}
+				if SafeMode {
+					return fmt.Errorf("ip address [%s] is prohibited", host)
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
## Description / 描述

<details>
<summary>English</summary>

Improves plugin-side WebSocket client behavior and proxy networking controls.

**Plugin WebSocket client fixes:**

- [kernel/plugin/api_client.go](kernel/plugin/api_client.go) now tracks all pending `siyuan.client.socket.open()` promises, so repeated `open()` calls while the same connection attempt is in progress are resolved or rejected together instead of leaving later calls waiting indefinitely.
- `open()` now rejects immediately when the socket is already closing or closed, and resolves immediately when the socket is already open.
- Dial failures now set `readyState` to `Closed`, trigger `onerror`, reject all pending open promises, and close the client context consistently.
- Closing before the connection finishes now closes the newly created network connection, sets `readyState` to `Closed`, and rejects pending open promises with the context error.
- `close()` now moves the socket to `Closed` and cancels the client context even when no underlying connection has been established yet.

**Shared helpers:**

- [kernel/plugin/sandbox.go](kernel/plugin/sandbox.go) adds a reusable `Promise` struct for storing Goja promise resolve/reject callbacks.

**Proxy timeout support:**

- [kernel/api/network.go](kernel/api/network.go) extends forward proxy parameter parsing with an optional `t` query parameter parsed by [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration).
- `/api/network/proxy`, `/ws/network/proxy`, and `/es/network/proxy` now pass the parsed timeout into the SSRF-safe dialer; WebSocket proxy handshakes use the same timeout.
- The default proxy timeout remains `30s` when `t` is not provided.

**SSRF safe dialer adjustment:**

- [kernel/util/net.go](kernel/util/net.go) now logs private-network connection attempts once per address/network pair.
- Private-network connections are blocked only in `SafeMode`; outside `SafeMode`, the connection is allowed after emitting the audit warning.

</details>

<details>
<summary>中文</summary>

改进插件侧 WebSocket 客户端行为，并增强代理网络超时与审计控制。

**插件 WebSocket 客户端修复：**

- [kernel/plugin/api_client.go](kernel/plugin/api_client.go) 现在会记录所有等待中的 `siyuan.client.socket.open()` Promise，同一次连接过程中的重复 `open()` 调用会一起 resolve 或 reject，避免后续调用一直等待。
- 当 WebSocket 已打开时，`open()` 会立即 resolve；当 WebSocket 正在关闭或已关闭时，`open()` 会立即 reject。
- 连接失败时会将 `readyState` 置为 `Closed`，触发 `onerror`，reject 所有等待中的 open Promise，并统一关闭客户端上下文。
- 如果连接完成前已经关闭客户端，会立即关闭新建的网络连接，将 `readyState` 置为 `Closed`，并使用上下文错误 reject 等待中的 open Promise。
- 即使底层连接尚未建立，`close()` 也会将状态切换为 `Closed` 并取消客户端上下文。

**共享辅助结构：**

- [kernel/plugin/sandbox.go](kernel/plugin/sandbox.go) 新增可复用的 `Promise` 结构，用于保存 Goja Promise 的 resolve/reject 回调。

**代理超时支持：**

- [kernel/api/network.go](kernel/api/network.go) 在转发代理参数解析中新增可选 `t` 查询参数，并通过 [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) 解析。
- `/api/network/proxy`, `/ws/network/proxy` 和 `/es/network/proxy` 现在会把解析后的超时时间传入 SSRF 安全拨号器；WebSocket 代理握手也使用同一超时时间。
- 未提供 `t` 时，代理默认超时时间仍为 `30s`。

**SSRF 安全拨号器调整：**

- [kernel/util/net.go](kernel/util/net.go) 现在会按 address/network 组合对私有网络连接尝试进行一次性日志审计，避免重复输出。
- 私有网络连接仅在 `SafeMode` 下阻断；非 `SafeMode` 下会记录审计警告后允许连接。

</details>

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text edits or new language additions
      修改文案或增加新语言

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突
