### PR TITLE
✨ Add Atlas Cloud AI provider env support

### DIFF
--- a/kernel/conf/ai.go
+++ b/kernel/conf/ai.go
@@ -28,6 +28,11 @@ import (
 	"github.com/siyuan-note/siyuan/kernel/util"
 )
 
+const (
+	atlasCloudDefaultBaseURL = "https://api.atlascloud.ai/v1"
+	atlasCloudDefaultModel   = "deepseek-ai/deepseek-v4-pro"
+)
+
 type AI struct {
 	MCP             *MCP             `json:"mcp"`
 	Embedding       *Embedding       `json:"embedding"`
@@ -190,15 +195,38 @@ func NewAI() *AI {
 	apiKey := os.Getenv("SIYUAN_OPENAI_API_KEY")
 	apiModel := os.Getenv("SIYUAN_OPENAI_API_MODEL")
 	apiBaseURL := os.Getenv("SIYUAN_OPENAI_API_BASE_URL")
+	apiTimeout := os.Getenv("SIYUAN_OPENAI_API_TIMEOUT")
+	apiMaxTokens := os.Getenv("SIYUAN_OPENAI_API_MAX_TOKENS")
+	apiTemperature := os.Getenv("SIYUAN_OPENAI_API_TEMPERATURE")
+	apiMaxContexts := os.Getenv("SIYUAN_OPENAI_API_MAX_CONTEXTS")
+	providerDisplayName := ""
 
-	if apiModel != "" && apiBaseURL != "" {
+	if !hasOpenAIProviderEnv(apiModel, apiBaseURL) && hasAtlasCloudProviderEnv() {
+		apiKey = firstEnvValue("SIYUAN_ATLASCLOUD_API_KEY", "SIYUAN_ATLAS_CLOUD_API_KEY")
+		apiModel = firstEnvValue("SIYUAN_ATLASCLOUD_API_MODEL", "SIYUAN_ATLAS_CLOUD_API_MODEL")
+		if "" == apiModel {
+			apiModel = atlasCloudDefaultModel
+		}
+		apiBaseURL = firstEnvValue("SIYUAN_ATLASCLOUD_API_BASE_URL", "SIYUAN_ATLAS_CLOUD_API_BASE_URL")
+		if "" == apiBaseURL {
+			apiBaseURL = atlasCloudDefaultBaseURL
+		}
+		apiTimeout = firstEnvValue("SIYUAN_ATLASCLOUD_API_TIMEOUT", "SIYUAN_ATLAS_CLOUD_API_TIMEOUT")
+		apiMaxTokens = firstEnvValue("SIYUAN_ATLASCLOUD_API_MAX_TOKENS", "SIYUAN_ATLAS_CLOUD_API_MAX_TOKENS")
+		apiTemperature = firstEnvValue("SIYUAN_ATLASCLOUD_API_TEMPERATURE", "SIYUAN_ATLAS_CLOUD_API_TEMPERATURE")
+		apiMaxContexts = firstEnvValue("SIYUAN_ATLASCLOUD_API_MAX_CONTEXTS", "SIYUAN_ATLAS_CLOUD_API_MAX_CONTEXTS")
+		providerDisplayName = "Atlas Cloud"
+	}
+
+	if strings.TrimSpace(apiModel) != "" && strings.TrimSpace(apiBaseURL) != "" {
 		provider := &Provider{
+			DisplayName:    providerDisplayName,
 			BaseURL:        apiBaseURL,
 			RequestTimeout: 120,
 			Enabled:        true,
 			APIKey:         apiKey,
 		}
-		if timeout := os.Getenv("SIYUAN_OPENAI_API_TIMEOUT"); "" != timeout {
+		if timeout := apiTimeout; "" != timeout {
 			if v, err := strconv.Atoi(timeout); err == nil {
 				provider.RequestTimeout = v
 			}
@@ -208,17 +236,17 @@ func NewAI() *AI {
 			Name:    apiModel,
 			Enabled: true,
 		}
-		if maxTokens := os.Getenv("SIYUAN_OPENAI_API_MAX_TOKENS"); "" != maxTokens {
+		if maxTokens := apiMaxTokens; "" != maxTokens {
 			if v, err := strconv.Atoi(maxTokens); err == nil {
 				ai.Editing.MaxCompletionTokens = v
 			}
 		}
-		if temperature := os.Getenv("SIYUAN_OPENAI_API_TEMPERATURE"); "" != temperature {
+		if temperature := apiTemperature; "" != temperature {
 			if v, err := strconv.ParseFloat(temperature, 64); err == nil {
 				ai.Editing.Temperature = v
 			}
 		}
-		if maxContexts := os.Getenv("SIYUAN_OPENAI_API_MAX_CONTEXTS"); "" != maxContexts {
+		if maxContexts := apiMaxContexts; "" != maxContexts {
 			if v, err := strconv.Atoi(maxContexts); err == nil {
 				ai.Editing.MaxHistoryMessages = v
 			}
@@ -277,6 +305,31 @@ func NewAI() *AI {
 	}
 
 	return ai
+}
+
+func hasOpenAIProviderEnv(apiModel, apiBaseURL string) bool {
+	return strings.TrimSpace(apiModel) != "" && strings.TrimSpace(apiBaseURL) != ""
+}
+
+func hasAtlasCloudProviderEnv() bool {
+	return firstEnvValue(
+		"SIYUAN_ATLASCLOUD_API_KEY",
+		"SIYUAN_ATLAS_CLOUD_API_KEY",
+		"SIYUAN_ATLASCLOUD_API_MODEL",
+		"SIYUAN_ATLAS_CLOUD_API_MODEL",
+		"SIYUAN_ATLASCLOUD_API_BASE_URL",
+		"SIYUAN_ATLAS_CLOUD_API_BASE_URL",
+	) != ""
+}
+
+func firstEnvValue(names ...string) string {
+	for _, name := range names {
+		value := strings.TrimSpace(os.Getenv(name))
+		if "" != value {
+			return value
+		}
+	}
+	return ""
 }
 
 func (ai *AI) HasAnyProvider() bool {

--- a/kernel/conf/ai_provider_test.go
+++ b/kernel/conf/ai_provider_test.go
@@ -28,6 +28,68 @@ func TestNewAIAddsKeylessProviderFromEnvironment(t *testing.T) {
 	}
 }
 
+func TestNewAIAddsAtlasCloudProviderFromEnvironment(t *testing.T) {
+	t.Setenv("SIYUAN_ATLASCLOUD_API_KEY", "atlas-key")
+
+	ai := NewAI()
+	if len(ai.Providers) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(ai.Providers))
+	}
+	provider := ai.Providers[0]
+	if provider.DisplayName != "Atlas Cloud" || provider.APIKey != "atlas-key" || provider.BaseURL != atlasCloudDefaultBaseURL || !provider.Enabled {
+		t.Fatalf("unexpected Atlas Cloud provider: %#v", provider)
+	}
+	if len(provider.Models) != 1 || provider.Models[0].Name != atlasCloudDefaultModel || !provider.Models[0].Enabled {
+		t.Fatalf("unexpected Atlas Cloud provider models: %#v", provider.Models)
+	}
+}
+
+func TestNewAIReadsAtlasCloudAliasEnvironment(t *testing.T) {
+	t.Setenv("SIYUAN_ATLAS_CLOUD_API_KEY", "alias-key")
+	t.Setenv("SIYUAN_ATLAS_CLOUD_API_MODEL", "deepseek-ai/deepseek-v4-pro")
+	t.Setenv("SIYUAN_ATLAS_CLOUD_API_BASE_URL", "https://atlas.example/v1")
+	t.Setenv("SIYUAN_ATLAS_CLOUD_API_TIMEOUT", "240")
+	t.Setenv("SIYUAN_ATLAS_CLOUD_API_MAX_TOKENS", "4096")
+	t.Setenv("SIYUAN_ATLAS_CLOUD_API_TEMPERATURE", "0.6")
+	t.Setenv("SIYUAN_ATLAS_CLOUD_API_MAX_CONTEXTS", "12")
+
+	ai := NewAI()
+	if len(ai.Providers) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(ai.Providers))
+	}
+	provider := ai.Providers[0]
+	if provider.APIKey != "alias-key" || provider.BaseURL != "https://atlas.example/v1" || provider.RequestTimeout != 240 {
+		t.Fatalf("unexpected Atlas Cloud alias provider: %#v", provider)
+	}
+	if provider.Models[0].Name != "deepseek-ai/deepseek-v4-pro" {
+		t.Fatalf("unexpected Atlas Cloud alias model: %#v", provider.Models[0])
+	}
+	if ai.Editing.MaxCompletionTokens != 4096 || ai.Editing.Temperature != 0.6 || ai.Editing.MaxHistoryMessages != 12 {
+		t.Fatalf("unexpected Atlas Cloud editing defaults: %#v", ai.Editing)
+	}
+}
+
+func TestNewAIPrefersOpenAIEnvironmentOverAtlasCloud(t *testing.T) {
+	t.Setenv("SIYUAN_OPENAI_API_KEY", "")
+	t.Setenv("SIYUAN_OPENAI_API_MODEL", "openai-model")
+	t.Setenv("SIYUAN_OPENAI_API_BASE_URL", "https://openai.example/v1")
+	t.Setenv("SIYUAN_ATLASCLOUD_API_KEY", "atlas-key")
+	t.Setenv("SIYUAN_ATLASCLOUD_API_MODEL", "atlas-model")
+	t.Setenv("SIYUAN_ATLASCLOUD_API_BASE_URL", "https://atlas.example/v1")
+
+	ai := NewAI()
+	if len(ai.Providers) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(ai.Providers))
+	}
+	provider := ai.Providers[0]
+	if provider.DisplayName != "" || provider.APIKey != "" || provider.BaseURL != "https://openai.example/v1" {
+		t.Fatalf("unexpected OpenAI provider precedence: %#v", provider)
+	}
+	if len(provider.Models) != 1 || provider.Models[0].Name != "openai-model" {
+		t.Fatalf("unexpected OpenAI model precedence: %#v", provider.Models)
+	}
+}
+
 func TestAIKeylessProviderIsAvailable(t *testing.T) {
 	model := &Model{ID: "model-id", DisplayName: "Local Model", Name: "local-model", Enabled: true}
 	provider := &Provider{Enabled: true, BaseURL: "http://127.0.0.1:8080/v1", Models: []*Model{model}}


### PR DESCRIPTION
## Summary

- add `SIYUAN_ATLASCLOUD_*` and `SIYUAN_ATLAS_CLOUD_*` environment aliases for SiYuan's existing OpenAI-compatible AI provider bootstrap
- default Atlas Cloud bootstrap to `https://api.atlascloud.ai/v1` and `deepseek-ai/deepseek-v4-pro` when an Atlas key/base/model alias is provided
- keep explicit `SIYUAN_OPENAI_API_MODEL` + `SIYUAN_OPENAI_API_BASE_URL` configuration taking precedence over Atlas aliases
- cover default Atlas config, alias config, and OpenAI precedence in `kernel/conf` tests

## Validation

- `git diff --check`
- checked changed files only; no README/docs/logo changes
- local Go toolchain is unavailable on this machine (`go` and `gofmt` are not in PATH), so I could not run `gofmt` or `go test ./kernel/conf`
- Atlas Cloud live model catalog returned HTTP 403 from this environment; the base URL and model IDs were checked against the local Atlas Cloud API reference (`api.md`)
