### PR TITLE
Improve Trackpad Adjustment Editor Font Size

### DIFF
--- a/app/src/protyle/ui/initUI.ts
+++ b/app/src/protyle/ui/initUI.ts
@@ -2,7 +2,6 @@ import {setEditMode} from "../util/setEditMode";
 import {scrollEvent} from "../scroll/event";
 import {isMobile} from "../../util/functions";
 import {Constants} from "../../constants";
-import {isMac} from "../util/compatibility";
 import {setInlineStyle} from "../../util/assets";
 import {fetchPost} from "../../util/fetch";
 import {lineNumberRender} from "../render/highlightRender";
@@ -97,25 +96,54 @@ export const initUI = (protyle: IProtyle) => {
 
     let wheelTimeout: number;
     const wheelId = genUUID();
-    const isMacOS = isMac();
-    protyle.contentElement.addEventListener("mousewheel", (event: WheelEvent) => {
-        if (!window.siyuan.config.editor.fontSizeScrollZoom || (isMacOS && !event.metaKey) || (!isMacOS && !event.ctrlKey) || event.deltaX !== 0) {
+    const ZOOM_THRESHOLD = 20; // 累加 deltaY 达到阈值时改动一级字号，避免单次缩放触发多次事件导致跳级
+    const WHEEL_IDLE_MS = 200; // 单轮滚动的间隔时间，超过该时间后重置累加值
+    let accumDeltaY = 0;
+    let resetTimer: number;
+    let wheelActive = false; // 记录是否处于同一轮滚动中
+    let modifierOnset = false; // 记录同一轮滚动的首次滚动是否按下 Ctrl
+    protyle.contentElement.addEventListener("wheel", (event: WheelEvent) => {
+        if (!window.siyuan.config.editor.fontSizeScrollZoom || event.shiftKey || event.deltaY === 0) {
+            // 用 event.shiftKey || event.deltaY === 0 检测横向滚动，因为触控板快速划动时 deltaX 可能很大，即使容器并不能发生横向滚动
+            return;
+        }
+        // 用「首轮是否带修饰键 + 空闲窗口」避免惯性或残留累加误触
+        // 浏览器无法区分触控板与鼠标滚轮 https://github.com/w3c/pointerevents/issues/596 ，浏览器将触控板双指捏合与张开映射为带 ctrlKey 的 wheel
+        const modifierPressed = event.ctrlKey;
+        if (!modifierPressed) {
+            accumDeltaY = 0;
+        }
+        clearTimeout(resetTimer);
+        resetTimer = window.setTimeout(() => {
+            wheelActive = false;
+            accumDeltaY = 0;
+        }, WHEEL_IDLE_MS);
+        if (!wheelActive) {
+            wheelActive = true;
+            modifierOnset = modifierPressed;
+        }
+        if (!modifierPressed || !modifierOnset) {
+            // 触控板惯性会在松手后仍产生滚轮事件，避免划动后再按下 Ctrl 会调整字号 https://ld246.com/article/1764296257377
+            // 要在单轮滚动的最后一个滚动事件触发之后等待 WHEEL_IDLE_MS 时间间隔之后再按下 Ctrl 滚动才能调整字号
             return;
         }
         event.stopPropagation();
-        if (event.deltaY < 0) {
-            if (window.siyuan.config.editor.fontSize < 72) {
-                window.siyuan.config.editor.fontSize++;
-            } else {
-                return;
-            }
-        } else if (event.deltaY > 0) {
-            if (window.siyuan.config.editor.fontSize > 9) {
-                window.siyuan.config.editor.fontSize--;
-            } else {
-                return;
-            }
+        if (accumDeltaY !== 0 && Math.sign(event.deltaY) !== Math.sign(accumDeltaY)) {
+            accumDeltaY = 0;
         }
+        accumDeltaY += event.deltaY;
+        let stepped = false;
+        if (accumDeltaY <= -ZOOM_THRESHOLD && window.siyuan.config.editor.fontSize < 72) {
+            window.siyuan.config.editor.fontSize++;
+            stepped = true;
+        } else if (accumDeltaY >= ZOOM_THRESHOLD && window.siyuan.config.editor.fontSize > 9) {
+            window.siyuan.config.editor.fontSize--;
+            stepped = true;
+        }
+        if (!stepped) {
+            return;
+        }
+        accumDeltaY = 0;
         setInlineStyle();
         clearTimeout(wheelTimeout);
         showMessage(`${window.siyuan.languages.fontSize} ${window.siyuan.config.editor.fontSize}px<span class="fn__space"></span>
@@ -139,7 +167,7 @@ export const initUI = (protyle: IProtyle) => {
                 });
             });
         }, Constants.TIMEOUT_LOAD);
-    }, {passive: true});
+    }, {passive: true}); // 调整字号有时候会滚动编辑器，目前使用 passive: true 没有解决方法
     protyle.contentElement.addEventListener("click", (event: MouseEvent & { target: HTMLElement }) => {
         hideElements(["hint", "util"], protyle);
         // wysiwyg 元素下方点击无效果 https://github.com/siyuan-note/siyuan/issues/12009


### PR DESCRIPTION
相比 https://github.com/siyuan-note/siyuan/pull/17295 ，移除了 macOS 上按下 Cmd 键加鼠标滚轮缩放字号的功能，简化了逻辑，也与设置项的文案描述保持一致，即使用 Ctrl 键。

这里的关键是浏览器将触控板双指捏合与张开映射为带 ctrlKey 的 wheel，只判断 Ctrl 键就可以同时支持鼠标滚轮和触控板操作。

---

在交互习惯上，Windows 系统的“Ctrl+滚轮”等于 macOS 系统的“触控板双指捏合与张开”，两者都是在浏览器里用于整页缩放、在 IDE (开启 编辑器-常规-鼠标控制-使用 Ctrl + 鼠标滚轮更改字号) 和 VSCode (开启editor.mouseWheelZoom) 里用于缩放编辑器字号。