### PR TITLE
Callout content disappears when opening a document with folded headings

### DIFF
--- a/kernel/model/file.go
+++ b/kernel/model/file.go
@@ -718,22 +718,43 @@ func GetDocInBox(startID, endID, id string, index int, query string, queryTypes,
 	}
 
 	existKeywords := 0 < len(keywords)
+	// 在 AppendChild 搬移节点前先做完顶层单点查询，避免兄弟链被改写后 IsInFoldedHeading 误判
+	topInFoldedHeading := map[string]bool{}
+	for _, n := range nodes {
+		if treenode.IsInFoldedHeading(n, nil) {
+			topInFoldedHeading[n.ID] = true
+		}
+	}
 	for _, n := range nodes {
 		var unlinks []*ast.Node
+
+		// 顶层块整体位于折叠标题下方时用单点查询判断（不依赖子块 heading-fold）：
+		// 非当前 ID 的悬浮或文档加载场景整块剔除；当前 ID 的悬浮保留
+		// The referenced block under the folded heading cannot be hovered to view https://github.com/siyuan-note/siyuan/issues/9582
+		nInFoldedHeading := topInFoldedHeading[n.ID]
+		if nInFoldedHeading && ((0 != mode && id != n.ID) || isDoc) {
+			continue
+		}
+
+		// 一次正向扫描收集 n 子树内被折叠标题盖住的后代，避免逐块 O(N²) 回溯 IsInFoldedHeading
+		foldHidden := map[*ast.Node]bool{}
+		for _, h := range treenode.CollectFoldHiddenNodes(n) {
+			foldHidden[h] = true
+		}
+
 		ast.Walk(n, func(n *ast.Node, entering bool) ast.WalkStatus {
 			if !entering {
 				return ast.WalkContinue
 			}
 
 			if n.IsBlock() {
-				if treenode.IsInFoldedHeading(n, nil) {
-					// 折叠标题下被引用的块无法悬浮查看
-					// The referenced block under the folded heading cannot be hovered to view https://github.com/siyuan-note/siyuan/issues/9582
-					if (0 != mode && id != n.ID) || isDoc {
-						unlinks = append(unlinks, n)
-						return ast.WalkContinue
-					}
-				} else if "1" == n.IALAttr("heading-fold") {
+				if foldHidden[n] {
+					// 被嵌套折叠标题盖住的整棵子树剔除，无需继续递归其内部
+					unlinks = append(unlinks, n)
+					return ast.WalkSkipChildren
+				}
+
+				if !nInFoldedHeading && "1" == n.IALAttr("heading-fold") {
 					// 标题已展开但子块仍残留 heading-fold 时清理，避免列表等嵌套块渲染为空
 					n.RemoveIALAttr("heading-fold")
 					n.RemoveIALAttr("fold")
@@ -816,14 +837,47 @@ func GetDocInBox(startID, endID, id string, index int, query string, queryTypes,
 	return
 }
 
+func foldedHiddenSiblings(anchor *ast.Node) (hidden map[string]bool) {
+	hidden = map[string]bool{}
+	if nil == anchor || nil == anchor.Parent {
+		return
+	}
+
+	var stack treenode.FoldHeadingStack
+	for n := anchor.Parent.FirstChild; nil != n; n = n.Next {
+		stack.Enter(n)
+		if stack.Hidden() {
+			hidden[n.ID] = true
+		}
+	}
+	return
+}
+
+// foldHeadingStackBefore 通过扫描 node 之前的同级兄弟节点，构造到达 node 之前（不含 node）的折叠层级栈。
+func foldHeadingStackBefore(node *ast.Node) (stack treenode.FoldHeadingStack) {
+	if nil == node || nil == node.Parent {
+		return
+	}
+
+	for n := node.Parent.FirstChild; nil != n && n != node; n = n.Next {
+		stack.Enter(n)
+	}
+	return
+}
+
 func loadNodesByStartEnd(tree *parse.Tree, startID, endID string) (nodes []*ast.Node, eof bool) {
 	node := treenode.GetNodeInTree(tree, startID)
 	if nil == node {
 		return
 	}
+
+	// 用折叠层级栈正向扫描跳过被折叠标题盖住的块
+	stack := foldHeadingStackBefore(node)
+	stack.Enter(node)
 	nodes = append(nodes, node)
 	for n := node.Next; nil != n; n = n.Next {
-		if treenode.IsInFoldedHeading(n, nil) {
+		stack.Enter(n)
+		if stack.Hidden() {
 			continue
 		}
 		nodes = append(nodes, n)
@@ -862,13 +916,20 @@ func loadNodesByMode(node *ast.Node, inputIndex, mode, size int, isDoc, isHeadin
 		}
 	}
 
+	// 一次正向扫描顶层同级子块，标记被折叠标题盖住的隐藏块，向上 / 双向遍历据此判断，避免逐块 O(N²) 回溯
+	hidden := foldedHiddenSiblings(node)
+
 	count := 0
 	switch mode {
 	case 0: // 仅加载当前 ID
 		nodes = append(nodes, node)
 		if isDoc {
+			// 用折叠层级栈正向扫描顶层同级子块（含 node 自身折叠），避免嵌套折叠漏网
+			stack := foldHeadingStackBefore(node)
+			stack.Enter(node)
 			for n := node.Next; nil != n; n = n.Next {
-				if treenode.IsInFoldedHeading(n, nil) {
+				stack.Enter(n)
+				if stack.Hidden() {
 					continue
 				}
 				nodes = append(nodes, n)
@@ -882,17 +943,18 @@ func loadNodesByMode(node *ast.Node, inputIndex, mode, size int, isDoc, isHeadin
 				}
 			}
 		} else if isHeading {
+			// 聚焦标题：先把当前标题入栈，自身 fold=1 时不摊开下方内容（与旧 IsInFoldedHeading(n, node) 一致）；
+			// 未折叠时仍用栈省略更深嵌套折叠 https://github.com/siyuan-note/siyuan/issues/4997
 			level := node.HeadingLevel
+			var stack treenode.FoldHeadingStack
+			stack.Enter(node)
 			for n := node.Next; nil != n; n = n.Next {
-				if treenode.IsInFoldedHeading(n, node) {
-					// 大纲点击折叠标题跳转聚焦 https://github.com/siyuan-note/siyuan/issues/4920
-					// 多级标题折叠后上级块引浮窗中未折叠 https://github.com/siyuan-note/siyuan/issues/4997
-					continue
+				if ast.NodeHeading == n.Type && n.HeadingLevel <= level {
+					break
 				}
-				if ast.NodeHeading == n.Type {
-					if n.HeadingLevel <= level {
-						break
-					}
+				stack.Enter(n)
+				if stack.Hidden() {
+					continue
 				}
 				nodes = append(nodes, n)
 				count++
@@ -903,7 +965,7 @@ func loadNodesByMode(node *ast.Node, inputIndex, mode, size int, isDoc, isHeadin
 		}
 	case 4: // Ctrl+End 跳转到末尾后向上加载
 		for n := node; nil != n; n = n.Previous {
-			if treenode.IsInFoldedHeading(n, nil) {
+			if hidden[n.ID] {
 				continue
 			}
 			nodes = append([]*ast.Node{n}, nodes...)
@@ -919,7 +981,7 @@ func loadNodesByMode(node *ast.Node, inputIndex, mode, size int, isDoc, isHeadin
 		eof = true
 	case 1: // 向上加载
 		for n := node.Previous; /* 从上一个节点开始加载 */ nil != n; n = n.Previous {
-			if treenode.IsInFoldedHeading(n, nil) {
+			if hidden[n.ID] {
 				continue
 			}
 			nodes = append([]*ast.Node{n}, nodes...)
@@ -934,8 +996,13 @@ func loadNodesByMode(node *ast.Node, inputIndex, mode, size int, isDoc, isHeadin
 		}
 		eof = nil == node.Previous
 	case 2: // 向下加载
+		// 先恢复到 node 处的折叠栈（含 node 自身），与旧 IsInFoldedHeading(n, node) 一致：
+		// 若 node 为折叠标题，则跳过其下方被盖住的块
+		stack := foldHeadingStackBefore(node)
+		stack.Enter(node)
 		for n := node.Next; /* 从下一个节点开始加载 */ nil != n; n = n.Next {
-			if treenode.IsInFoldedHeading(n, node) {
+			stack.Enter(n)
+			if stack.Hidden() {
 				continue
 			}
 			nodes = append(nodes, n)
@@ -950,7 +1017,7 @@ func loadNodesByMode(node *ast.Node, inputIndex, mode, size int, isDoc, isHeadin
 		}
 	case 3: // 上下都加载
 		for n := node; nil != n; n = n.Previous {
-			if treenode.IsInFoldedHeading(n, nil) {
+			if hidden[n.ID] {
 				continue
 			}
 			nodes = append([]*ast.Node{n}, nodes...)
@@ -976,7 +1043,7 @@ func loadNodesByMode(node *ast.Node, inputIndex, mode, size int, isDoc, isHeadin
 		}
 		count = 0
 		for n := node.Next; nil != n; n = n.Next {
-			if treenode.IsInFoldedHeading(n, nil) {
+			if hidden[n.ID] {
 				continue
 			}
 			nodes = append(nodes, n)

--- a/kernel/treenode/fold_heading_stack_test.go
+++ b/kernel/treenode/fold_heading_stack_test.go
@@ -1,0 +1,141 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package treenode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/88250/lute"
+	"github.com/88250/lute/ast"
+	"github.com/88250/lute/parse"
+)
+
+func TestFoldHeadingStackHidesChildren(t *testing.T) {
+	root := &ast.Node{Type: ast.NodeDocument}
+	h4 := &ast.Node{Type: ast.NodeHeading, HeadingLevel: 4, ID: "h4"}
+	h4.SetIALAttr("fold", "1")
+	child := &ast.Node{Type: ast.NodeParagraph, ID: "p1"}
+	h4Next := &ast.Node{Type: ast.NodeHeading, HeadingLevel: 4, ID: "h4b"}
+	root.AppendChild(h4)
+	root.AppendChild(child)
+	root.AppendChild(h4Next)
+
+	var stack FoldHeadingStack
+	stack.Enter(h4)
+	if stack.Hidden() {
+		t.Fatal("folded heading itself should be visible")
+	}
+	stack.Enter(child)
+	if !stack.Hidden() {
+		t.Fatal("child under folded heading should be hidden")
+	}
+	stack.Enter(h4Next)
+	if stack.Hidden() {
+		t.Fatal("same-level heading after fold should be visible")
+	}
+}
+
+func TestCollectFoldHiddenNodesKeepsCalloutChildren(t *testing.T) {
+	callout := &ast.Node{Type: ast.NodeCallout, ID: "c1"}
+	p := &ast.Node{Type: ast.NodeParagraph, ID: "p1"}
+	callout.AppendChild(p)
+
+	if hidden := CollectFoldHiddenNodes(callout); 0 != len(hidden) {
+		t.Fatalf("callout without nested folded heading should keep children, got %d", len(hidden))
+	}
+}
+
+func TestDocLoadDoesNotStripCalloutChildren(t *testing.T) {
+	// 复现：前一段折叠标题下残留 fold=1 的兄弟块，getDoc AppendChild 改写兄弟链后，
+	// 旧逻辑对 callout 子块逐块 IsInFoldedHeading 会误卸子块；新逻辑用栈 + CollectFoldHiddenNodes 应保留。
+	root := &ast.Node{Type: ast.NodeDocument, ID: "doc"}
+	h4Folded := &ast.Node{Type: ast.NodeHeading, HeadingLevel: 4, ID: "h4-folded"}
+	h4Folded.SetIALAttr("id", "h4-folded")
+	h4Folded.SetIALAttr("fold", "1")
+	h5Folded := &ast.Node{Type: ast.NodeHeading, HeadingLevel: 5, ID: "h5-folded"}
+	h5Folded.SetIALAttr("id", "h5-folded")
+	h5Folded.SetIALAttr("fold", "1")
+	h5Folded.SetIALAttr("heading-fold", "1")
+	h4Visible := &ast.Node{Type: ast.NodeHeading, HeadingLevel: 4, ID: "h4-visible"}
+	h4Visible.SetIALAttr("id", "h4-visible")
+	h5Visible := &ast.Node{Type: ast.NodeHeading, HeadingLevel: 5, ID: "h5-visible"}
+	h5Visible.SetIALAttr("id", "h5-visible")
+	callout := &ast.Node{Type: ast.NodeCallout, ID: "callout", CalloutType: "NOTE", CalloutTitle: "Note", CalloutIcon: "✏️"}
+	callout.SetIALAttr("id", "callout")
+	para := &ast.Node{Type: ast.NodeParagraph, ID: "callout-p"}
+	para.SetIALAttr("id", "callout-p")
+	para.AppendChild(&ast.Node{Type: ast.NodeText, Tokens: []byte("keep-me")})
+	callout.AppendChild(para)
+
+	root.AppendChild(h4Folded)
+	root.AppendChild(h5Folded)
+	root.AppendChild(h4Visible)
+	root.AppendChild(h5Visible)
+	root.AppendChild(callout)
+
+	tree := &parse.Tree{ID: "doc", Root: root}
+
+	// 模拟 loadNodes mode=0 isDoc：用折叠栈收集可见顶层块
+	var nodes []*ast.Node
+	node := tree.Root.FirstChild
+	nodes = append(nodes, node)
+	var stack FoldHeadingStack
+	stack.Enter(node)
+	for n := node.Next; nil != n; n = n.Next {
+		stack.Enter(n)
+		if stack.Hidden() {
+			continue
+		}
+		nodes = append(nodes, n)
+	}
+
+	subTree := &parse.Tree{ID: tree.ID, Root: &ast.Node{Type: ast.NodeDocument}}
+	for _, n := range nodes {
+		foldHidden := map[*ast.Node]bool{}
+		for _, h := range CollectFoldHiddenNodes(n) {
+			foldHidden[h] = true
+		}
+		var unlinks []*ast.Node
+		ast.Walk(n, func(cn *ast.Node, entering bool) ast.WalkStatus {
+			if !entering || !cn.IsBlock() {
+				return ast.WalkContinue
+			}
+			if foldHidden[cn] {
+				unlinks = append(unlinks, cn)
+				return ast.WalkSkipChildren
+			}
+			return ast.WalkContinue
+		})
+		for _, unlink := range unlinks {
+			unlink.Unlink()
+		}
+		subTree.Root.AppendChild(n)
+	}
+
+	engine := lute.New()
+	engine.SetProtyleWYSIWYG(true)
+	engine.SetKramdownIAL(true)
+	engine.SetCallout(true)
+	dom := engine.Tree2BlockDOM(subTree, engine.RenderOptions, engine.ParseOptions)
+	if !strings.Contains(dom, "keep-me") {
+		t.Fatal("callout child text missing after stack-based doc load")
+	}
+	if !strings.Contains(dom, "callout-p") {
+		t.Fatal("callout child block id missing after stack-based doc load")
+	}
+}

--- a/kernel/treenode/heading.go
+++ b/kernel/treenode/heading.go
@@ -56,6 +56,76 @@ func MoveFoldHeading(updateNode, oldNode *ast.Node) {
 	}
 }
 
+// FoldHeadingStack 用于正向扫描文档同级子块序列时维护「当前生效的折叠标题」层级栈。
+// 语义：某个块被隐藏 = 其上方存在更高级（层级数更小）且 fold=1 的标题盖住它；
+// 折叠标题自身仍然渲染（保留 fold=1），只是其后更深层级的块被省略。
+// 批量路径（加载等）用它做一次 O(N) 扫描，避免逐块回溯 IsInFoldedHeading 造成的 O(N²)。
+type FoldHeadingStack struct {
+	levels []int     // 当前生效的折叠标题层级栈，栈顶层级最深（数值最大）
+	last   *ast.Node // 最近一次 Enter 的节点，供 Hidden 判断折叠标题自身是否可见
+}
+
+// Enter 在正向遍历到节点 n 时调用，维护折叠标题层级栈。
+// 必须按文档顺序对同一层级的兄弟节点序列依次调用（通常是文档根或容器块的直接子节点）。
+func (s *FoldHeadingStack) Enter(n *ast.Node) {
+	s.last = n
+	if ast.NodeHeading != n.Type {
+		return
+	}
+
+	// 遇到同级或更高级标题：这些更深的折叠范围到此结束，先出栈
+	for 0 < len(s.levels) && s.levels[len(s.levels)-1] >= n.HeadingLevel {
+		s.levels = s.levels[:len(s.levels)-1]
+	}
+
+	// 当前标题自身折叠时入栈，其后更深层级的兄弟块都被它盖住
+	if "1" == n.IALAttr("fold") {
+		s.levels = append(s.levels, n.HeadingLevel)
+	}
+}
+
+// Hidden 返回最近一次 Enter 的块是否应被隐藏（被祖先折叠标题盖住）。
+// 折叠标题节点自身仍可见（除非它又被更浅的折叠标题盖住），其余落在折叠范围内的块返回 true。
+func (s *FoldHeadingStack) Hidden() bool {
+	depth := len(s.levels)
+	if 0 == depth {
+		return false
+	}
+
+	if n := s.last; nil != n && ast.NodeHeading == n.Type && "1" == n.IALAttr("fold") && s.levels[depth-1] == n.HeadingLevel {
+		// 折叠标题自身刚入栈：仅当它还被更浅的折叠标题盖住时才隐藏
+		return 1 < depth
+	}
+	return true
+}
+
+// CollectFoldHiddenNodes 按容器层级用折叠层级栈标记被折叠标题盖住的块，返回应被剔除的节点列表。
+// 被隐藏的整棵子树只收集其顶端一次（无需再递归其内部）；折叠标题节点自身不会被收集（仍可见）。
+func CollectFoldHiddenNodes(parent *ast.Node) (unlinks []*ast.Node) {
+	if nil == parent {
+		return
+	}
+
+	collectFoldHiddenNodes(parent, &unlinks)
+	return
+}
+
+func collectFoldHiddenNodes(parent *ast.Node, unlinks *[]*ast.Node) {
+	var stack FoldHeadingStack
+	for n := parent.FirstChild; nil != n; n = n.Next {
+		stack.Enter(n)
+		if stack.Hidden() {
+			*unlinks = append(*unlinks, n)
+			continue
+		}
+
+		if n.IsContainerBlock() {
+			collectFoldHiddenNodes(n, unlinks)
+		}
+	}
+}
+
+// IsInFoldedHeading 单点查询块是否位于折叠标题下方。禁止在批量热路径对每个块反复调用，改用 FoldHeadingStack。
 func IsInFoldedHeading(node, currentHeading *ast.Node) bool {
 	if nil == node {
 		return false


### PR DESCRIPTION
Fix getDoc stripping callout children under folded headings

## Description / 描述

<!--
Please provide a summary of the change and the issue being fixed. Include relevant motivation and context.
请说明更改的摘要以及修复了哪个问题，包含相关的动机和上下文。
-->

fix https://ld246.com/article/1784084259270

- `getDoc` 加载文档时，对每个块反复调用 `IsInFoldedHeading`（沿 `Previous` 回溯）。在 `AppendChild` 把可见块挪到子树后，兄弟链被改写，后续块（尤其是 callout 的子块）会被误判为仍在折叠标题下并被 `Unlink`，表现为 callout 外壳在、子块不渲染。
- 改为用正向 `FoldHeadingStack` + `CollectFoldHiddenNodes` 做 O(N) 扫描，避免热路径逐块回溯。
- 顶层 [#9582](https://github.com/siyuan-note/siyuan/issues/9582) 场景仍保留单点 `IsInFoldedHeading`，但在任何 `AppendChild` 之前算完，避免兄弟链污染。

## Type of change / 变更类型

<!--
A PR should have a single purpose. Please do not include multiple changes such as bug fixes, refactoring, or new features in one PR; otherwise, the PR will be rejected.
一个 PR 应该只包含一个目的，请勿将缺陷修复、代码重构或新功能等多个变更包含在同一个 PR 中，否则 PR 将被拒绝。
-->

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

<!--
If you want to contribute a feature, or refactoring, or bug fix, please submit an issue first. After sufficient discussion in the community, we will decide whether to make the change. Do not submit contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性、重构或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交贡献代码，否则可能会被拒绝。

If your contribution involves text updates or adding new languages, please submit directly, and we will evaluate.
如果你的贡献涉及文案修改或增加新语言，请直接提交，我们会进行评估。
-->

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突