### PR TITLE
Harden workspace enumeration and plugin storage CRUD

### DIFF
--- a/kernel/api/file.go
+++ b/kernel/api/file.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -606,7 +607,6 @@ func readDir(c *gin.Context) {
 
 	arg, ok := util.JsonArg(c, ret)
 	if !ok {
-		c.JSON(http.StatusOK, ret)
 		return
 	}
 
@@ -617,61 +617,108 @@ func readDir(c *gin.Context) {
 		return
 	}
 
-	dirAbsPath, err := util.GetAbsPathInWorkspace(dirPath)
-	if err != nil {
+	guard, err := newWorkspacePathGuard(util.WorkspaceDir, dirPath)
+	if errors.Is(err, errWorkspacePathOutside) {
 		ret.Code = http.StatusForbidden
-		ret.Msg = err.Error()
+		ret.Msg = errWorkspacePathOutside.Error()
 		return
 	}
-	// 加密笔记本的任何目录都不允许通过原始文件 API 枚举（不只 .sy）：
-	// 目录结构、文档 ID、随机化资产名和时间戳可能泄漏信息；合法读取走专用 API（已加密感知）
-	if rejectEncryptedBoxPath(dirAbsPath) {
-		ret.Code = -3
-		ret.Msg = model.Conf.Language(321)
-		return
-	}
-	info, err := os.Stat(dirAbsPath)
 	if os.IsNotExist(err) {
 		ret.Code = http.StatusNotFound
 		ret.Msg = "path does not exist"
 		return
 	}
 	if err != nil {
-		logging.LogErrorf("stat [%s] failed: %s", dirAbsPath, err)
+		logging.LogErrorf("validate directory [%s] failed: %s", dirPath, err)
 		ret.Code = http.StatusInternalServerError
 		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
 		return
 	}
-	if !info.IsDir() {
-		logging.LogErrorf("file [%s] is not a directory", dirAbsPath)
+	// 加密笔记本的任何目录都不允许通过原始文件 API 枚举（不只 .sy）：
+	// 目录结构、文档 ID、随机化资产名和时间戳可能泄漏信息；合法读取走专用 API（已加密感知）
+	if rejectEncryptedBoxPath(guard.requestedPath) {
+		ret.Code = -3
+		ret.Msg = model.Conf.Language(321)
+		return
+	}
+	if guard.unsupportedReparse {
+		logging.LogErrorf("read directory [%s] failed: %s", guard.requestedPath, errWorkspaceUnsupportedReparse)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+	if !guard.requestedInfo.IsDir() {
+		logging.LogErrorf("file [%s] is not a directory", guard.requestedPath)
 		ret.Code = http.StatusConflict
 		ret.Msg = "path is not a directory"
 		return
 	}
 
-	entries, err := os.ReadDir(dirAbsPath)
+	unlock := guard.lock()
+	defer unlock()
+	if err = guard.revalidate(); err != nil {
+		logging.LogErrorf("revalidate directory [%s] failed: %s", guard.requestedPath, err)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+	root, err := guard.openRoot()
 	if err != nil {
-		logging.LogErrorf("read dir [%s] failed: %s", dirAbsPath, err)
+		logging.LogErrorf("open workspace root [%s] failed: %s", guard.workspacePath, err)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+	defer root.Close()
+	if err = guard.revalidate(); err != nil {
+		logging.LogErrorf("revalidate directory [%s] failed: %s", guard.requestedPath, err)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+	directory, err := openReadDirDirectory(root, guard.relativePath)
+	if err != nil {
+		logging.LogErrorf("open rooted directory [%s] failed: %s", guard.requestedPath, err)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+	defer directory.Close()
+	directoryInfo, err := directory.Stat()
+	if err != nil || guard.verifyRequestedInfo(directoryInfo) != nil || !directoryInfo.IsDir() {
+		logging.LogErrorf("verify rooted directory [%s] failed: %v", guard.requestedPath, err)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+	if err = guard.revalidate(); err != nil {
+		logging.LogErrorf("revalidate directory [%s] failed: %s", guard.requestedPath, err)
 		ret.Code = http.StatusInternalServerError
 		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
 		return
 	}
 
-	files := []map[string]any{}
-	for _, entry := range entries {
-		path := filepath.Join(dirAbsPath, entry.Name())
-		info, err = os.Stat(path)
-		if err != nil {
-			logging.LogErrorf("stat [%s] failed: %s", path, err)
-			ret.Code = http.StatusInternalServerError
-			ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
-			return
-		}
+	snapshot, err := readDirSnapshot(root, directory, guard.relativePath, guard.resolvedWorkspace)
+	if err != nil {
+		logging.LogErrorf("read directory snapshot [%s] failed: %s", guard.requestedPath, err)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+	if err = guard.revalidate(); err != nil {
+		logging.LogErrorf("revalidate directory [%s] failed: %s", guard.requestedPath, err)
+		ret.Code = http.StatusInternalServerError
+		ret.Msg = http.StatusText(http.StatusInternalServerError) + errMsgSeeKernelLog
+		return
+	}
+
+	files := make([]map[string]any, 0, len(snapshot))
+	for _, entry := range snapshot {
 		files = append(files, map[string]any{
-			"name":      entry.Name(),
-			"isDir":     info.IsDir(),
-			"isSymlink": util.IsSymlink(entry),
-			"updated":   info.ModTime().Unix(),
+			"name":      entry.name,
+			"isDir":     entry.isDir,
+			"isSymlink": entry.isSymlink,
+			"updated":   entry.updated,
 		})
 	}
 

--- a/kernel/api/file_read_dir_link_nonwindows.go
+++ b/kernel/api/file_read_dir_link_nonwindows.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import "os"
+
+func classifyWorkspaceLink(_ string, info os.FileInfo) (workspaceLinkKind, error) {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return workspaceSymbolicLink, nil
+	}
+	return workspaceNotLink, nil
+}

--- a/kernel/api/file_read_dir_link_windows.go
+++ b/kernel/api/file_read_dir_link_windows.go
@@ -1,0 +1,59 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type workspaceFileAttributeTagInfo struct {
+	fileAttributes uint32
+	reparseTag     uint32
+}
+
+func classifyWorkspaceLink(path string, _ os.FileInfo) (workspaceLinkKind, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return workspaceNotLink, err
+	}
+	attributes, err := windows.GetFileAttributes(pathPtr)
+	if err != nil {
+		return workspaceNotLink, err
+	}
+	if attributes&windows.FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+		return workspaceNotLink, nil
+	}
+
+	handle, err := windows.CreateFile(
+		pathPtr,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return workspaceNotLink, err
+	}
+	defer windows.CloseHandle(handle)
+
+	tagInfo := workspaceFileAttributeTagInfo{}
+	err = windows.GetFileInformationByHandleEx(
+		handle,
+		windows.FileAttributeTagInfo,
+		(*byte)(unsafe.Pointer(&tagInfo)),
+		uint32(unsafe.Sizeof(tagInfo)),
+	)
+	if err != nil {
+		return workspaceNotLink, err
+	}
+	if tagInfo.reparseTag == windows.IO_REPARSE_TAG_SYMLINK {
+		return workspaceSymbolicLink, nil
+	}
+	return workspaceOtherReparse, nil
+}

--- a/kernel/api/file_read_dir_metadata_darwin.go
+++ b/kernel/api/file_read_dir_metadata_darwin.go
@@ -1,0 +1,119 @@
+//go:build darwin
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type darwinReadDirFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+}
+
+func (info *darwinReadDirFileInfo) Name() string       { return info.name }
+func (info *darwinReadDirFileInfo) Size() int64        { return info.size }
+func (info *darwinReadDirFileInfo) Mode() os.FileMode  { return info.mode }
+func (info *darwinReadDirFileInfo) ModTime() time.Time { return info.modTime }
+func (info *darwinReadDirFileInfo) IsDir() bool        { return info.mode.IsDir() }
+func (info *darwinReadDirFileInfo) Sys() any           { return nil }
+
+type darwinReadDirIdentity struct {
+	device     int32
+	inode      uint64
+	generation uint32
+}
+
+func captureReadDirMetadataReference(directory *os.File, name string) (*readDirMetadataReference, error) {
+	stat, err := darwinReadDirStatAt(directory, name)
+	if err != nil {
+		return nil, err
+	}
+	identity := darwinReadDirIdentity{device: stat.Dev, inode: stat.Ino, generation: stat.Gen}
+	fileType := stat.Mode & unix.S_IFMT
+	info := &darwinReadDirFileInfo{
+		name:    name,
+		size:    stat.Size,
+		mode:    darwinReadDirMode(stat.Mode),
+		modTime: time.Unix(stat.Mtim.Unix()),
+	}
+
+	// Darwin has no public metadata-only entry handle equivalent to Linux
+	// O_PATH or Windows FILE_READ_ATTRIBUTES. Repeated fstatat observations do
+	// not open the entry and therefore cannot trigger FIFO/device open behavior
+	// or require file-content read permission. They cannot exclude an ABA
+	// replacement that restores the same filesystem identity between calls.
+	return &readDirMetadataReference{
+		info: info,
+		sameFile: func(other os.FileInfo) bool {
+			return identity.matchesFileInfo(other)
+		},
+		revalidate: func() error {
+			after, statErr := darwinReadDirStatAt(directory, name)
+			if statErr != nil {
+				return statErr
+			}
+			if !identity.matchesStat(after) || after.Mode&unix.S_IFMT != fileType {
+				return errReadDirEntryChanged
+			}
+			return nil
+		},
+	}, nil
+}
+
+func darwinReadDirStatAt(directory *os.File, name string) (*unix.Stat_t, error) {
+	var stat unix.Stat_t
+	err := unix.Fstatat(int(directory.Fd()), name, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	runtime.KeepAlive(directory)
+	if err != nil {
+		return nil, err
+	}
+	return &stat, nil
+}
+
+func (identity darwinReadDirIdentity) matchesStat(stat *unix.Stat_t) bool {
+	return stat != nil && identity.device == stat.Dev && identity.inode == stat.Ino && identity.generation == stat.Gen
+}
+
+func (identity darwinReadDirIdentity) matchesFileInfo(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && identity.device == stat.Dev && identity.inode == stat.Ino && identity.generation == stat.Gen
+}
+
+func darwinReadDirMode(raw uint16) os.FileMode {
+	mode := os.FileMode(raw & 0777)
+	switch raw & unix.S_IFMT {
+	case unix.S_IFBLK, unix.S_IFWHT:
+		mode |= os.ModeDevice
+	case unix.S_IFCHR:
+		mode |= os.ModeDevice | os.ModeCharDevice
+	case unix.S_IFDIR:
+		mode |= os.ModeDir
+	case unix.S_IFIFO:
+		mode |= os.ModeNamedPipe
+	case unix.S_IFLNK:
+		mode |= os.ModeSymlink
+	case unix.S_IFSOCK:
+		mode |= os.ModeSocket
+	}
+	if raw&unix.S_ISGID != 0 {
+		mode |= os.ModeSetgid
+	}
+	if raw&unix.S_ISUID != 0 {
+		mode |= os.ModeSetuid
+	}
+	if raw&unix.S_ISVTX != 0 {
+		mode |= os.ModeSticky
+	}
+	return mode
+}

--- a/kernel/api/file_read_dir_metadata_linux.go
+++ b/kernel/api/file_read_dir_metadata_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func captureReadDirMetadataReference(directory *os.File, name string) (reference *readDirMetadataReference, err error) {
+	fd, err := unix.Openat(int(directory.Fd()), name, unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, errors.New("failed to create directory entry metadata handle")
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, file.Close())
+		}
+	}()
+
+	info, err := file.Stat()
+	if err == nil {
+		err = pinWorkspaceFileInfo(info)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &readDirMetadataReference{
+		info:     info,
+		sameFile: func(other os.FileInfo) bool { return os.SameFile(info, other) },
+		close:    file.Close,
+	}, nil
+}

--- a/kernel/api/file_read_dir_metadata_unix_test.go
+++ b/kernel/api/file_read_dir_metadata_unix_test.go
@@ -1,0 +1,219 @@
+//go:build linux || darwin
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const readDirTimeoutWorkerEnv = "SIYUAN_TEST_READ_DIR_TIMEOUT_WORKER"
+
+func TestOpenReadDirDirectoryRejectsFIFOWithoutBlocking(t *testing.T) {
+	if os.Getenv(readDirTimeoutWorkerEnv) == "" {
+		runBoundedReadDirWorker(t, "open-directory-fifo")
+		return
+	}
+
+	workspace := t.TempDir()
+	fifo := filepath.Join(workspace, "fifo")
+	if err := unix.Mkfifo(fifo, 0600); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	file, openErr := openReadDirDirectory(root, "fifo")
+	if file != nil {
+		_ = file.Close()
+		t.Fatal("FIFO was opened as a directory")
+	}
+	if openErr == nil {
+		t.Fatal("FIFO directory open unexpectedly succeeded")
+	}
+}
+
+func runBoundedReadDirWorker(t *testing.T, worker string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, os.Args[0], "-test.run=^"+t.Name()+"$", "-test.count=1")
+	command.Env = append(os.Environ(), readDirTimeoutWorkerEnv+"="+worker)
+	command.WaitDelay = 2 * time.Second
+	output, err := command.CombinedOutput()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("readDir timeout worker %q blocked; process was killed and joined: %v\n%s", worker, err, output)
+	}
+	if err != nil {
+		t.Fatalf("readDir timeout worker %q failed: %v\n%s", worker, err, output)
+	}
+}
+
+func TestReadDirSnapshotSpecialFileReplacementDoesNotBlock(t *testing.T) {
+	if os.Getenv(readDirTimeoutWorkerEnv) == "" {
+		runBoundedReadDirWorker(t, "snapshot-special-replacement")
+		return
+	}
+
+	testCases := []struct {
+		name            string
+		initialType     string
+		replacementType string
+	}{
+		{name: "regular-to-FIFO", initialType: "regular", replacementType: "fifo"},
+		{name: "directory-to-FIFO", initialType: "directory", replacementType: "fifo"},
+		{name: "regular-to-socket", initialType: "regular", replacementType: "socket"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			directoryPath := filepath.Join(workspace, "directory")
+			if err := os.Mkdir(directoryPath, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(directoryPath, "A"), []byte("stable"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			victim := filepath.Join(directoryPath, "z")
+			if testCase.initialType == "regular" {
+				if err := os.WriteFile(victim, []byte("replace"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.Mkdir(victim, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			root, directory, resolvedWorkspace := openSnapshotFixture(t, workspace, "directory")
+			replaced := false
+			var replacementErr error
+			var replacementSocket net.Listener
+			t.Cleanup(func() {
+				if replacementSocket != nil {
+					_ = replacementSocket.Close()
+				}
+			})
+			snapshotter := &readDirSnapshotter{
+				root:              root,
+				directory:         directory,
+				directoryRelative: "directory",
+				resolvedWorkspace: resolvedWorkspace,
+				afterInitialStat: func(name string) {
+					if name != "z" || replaced {
+						return
+					}
+					replaced = true
+					if replacementErr = os.Remove(victim); replacementErr != nil {
+						return
+					}
+					if testCase.replacementType == "fifo" {
+						replacementErr = unix.Mkfifo(victim, 0600)
+					} else {
+						replacementSocket, replacementErr = net.Listen("unix", victim)
+					}
+				},
+			}
+
+			snapshot, snapshotErr := snapshotter.read()
+			if replacementErr != nil {
+				t.Fatal(replacementErr)
+			}
+			if !errors.Is(snapshotErr, errReadDirEntryChanged) {
+				t.Fatalf("special-file replacement returned %v", snapshotErr)
+			}
+			if snapshot != nil {
+				t.Fatalf("special-file replacement returned partial snapshot: %#v", snapshot)
+			}
+		})
+	}
+}
+
+func TestReadDirSnapshotDoesNotRequireFileContentReadPermission(t *testing.T) {
+	const unprivilegedRunEnv = "SIYUAN_TEST_READ_DIR_UNPRIVILEGED"
+	if os.Geteuid() == 0 && os.Getenv(unprivilegedRunEnv) == "" {
+		executableDirectory, err := os.MkdirTemp("", "siyuan-read-dir-unprivileged-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(executableDirectory) })
+		if err = os.Chmod(executableDirectory, 0755); err != nil {
+			t.Fatal(err)
+		}
+		executablePath := filepath.Join(executableDirectory, "api.test")
+		source, err := os.Open(os.Args[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		destination, err := os.OpenFile(executablePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
+		if err != nil {
+			_ = source.Close()
+			t.Fatal(err)
+		}
+		_, copyErr := io.Copy(destination, source)
+		sourceCloseErr := source.Close()
+		destinationCloseErr := destination.Close()
+		if copyErr != nil || sourceCloseErr != nil || destinationCloseErr != nil {
+			t.Fatalf("copy test executable: copy=%v source-close=%v destination-close=%v", copyErr, sourceCloseErr, destinationCloseErr)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		command := exec.CommandContext(ctx, executablePath, "-test.run=^TestReadDirSnapshotDoesNotRequireFileContentReadPermission$", "-test.count=1")
+		command.Dir = executableDirectory
+		command.Env = append(os.Environ(), unprivilegedRunEnv+"=1")
+		command.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: 65534, Gid: 65534, Groups: []uint32{65534}},
+		}
+		command.WaitDelay = 2 * time.Second
+		output, commandErr := command.CombinedOutput()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("unprivileged metadata listing blocked; process was killed and joined: %v\n%s", commandErr, output)
+		}
+		if commandErr != nil {
+			t.Fatalf("unprivileged metadata listing failed: %v\n%s", commandErr, output)
+		}
+		return
+	}
+
+	workspace := t.TempDir()
+	directoryPath := filepath.Join(workspace, "directory")
+	if err := os.Mkdir(directoryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	victim := filepath.Join(directoryPath, "unreadable")
+	if err := os.WriteFile(victim, []byte("content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(victim, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(victim, 0600) })
+	if content, err := os.Open(victim); err == nil {
+		_ = content.Close()
+		t.Skip("current user can open mode-000 files for content")
+	}
+
+	root, directory, resolvedWorkspace := openSnapshotFixture(t, workspace, "directory")
+	snapshot, err := readDirSnapshot(root, directory, "directory", resolvedWorkspace)
+	if err != nil {
+		t.Fatalf("metadata-only listing failed: %v", err)
+	}
+	if len(snapshot) != 1 || snapshot[0].name != "unreadable" || snapshot[0].isDir {
+		t.Fatalf("unexpected metadata-only snapshot: %#v", snapshot)
+	}
+}

--- a/kernel/api/file_read_dir_metadata_unsupported.go
+++ b/kernel/api/file_read_dir_metadata_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin && !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import "os"
+
+func captureReadDirMetadataReference(_ *os.File, _ string) (*readDirMetadataReference, error) {
+	return nil, errReadDirMetadataReferenceUnsupported
+}

--- a/kernel/api/file_read_dir_metadata_windows.go
+++ b/kernel/api/file_read_dir_metadata_windows.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func captureReadDirMetadataReference(directory *os.File, name string) (reference *readDirMetadataReference, err error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return nil, err
+	}
+	attributes := windows.OBJECT_ATTRIBUTES{
+		RootDirectory: windows.Handle(directory.Fd()),
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE,
+	}
+	attributes.Length = uint32(unsafe.Sizeof(attributes))
+
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(
+		&handle,
+		windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE,
+		&attributes,
+		&status,
+		nil,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_OPEN,
+		windows.FILE_SYNCHRONOUS_IO_NONALERT|windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_OPEN_REPARSE_POINT,
+		0,
+		0,
+	)
+	runtime.KeepAlive(directory)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(handle), name)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, errors.New("failed to create directory entry metadata handle")
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, file.Close())
+		}
+	}()
+
+	info, err := file.Stat()
+	if err == nil {
+		err = pinWorkspaceFileInfo(info)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &readDirMetadataReference{
+		info:     info,
+		sameFile: func(other os.FileInfo) bool { return os.SameFile(info, other) },
+		close:    file.Close,
+	}, nil
+}

--- a/kernel/api/file_read_dir_snapshot.go
+++ b/kernel/api/file_read_dir_snapshot.go
@@ -1,0 +1,220 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+var (
+	errReadDirEntryChanged                 = errors.New("directory entry changed during read")
+	errReadDirMetadataReferenceUnsupported = errors.New("safe directory entry metadata references are unsupported on this platform")
+)
+
+type readDirMetadataReference struct {
+	info       os.FileInfo
+	sameFile   func(os.FileInfo) bool
+	revalidate func() error
+	close      func() error
+}
+
+func (reference *readDirMetadataReference) matches(info os.FileInfo) bool {
+	return reference != nil && reference.info != nil && reference.sameFile != nil && reference.sameFile(info)
+}
+
+func (reference *readDirMetadataReference) revalidateEntry() error {
+	if reference == nil || reference.revalidate == nil {
+		return nil
+	}
+	return reference.revalidate()
+}
+
+func (reference *readDirMetadataReference) closeReference() error {
+	if reference == nil || reference.close == nil {
+		return nil
+	}
+	return reference.close()
+}
+
+type readDirSnapshotEntry struct {
+	name      string
+	isDir     bool
+	isSymlink bool
+	updated   int64
+}
+
+type readDirSnapshotter struct {
+	root              *os.Root
+	directory         *os.File
+	directoryRelative string
+	resolvedWorkspace string
+	afterInitialStat  func(string)
+}
+
+func openReadDirDirectory(root *os.Root, relativePath string) (*os.File, error) {
+	return root.Open(relativePath + string(filepath.Separator))
+}
+
+func readDirSnapshot(root *os.Root, directory *os.File, directoryRelative, resolvedWorkspace string) ([]readDirSnapshotEntry, error) {
+	return (&readDirSnapshotter{
+		root:              root,
+		directory:         directory,
+		directoryRelative: directoryRelative,
+		resolvedWorkspace: resolvedWorkspace,
+	}).read()
+}
+
+func (snapshotter *readDirSnapshotter) read() ([]readDirSnapshotEntry, error) {
+	entries, err := snapshotter.directory.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	result := make([]readDirSnapshotEntry, 0, len(entries))
+	for _, entry := range entries {
+		snapshot, snapshotErr := snapshotter.readEntry(entry.Name())
+		if snapshotErr != nil {
+			return nil, snapshotErr
+		}
+		result = append(result, snapshot)
+	}
+	return result, nil
+}
+
+func (snapshotter *readDirSnapshotter) readEntry(name string) (readDirSnapshotEntry, error) {
+	relativePath := filepath.Join(snapshotter.directoryRelative, name)
+	absolutePath := filepath.Join(snapshotter.resolvedWorkspace, relativePath)
+	before, err := snapshotter.root.Lstat(relativePath)
+	if err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	if err = pinWorkspaceFileInfo(before); err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	linkKind, err := classifyWorkspaceLink(absolutePath, before)
+	if err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	if snapshotter.afterInitialStat != nil {
+		snapshotter.afterInitialStat(name)
+	}
+
+	switch linkKind {
+	case workspaceSymbolicLink:
+		return snapshotter.readLinkEntry(name, absolutePath, before)
+	case workspaceOtherReparse:
+		return readDirSnapshotEntry{}, fmt.Errorf("%w: %s", errWorkspaceUnsupportedReparse, name)
+	}
+	if before.Mode().IsRegular() || before.IsDir() {
+		return snapshotter.readMetadataEntry(name, relativePath, absolutePath, before)
+	}
+
+	after, err := snapshotter.root.Lstat(relativePath)
+	if err != nil || pinWorkspaceFileInfo(after) != nil || !sameReadDirEntryType(before, after) || !os.SameFile(before, after) {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	afterLinkKind, err := classifyWorkspaceLink(absolutePath, after)
+	if err != nil || afterLinkKind != workspaceNotLink {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	return readDirSnapshotEntry{name: name, updated: before.ModTime().Unix()}, nil
+}
+
+func (snapshotter *readDirSnapshotter) readMetadataEntry(name, relativePath, absolutePath string, before os.FileInfo) (snapshot readDirSnapshotEntry, err error) {
+	reference, err := captureReadDirMetadataReference(snapshotter.directory, name)
+	if err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	defer func() {
+		if closeErr := reference.closeReference(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	if !sameReadDirEntryType(before, reference.info) || !reference.matches(before) {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, nil)
+	}
+
+	after, err := snapshotter.root.Lstat(relativePath)
+	if err != nil || pinWorkspaceFileInfo(after) != nil ||
+		!sameReadDirEntryType(reference.info, after) || !reference.matches(after) {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	afterLinkKind, err := classifyWorkspaceLink(absolutePath, after)
+	if err != nil || afterLinkKind != workspaceNotLink {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	if err = reference.revalidateEntry(); err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	return readDirSnapshotEntry{
+		name:    name,
+		isDir:   reference.info.IsDir(),
+		updated: reference.info.ModTime().Unix(),
+	}, nil
+}
+
+func sameReadDirEntryType(left, right os.FileInfo) bool {
+	return left != nil && right != nil && left.Mode().Type() == right.Mode().Type()
+}
+
+func (snapshotter *readDirSnapshotter) readLinkEntry(name, absolutePath string, before os.FileInfo) (readDirSnapshotEntry, error) {
+	resolved, err := resolveExistingWorkspacePath(absolutePath)
+	if err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	targetRelative, contained := workspaceRelativePath(snapshotter.resolvedWorkspace, resolved)
+	if !contained {
+		return readDirSnapshotEntry{}, errWorkspacePathOutside
+	}
+	targetInfo, err := snapshotter.root.Stat(targetRelative)
+	if err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	if err = pinWorkspaceFileInfo(targetInfo); err != nil {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+
+	after, err := os.Lstat(absolutePath)
+	if err != nil || pinWorkspaceFileInfo(after) != nil || !sameReadDirEntryType(before, after) || !os.SameFile(before, after) {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	afterLinkKind, err := classifyWorkspaceLink(absolutePath, after)
+	if err != nil || afterLinkKind != workspaceSymbolicLink {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	resolvedAfter, err := resolveExistingWorkspacePath(absolutePath)
+	if err != nil || !sameCanonicalWorkspacePath(resolved, resolvedAfter) {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	targetInfoAfter, err := snapshotter.root.Stat(targetRelative)
+	if err != nil || pinWorkspaceFileInfo(targetInfoAfter) != nil || !sameReadDirEntryType(targetInfo, targetInfoAfter) || !os.SameFile(targetInfo, targetInfoAfter) {
+		return readDirSnapshotEntry{}, changedReadDirEntryError(name, err)
+	}
+	return readDirSnapshotEntry{
+		name:      name,
+		isDir:     targetInfo.IsDir(),
+		isSymlink: true,
+		updated:   targetInfo.ModTime().Unix(),
+	}, nil
+}
+
+func changedReadDirEntryError(name string, err error) error {
+	if err == nil {
+		return fmt.Errorf("%w: %s", errReadDirEntryChanged, name)
+	}
+	return fmt.Errorf("%w: %s: %v", errReadDirEntryChanged, name, err)
+}

--- a/kernel/api/file_read_dir_snapshot_test.go
+++ b/kernel/api/file_read_dir_snapshot_test.go
@@ -1,0 +1,271 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestReadDirMetadataReferenceIdentityAndType(t *testing.T) {
+	workspace := t.TempDir()
+	directoryPath := filepath.Join(workspace, "directory")
+	if err := os.Mkdir(directoryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directoryPath, "file"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(directoryPath, "child"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	root, directory, _ := openSnapshotFixture(t, workspace, "directory")
+	for _, name := range []string{"file", "child"} {
+		reference, err := captureReadDirMetadataReference(directory, name)
+		if errors.Is(err, errReadDirMetadataReferenceUnsupported) {
+			t.Skip(err)
+		}
+		if err != nil {
+			t.Fatalf("capture metadata reference for %s: %v", name, err)
+		}
+		pathInfo, statErr := root.Lstat(filepath.Join("directory", name))
+		revalidateErr := reference.revalidateEntry()
+		closeErr := reference.closeReference()
+		if statErr != nil {
+			t.Fatalf("stat metadata path for %s: %v", name, statErr)
+		}
+		if revalidateErr != nil {
+			t.Fatalf("revalidate metadata reference for %s: %v", name, revalidateErr)
+		}
+		if closeErr != nil {
+			t.Fatalf("close metadata reference for %s: %v", name, closeErr)
+		}
+		if !sameReadDirEntryType(pathInfo, reference.info) || !reference.matches(pathInfo) {
+			t.Fatalf("metadata reference for %s did not preserve entry identity and type", name)
+		}
+	}
+}
+
+func TestReadDirMetadataReferenceDoesNotFollowLink(t *testing.T) {
+	workspace := t.TempDir()
+	directoryPath := filepath.Join(workspace, "directory")
+	if err := os.Mkdir(directoryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(directoryPath, "target")
+	if err := os.WriteFile(target, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(directoryPath, "link")
+	if !createTestSymlink(t, "target", link) {
+		t.Skip("symlink privilege unavailable")
+	}
+
+	_, directory, _ := openSnapshotFixture(t, workspace, "directory")
+	reference, err := captureReadDirMetadataReference(directory, "link")
+	if errors.Is(err, errReadDirMetadataReferenceUnsupported) {
+		t.Skip(err)
+	}
+	if err != nil {
+		t.Fatalf("capture no-follow metadata reference: %v", err)
+	}
+	defer reference.closeReference()
+	linkInfo, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetInfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reference.matches(linkInfo) || reference.matches(targetInfo) {
+		t.Fatal("metadata reference followed the symbolic link")
+	}
+	if err = reference.revalidateEntry(); err != nil {
+		t.Fatalf("revalidate no-follow metadata reference: %v", err)
+	}
+}
+
+func TestReadDirSnapshotOrderingAndMetadata(t *testing.T) {
+	workspace := t.TempDir()
+	directoryPath := filepath.Join(workspace, "directory")
+	if err := os.Mkdir(directoryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(directoryPath, "A"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"b", "z"} {
+		if err := os.WriteFile(filepath.Join(directoryPath, name), []byte(name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkCreated := createTestSymlink(t, "b", filepath.Join(directoryPath, "m"))
+	if !linkCreated {
+		if err := os.WriteFile(filepath.Join(directoryPath, "m"), []byte("m"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	root, directory, resolvedWorkspace := openSnapshotFixture(t, workspace, "directory")
+	snapshot, err := readDirSnapshot(root, directory, "directory", resolvedWorkspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNames := []string{"A", "b", "m", "z"}
+	if len(snapshot) != len(wantNames) {
+		t.Fatalf("snapshot length = %d", len(snapshot))
+	}
+	for i, want := range wantNames {
+		if snapshot[i].name != want {
+			t.Fatalf("snapshot[%d].name = %q, want %q", i, snapshot[i].name, want)
+		}
+		if snapshot[i].updated == 0 {
+			t.Fatalf("snapshot[%d] has no update time", i)
+		}
+	}
+	if !snapshot[0].isDir {
+		t.Fatal("directory entry was not classified as a directory")
+	}
+	if snapshot[1].isDir || snapshot[3].isDir {
+		t.Fatal("regular file was classified as a directory")
+	}
+	if snapshot[2].isSymlink != linkCreated {
+		t.Fatalf("link classification = %t, want %t", snapshot[2].isSymlink, linkCreated)
+	}
+}
+
+func TestReadDirSnapshotDetectsReplacementWithoutPartialResult(t *testing.T) {
+	workspace := t.TempDir()
+	directoryPath := filepath.Join(workspace, "directory")
+	if err := os.Mkdir(directoryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directoryPath, "A"), []byte("stable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	victim := filepath.Join(directoryPath, "z")
+	if err := os.WriteFile(victim, []byte("replace"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, directory, resolvedWorkspace := openSnapshotFixture(t, workspace, "directory")
+	replaced := false
+	snapshotter := &readDirSnapshotter{
+		root:              root,
+		directory:         directory,
+		directoryRelative: "directory",
+		resolvedWorkspace: resolvedWorkspace,
+		afterInitialStat: func(name string) {
+			if name != "z" || replaced {
+				return
+			}
+			replaced = true
+			if err := os.Remove(victim); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(victim, 0755); err != nil {
+				t.Fatal(err)
+			}
+		},
+	}
+	snapshot, err := snapshotter.read()
+	if !errors.Is(err, errReadDirEntryChanged) {
+		t.Fatalf("replacement returned %v", err)
+	}
+	if snapshot != nil {
+		t.Fatalf("replacement returned partial snapshot: %#v", snapshot)
+	}
+}
+
+func TestReadDirSnapshotRejectsEscapingLinkWithoutPartialResult(t *testing.T) {
+	workspace := t.TempDir()
+	directoryPath := filepath.Join(workspace, "directory")
+	if err := os.Mkdir(directoryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directoryPath, "A"), []byte("stable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("outside"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !createTestSymlink(t, outside, filepath.Join(directoryPath, "z")) {
+		t.Skip("symlink privilege unavailable")
+	}
+
+	root, directory, resolvedWorkspace := openSnapshotFixture(t, workspace, "directory")
+	snapshot, err := readDirSnapshot(root, directory, "directory", resolvedWorkspace)
+	if !errors.Is(err, errWorkspacePathOutside) {
+		t.Fatalf("escaping link returned %v", err)
+	}
+	if snapshot != nil {
+		t.Fatalf("escaping link returned partial snapshot: %#v", snapshot)
+	}
+}
+
+func TestReadDirSnapshotWindowsRejectsJunctionEntry(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows junction test")
+	}
+	workspace := t.TempDir()
+	directoryPath := filepath.Join(workspace, "directory")
+	target := filepath.Join(workspace, "target")
+	if err := os.MkdirAll(directoryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+	createTestJunction(t, target, filepath.Join(directoryPath, "junction"))
+
+	root, directory, resolvedWorkspace := openSnapshotFixture(t, workspace, "directory")
+	metadataReference, err := captureReadDirMetadataReference(directory, "junction")
+	if err != nil {
+		t.Fatalf("capture junction metadata reference: %v", err)
+	}
+	junctionInfo, statErr := root.Lstat(filepath.Join("directory", "junction"))
+	closeErr := metadataReference.closeReference()
+	if statErr != nil {
+		t.Fatalf("stat junction path: %v", statErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close junction metadata reference: %v", closeErr)
+	}
+	if !sameReadDirEntryType(junctionInfo, metadataReference.info) || !metadataReference.matches(junctionInfo) {
+		t.Fatal("junction metadata reference did not preserve reparse-point identity")
+	}
+
+	snapshot, err := readDirSnapshot(root, directory, "directory", resolvedWorkspace)
+	if !errors.Is(err, errWorkspaceUnsupportedReparse) {
+		t.Fatalf("junction entry returned %v", err)
+	}
+	if snapshot != nil {
+		t.Fatalf("junction entry returned partial snapshot: %#v", snapshot)
+	}
+}
+
+func openSnapshotFixture(t *testing.T, workspace, relative string) (*os.Root, *os.File, string) {
+	t.Helper()
+	resolvedWorkspace, err := resolveExistingWorkspacePath(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { root.Close() })
+	directory, err := root.Open(relative)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { directory.Close() })
+	return root, directory, resolvedWorkspace
+}

--- a/kernel/api/file_test.go
+++ b/kernel/api/file_test.go
@@ -1,14 +1,18 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/siyuan-note/siyuan/kernel/conf"
 	"github.com/siyuan-note/siyuan/kernel/model"
 	"github.com/siyuan-note/siyuan/kernel/util"
 )
@@ -47,4 +51,259 @@ func TestGetFileAllowsWorkspaceTemp(t *testing.T) {
 	if recorder.Body.String() != string(content) {
 		t.Fatalf("unexpected workspace temp file content: %q", recorder.Body.String())
 	}
+}
+
+func TestReadDirAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldWorkspaceDir := util.WorkspaceDir
+	oldDataDir := util.DataDir
+	oldReadOnly := util.ReadOnly
+	oldConf := model.Conf
+	oldLangs := util.Langs
+	workspace := t.TempDir()
+	util.WorkspaceDir = workspace
+	util.DataDir = filepath.Join(workspace, "data")
+	util.ReadOnly = false
+	model.Conf = model.NewAppConf()
+	model.Conf.Lang = "read-dir-test"
+	util.Langs = map[string]map[int]string{
+		"read-dir-test": {321: "encrypted notebook access denied"},
+	}
+	t.Cleanup(func() {
+		util.WorkspaceDir = oldWorkspaceDir
+		util.DataDir = oldDataDir
+		util.ReadOnly = oldReadOnly
+		model.Conf = oldConf
+		util.Langs = oldLangs
+	})
+
+	directory := filepath.Join(workspace, "directory")
+	if err := os.MkdirAll(filepath.Join(directory, "A"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"b", "m", "z"} {
+		if err := os.WriteFile(filepath.Join(directory, name), []byte(name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mixedCaseDirectory := filepath.Join(workspace, "MiXeD")
+	if err := os.Mkdir(mixedCaseDirectory, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mixedCaseDirectory, "entry"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mixedStatus, mixedBody := requestReadDir(t, model.RoleAdministrator, `{"path":"MiXeD"}`)
+	mixedResponse := decodeReadDirResponse(t, mixedBody)
+	if mixedStatus != http.StatusOK || mixedResponse.Code != 0 {
+		t.Fatalf("mixed-case directory access failed: status=%d body=%s", mixedStatus, mixedBody)
+	}
+
+	status, body := requestReadDir(t, model.RoleAdministrator, `{"path":"directory"}`)
+	if status != http.StatusOK {
+		t.Fatalf("administrator transport status = %d: %s", status, body)
+	}
+	response := decodeReadDirResponse(t, body)
+	if response.Code != 0 {
+		t.Fatalf("administrator logical code = %d: %s", response.Code, body)
+	}
+	var files []map[string]json.RawMessage
+	if err := json.Unmarshal(response.Data, &files); err != nil {
+		t.Fatal(err)
+	}
+	wantNames := []string{"A", "b", "m", "z"}
+	if len(files) != len(wantNames) {
+		t.Fatalf("file count = %d: %s", len(files), body)
+	}
+	allowedFields := map[string]bool{"name": true, "isDir": true, "isSymlink": true, "updated": true}
+	for i, file := range files {
+		if len(file) != len(allowedFields) {
+			t.Fatalf("file %d fields = %v", i, file)
+		}
+		for field := range file {
+			if !allowedFields[field] {
+				t.Fatalf("unexpected response field %q", field)
+			}
+		}
+		var name string
+		if err := json.Unmarshal(file["name"], &name); err != nil {
+			t.Fatal(err)
+		}
+		if name != wantNames[i] {
+			t.Fatalf("file %d name = %q, want %q", i, name, wantNames[i])
+		}
+	}
+
+	for _, role := range []model.Role{model.RoleEditor, model.RoleReader} {
+		status, _ = requestReadDir(t, role, `{"path":"directory"}`)
+		if status != http.StatusForbidden {
+			t.Fatalf("role %v transport status = %d", role, status)
+		}
+	}
+
+	util.ReadOnly = true
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"directory"}`)
+	util.ReadOnly = false
+	if status != http.StatusOK || decodeReadDirResponse(t, body).Code != 0 {
+		t.Fatalf("read-only directory read failed: status=%d body=%s", status, body)
+	}
+
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"missing"}`)
+	response = decodeReadDirResponse(t, body)
+	if status != http.StatusOK || response.Code != http.StatusNotFound || string(response.Data) != "null" {
+		t.Fatalf("missing path response: status=%d body=%s", status, body)
+	}
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"directory/b"}`)
+	response = decodeReadDirResponse(t, body)
+	if status != http.StatusOK || response.Code != http.StatusConflict || string(response.Data) != "null" {
+		t.Fatalf("non-directory response: status=%d body=%s", status, body)
+	}
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"../outside"}`)
+	response = decodeReadDirResponse(t, body)
+	if status != http.StatusOK || response.Code != http.StatusForbidden || string(response.Data) != "null" {
+		t.Fatalf("escape response: status=%d body=%s", status, body)
+	}
+
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":`)
+	if status != http.StatusOK || !json.Valid(body) {
+		t.Fatalf("malformed request returned invalid envelope: status=%d body=%q", status, body)
+	}
+
+	outside := t.TempDir()
+	unsafeDirectory := filepath.Join(workspace, "unsafe")
+	if err := os.Mkdir(unsafeDirectory, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unsafeDirectory, "A"), []byte("stable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if createTestSymlink(t, outside, filepath.Join(unsafeDirectory, "z")) {
+		status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"unsafe"}`)
+		response = decodeReadDirResponse(t, body)
+		if status != http.StatusOK || response.Code != http.StatusInternalServerError || string(response.Data) != "null" {
+			t.Fatalf("escaping entry response: status=%d body=%s", status, body)
+		}
+	}
+
+	const boxID = "20260807000000-abcdefg"
+	boxConf := conf.NewBoxConf()
+	boxConf.Encrypted = true
+	confData, err := json.Marshal(boxConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	confPath := filepath.Join(util.DataDir, boxID, ".siyuan", "conf.json")
+	if err = os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(confPath, confData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"data/`+boxID+`"}`)
+	response = decodeReadDirResponse(t, body)
+	if status != http.StatusOK || response.Code != -3 || string(response.Data) != "null" {
+		t.Fatalf("encrypted notebook response: status=%d body=%s", status, body)
+	}
+}
+
+func TestReadDirAPIWindowsReparseMatrix(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows reparse API test")
+	}
+	oldWorkspaceDir := util.WorkspaceDir
+	workspaceBase := windowsTempDir(t, os.Getenv("LOCALAPPDATA"))
+	workspace := filepath.Join(workspaceBase, "workspace")
+	if err := os.Mkdir(workspace, 0755); err != nil {
+		t.Fatal(err)
+	}
+	util.WorkspaceDir = workspace
+	t.Cleanup(func() { util.WorkspaceDir = oldWorkspaceDir })
+
+	insideTarget := filepath.Join(workspace, "inside-target")
+	if err := os.Mkdir(insideTarget, 0755); err != nil {
+		t.Fatal(err)
+	}
+	createTestJunction(t, insideTarget, filepath.Join(workspace, "inside-junction"))
+	status, body := requestReadDir(t, model.RoleAdministrator, `{"path":"inside-junction"}`)
+	response := decodeReadDirResponse(t, body)
+	if status != http.StatusOK || response.Code != http.StatusInternalServerError || string(response.Data) != "null" {
+		t.Fatalf("internal junction response: status=%d body=%s", status, body)
+	}
+	t.Log("internal junction request returned logical 500 with null data")
+
+	crossTarget := windowsCrossVolumeTempDir(t, `D:\`)
+	createTestJunction(t, crossTarget, filepath.Join(workspace, "cross-direct"))
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"cross-direct"}`)
+	response = decodeReadDirResponse(t, body)
+	if status != http.StatusOK || response.Code != http.StatusForbidden || string(response.Data) != "null" {
+		t.Fatalf("cross-volume junction response: status=%d body=%s", status, body)
+	}
+	t.Log("C:-to-D: junction request returned logical 403 with null data")
+
+	listing := filepath.Join(workspace, "listing")
+	if err := os.Mkdir(listing, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(listing, "A"), []byte("stable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	createTestJunction(t, crossTarget, filepath.Join(listing, "z"))
+	status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"listing"}`)
+	if !json.Valid(body) {
+		t.Fatalf("cross-volume entry returned invalid JSON: %q", body)
+	}
+	response = decodeReadDirResponse(t, body)
+	if status != http.StatusOK || response.Code != http.StatusInternalServerError || string(response.Data) != "null" {
+		t.Fatalf("cross-volume entry response: status=%d body=%s", status, body)
+	}
+	t.Log("C:-to-D: junction entry returned logical 500 with valid JSON and null data")
+
+	symlinkTarget := filepath.Join(workspace, "symlink-target")
+	if err := os.Mkdir(symlinkTarget, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(symlinkTarget, "A"), []byte("inside"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if createTestRelativeDirectorySymlink(t, "symlink-target", filepath.Join(workspace, "symlink")) {
+		status, body = requestReadDir(t, model.RoleAdministrator, `{"path":"symlink"}`)
+		response = decodeReadDirResponse(t, body)
+		if status != http.StatusOK || response.Code != 0 {
+			t.Fatalf("contained relative symlink response: status=%d body=%s", status, body)
+		}
+		t.Log("contained relative directory symlink traversal succeeded")
+	}
+}
+
+type readDirAPIResponse struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	Data json.RawMessage `json:"data"`
+}
+
+func requestReadDir(t *testing.T, role model.Role, body string) (int, []byte) {
+	t.Helper()
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set(model.RoleContextKey, role)
+		c.Next()
+	})
+	ServeAPI(engine)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/file/readDir", bytes.NewBufferString(body))
+	request.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(recorder, request)
+	return recorder.Code, recorder.Body.Bytes()
+}
+
+func decodeReadDirResponse(t *testing.T, body []byte) readDirAPIResponse {
+	t.Helper()
+	response := readDirAPIResponse{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode response failed: %v: %s", err, body)
+	}
+	return response
 }

--- a/kernel/api/workspace_path.go
+++ b/kernel/api/workspace_path.go
@@ -1,0 +1,283 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/siyuan-note/filelock"
+)
+
+var (
+	errWorkspacePathOutside        = errors.New("path escapes workspace")
+	errWorkspacePathChanged        = errors.New("workspace path changed during directory read")
+	errWorkspaceRootUnavailable    = errors.New("workspace root is unavailable")
+	errWorkspaceUnsupportedReparse = errors.New("unsupported reparse point in workspace path")
+)
+
+type workspaceLinkKind uint8
+
+const (
+	workspaceNotLink workspaceLinkKind = iota
+	workspaceSymbolicLink
+	workspaceOtherReparse
+)
+
+type workspacePathObservation struct {
+	path     string
+	info     os.FileInfo
+	linkKind workspaceLinkKind
+}
+
+type workspacePathGuard struct {
+	workspacePath      string
+	requestedPath      string
+	relativePath       string
+	resolvedWorkspace  string
+	resolvedRequested  string
+	workspaceInfo      os.FileInfo
+	requestedInfo      os.FileInfo
+	observations       []workspacePathObservation
+	unsupportedReparse bool
+}
+
+func newWorkspacePathGuard(workspacePath, requestedPath string) (*workspacePathGuard, error) {
+	workspaceAbs, err := filepath.Abs(workspacePath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errWorkspaceRootUnavailable, err)
+	}
+	workspaceAbs = filepath.Clean(workspaceAbs)
+	if filepath.IsAbs(requestedPath) || filepath.VolumeName(requestedPath) != "" {
+		return nil, errWorkspacePathOutside
+	}
+
+	requestedAbs := filepath.Clean(filepath.Join(workspaceAbs, requestedPath))
+	relativePath, contained := workspaceRelativePath(workspaceAbs, requestedAbs)
+	if !contained {
+		return nil, errWorkspacePathOutside
+	}
+
+	resolvedWorkspace, err := resolveExistingWorkspacePath(workspaceAbs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errWorkspaceRootUnavailable, err)
+	}
+	workspaceInfo, err := os.Stat(workspaceAbs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errWorkspaceRootUnavailable, err)
+	}
+	if err = pinWorkspaceFileInfo(workspaceInfo); err != nil {
+		return nil, fmt.Errorf("%w: %v", errWorkspaceRootUnavailable, err)
+	}
+	if !workspaceInfo.IsDir() {
+		return nil, fmt.Errorf("%w: workspace root is not a directory", errWorkspaceRootUnavailable)
+	}
+
+	resolvedRequested, err := resolveExistingWorkspacePath(requestedAbs)
+	if err != nil {
+		return nil, err
+	}
+	if !workspacePathContains(resolvedWorkspace, resolvedRequested) {
+		return nil, errWorkspacePathOutside
+	}
+	requestedInfo, err := os.Stat(requestedAbs)
+	if err != nil {
+		return nil, err
+	}
+	if err = pinWorkspaceFileInfo(requestedInfo); err != nil {
+		return nil, err
+	}
+
+	observations, unsupportedReparse, err := observeWorkspacePath(workspaceAbs, relativePath)
+	if err != nil {
+		return nil, err
+	}
+	return &workspacePathGuard{
+		workspacePath:      workspaceAbs,
+		requestedPath:      requestedAbs,
+		relativePath:       relativePath,
+		resolvedWorkspace:  resolvedWorkspace,
+		resolvedRequested:  resolvedRequested,
+		workspaceInfo:      workspaceInfo,
+		requestedInfo:      requestedInfo,
+		observations:       observations,
+		unsupportedReparse: unsupportedReparse,
+	}, nil
+}
+
+func (guard *workspacePathGuard) lock() func() {
+	// filelock coordinates exact path spellings only. Root and identity
+	// revalidation below enforce correctness when aliases do not share a lock.
+	pathsByName := map[string]struct{}{}
+	for _, observation := range guard.observations {
+		pathsByName[observation.path] = struct{}{}
+	}
+	paths := make([]string, 0, len(pathsByName))
+	for path := range pathsByName {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		filelock.Lock(path)
+	}
+	return func() {
+		for i := len(paths) - 1; i >= 0; i-- {
+			filelock.Unlock(paths[i])
+		}
+	}
+}
+
+func (guard *workspacePathGuard) revalidate() error {
+	resolvedWorkspace, err := resolveExistingWorkspacePath(guard.workspacePath)
+	if err != nil || !sameCanonicalWorkspacePath(resolvedWorkspace, guard.resolvedWorkspace) {
+		return errWorkspacePathChanged
+	}
+	workspaceInfo, err := os.Stat(guard.workspacePath)
+	if err != nil || pinWorkspaceFileInfo(workspaceInfo) != nil || !os.SameFile(workspaceInfo, guard.workspaceInfo) {
+		return errWorkspacePathChanged
+	}
+
+	for _, observation := range guard.observations {
+		info, statErr := os.Lstat(observation.path)
+		if statErr != nil || pinWorkspaceFileInfo(info) != nil || !os.SameFile(info, observation.info) {
+			return errWorkspacePathChanged
+		}
+		linkKind, linkErr := classifyWorkspaceLink(observation.path, info)
+		if linkErr != nil || linkKind != observation.linkKind {
+			return errWorkspacePathChanged
+		}
+	}
+
+	resolvedRequested, err := resolveExistingWorkspacePath(guard.requestedPath)
+	if err != nil || !sameCanonicalWorkspacePath(resolvedRequested, guard.resolvedRequested) {
+		return errWorkspacePathChanged
+	}
+	if !workspacePathContains(resolvedWorkspace, resolvedRequested) {
+		return errWorkspacePathChanged
+	}
+	requestedInfo, err := os.Stat(guard.requestedPath)
+	if err != nil || pinWorkspaceFileInfo(requestedInfo) != nil || !os.SameFile(requestedInfo, guard.requestedInfo) {
+		return errWorkspacePathChanged
+	}
+	return nil
+}
+
+func (guard *workspacePathGuard) openRoot() (*os.Root, error) {
+	root, err := os.OpenRoot(guard.workspacePath)
+	if err != nil {
+		return nil, err
+	}
+	rootInfo, err := root.Stat(".")
+	if err != nil || pinWorkspaceFileInfo(rootInfo) != nil || !os.SameFile(rootInfo, guard.workspaceInfo) {
+		root.Close()
+		return nil, errWorkspacePathChanged
+	}
+	return root, nil
+}
+
+func (guard *workspacePathGuard) verifyRequestedInfo(info os.FileInfo) error {
+	if pinWorkspaceFileInfo(info) != nil || !os.SameFile(info, guard.requestedInfo) {
+		return errWorkspacePathChanged
+	}
+	return nil
+}
+
+func observeWorkspacePath(workspacePath, relativePath string) ([]workspacePathObservation, bool, error) {
+	paths := []string{workspacePath}
+	if relativePath != "." {
+		current := workspacePath
+		for _, component := range strings.Split(relativePath, string(filepath.Separator)) {
+			current = filepath.Join(current, component)
+			paths = append(paths, current)
+		}
+	}
+
+	observations := make([]workspacePathObservation, 0, len(paths))
+	unsupportedReparse := false
+	for i, path := range paths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return nil, false, err
+		}
+		if err = pinWorkspaceFileInfo(info); err != nil {
+			return nil, false, err
+		}
+		linkKind, err := classifyWorkspaceLink(path, info)
+		if err != nil {
+			return nil, false, err
+		}
+		if i > 0 && linkKind == workspaceOtherReparse {
+			unsupportedReparse = true
+		}
+		observations = append(observations, workspacePathObservation{path: path, info: info, linkKind: linkKind})
+	}
+	return observations, unsupportedReparse, nil
+}
+
+func pinWorkspaceFileInfo(info os.FileInfo) error {
+	if info == nil || !os.SameFile(info, info) {
+		return errors.New("failed to capture filesystem identity")
+	}
+	return nil
+}
+
+func workspaceRelativePath(workspacePath, requestedPath string) (string, bool) {
+	return workspaceRelativePathForOS(workspacePath, requestedPath, runtime.GOOS)
+}
+
+func workspaceRelativePathForOS(workspacePath, requestedPath, goos string) (string, bool) {
+	workspaceCanonical := canonicalWorkspacePathForOS(workspacePath, goos)
+	requestedCanonical := canonicalWorkspacePathForOS(requestedPath, goos)
+	canonicalRelative, err := filepath.Rel(workspaceCanonical, requestedCanonical)
+	if err != nil || workspaceRelativePathEscapes(canonicalRelative) {
+		return "", false
+	}
+	if canonicalRelative == "." || canonicalRelative == "" {
+		return ".", true
+	}
+
+	requestedPath = filepath.Clean(requestedPath)
+	volume := filepath.VolumeName(requestedPath)
+	components := strings.Split(strings.TrimPrefix(requestedPath[len(volume):], string(filepath.Separator)), string(filepath.Separator))
+	relativeComponents := strings.Split(canonicalRelative, string(filepath.Separator))
+	if len(components) < len(relativeComponents) {
+		return "", false
+	}
+	return filepath.Join(components[len(components)-len(relativeComponents):]...), true
+}
+
+func workspaceRelativePathEscapes(relativePath string) bool {
+	return filepath.IsAbs(relativePath) || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator))
+}
+
+func workspacePathContains(workspacePath, requestedPath string) bool {
+	_, contained := workspaceRelativePath(workspacePath, requestedPath)
+	return contained
+}
+
+func sameCanonicalWorkspacePath(left, right string) bool {
+	return canonicalWorkspacePath(left) == canonicalWorkspacePath(right)
+}
+
+func canonicalWorkspacePath(path string) string {
+	return canonicalWorkspacePathForOS(path, runtime.GOOS)
+}
+
+func canonicalWorkspacePathForOS(path, goos string) string {
+	path = filepath.Clean(path)
+	if goos == "windows" {
+		path = strings.ToLower(path)
+	}
+	return path
+}

--- a/kernel/api/workspace_path_nonwindows.go
+++ b/kernel/api/workspace_path_nonwindows.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import "path/filepath"
+
+func resolveExistingWorkspacePath(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}

--- a/kernel/api/workspace_path_test.go
+++ b/kernel/api/workspace_path_test.go
@@ -1,0 +1,296 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWorkspacePathContainment(t *testing.T) {
+	workspace := t.TempDir()
+	inside := filepath.Join(workspace, "inside")
+	outside := t.TempDir()
+	if err := os.Mkdir(inside, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := newWorkspacePathGuard(workspace, filepath.Join("..", filepath.Base(outside))); !errors.Is(err, errWorkspacePathOutside) {
+		t.Fatalf("lexical escape returned %v", err)
+	}
+
+	escapeLink := filepath.Join(workspace, "escape")
+	if createTestSymlink(t, outside, escapeLink) {
+		if _, err := newWorkspacePathGuard(workspace, "escape"); !errors.Is(err, errWorkspacePathOutside) {
+			t.Fatalf("physical escape returned %v", err)
+		}
+	}
+
+	insideLink := filepath.Join(workspace, "inside-link")
+	if createTestSymlink(t, inside, insideLink) {
+		guard, err := newWorkspacePathGuard(workspace, "inside-link")
+		if err != nil {
+			t.Fatalf("contained link was rejected: %v", err)
+		}
+		if !guard.requestedInfo.IsDir() {
+			t.Fatal("contained directory link did not resolve to a directory")
+		}
+	}
+}
+
+func TestWorkspacePathDetectsRootReplacement(t *testing.T) {
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "workspace")
+	requested := filepath.Join(workspace, "requested")
+	if err := os.MkdirAll(requested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	guard, err := newWorkspacePathGuard(workspace, "requested")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	moved := filepath.Join(parent, "workspace-moved")
+	if err = os.Rename(workspace, moved); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.MkdirAll(requested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err = guard.revalidate(); !errors.Is(err, errWorkspacePathChanged) {
+		t.Fatalf("root replacement returned %v", err)
+	}
+}
+
+func TestWorkspacePathDetectsParentRedirect(t *testing.T) {
+	workspace := t.TempDir()
+	parent := filepath.Join(workspace, "parent")
+	requested := filepath.Join(parent, "requested")
+	if err := os.MkdirAll(requested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	guard, err := newWorkspacePathGuard(workspace, filepath.Join("parent", "requested"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	moved := filepath.Join(workspace, "parent-moved")
+	if err = os.Rename(parent, moved); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err = os.Mkdir(filepath.Join(outside, "requested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !createTestSymlink(t, outside, parent) {
+		if runtime.GOOS != "windows" {
+			return
+		}
+		createTestJunction(t, outside, parent)
+	}
+	if err = guard.revalidate(); !errors.Is(err, errWorkspacePathChanged) {
+		t.Fatalf("parent redirect returned %v", err)
+	}
+}
+
+func TestWorkspacePathRootIdentity(t *testing.T) {
+	workspace := t.TempDir()
+	guard, err := newWorkspacePathGuard(workspace, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := guard.openRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	info, err := root.Stat(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(info, guard.workspaceInfo) {
+		t.Fatal("root is not anchored to the validated workspace")
+	}
+}
+
+func TestWorkspacePathCanonicalComparison(t *testing.T) {
+	if got := canonicalWorkspacePathForOS(filepath.Join("Root", "Tree"), "windows"); got != filepath.Join("root", "tree") {
+		t.Fatalf("windows canonical path = %q", got)
+	}
+	windowsRelative, windowsContained := workspaceRelativePathForOS(
+		filepath.Join(string(filepath.Separator), "Root"),
+		filepath.Join(string(filepath.Separator), "root", "MiXeD"),
+		"windows",
+	)
+	if !windowsContained || windowsRelative != "MiXeD" {
+		t.Fatalf("windows original-case relative path = %q, contained=%t", windowsRelative, windowsContained)
+	}
+
+	for _, goos := range []string{"darwin", "linux"} {
+		if got := canonicalWorkspacePathForOS(filepath.Join("Root", "Tree"), goos); got != filepath.Join("Root", "Tree") {
+			t.Fatalf("%s canonical path = %q", goos, got)
+		}
+		relative, contained := workspaceRelativePathForOS(
+			filepath.Join(string(filepath.Separator), "Root"),
+			filepath.Join(string(filepath.Separator), "Root", "MiXeD"),
+			goos,
+		)
+		if !contained || relative != "MiXeD" {
+			t.Fatalf("%s original-case relative path = %q, contained=%t", goos, relative, contained)
+		}
+	}
+
+	if runtime.GOOS != "windows" {
+		if relative, contained := workspaceRelativePathForOS(
+			filepath.Join(string(filepath.Separator), "Root"),
+			filepath.Join(string(filepath.Separator), "root", "MiXeD"),
+			"darwin",
+		); contained || relative != "" {
+			t.Fatalf("Darwin case-distinct sibling root relative path = %q, contained=%t", relative, contained)
+		}
+	}
+}
+
+func TestWorkspacePathPreservesRequestedCaseForAccess(t *testing.T) {
+	workspace := t.TempDir()
+	mixedCaseName := "MiXeD"
+	mixedCasePath := filepath.Join(workspace, mixedCaseName)
+	if err := os.Mkdir(mixedCasePath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	guard, err := newWorkspacePathGuard(workspace, mixedCaseName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if guard.relativePath != mixedCaseName {
+		t.Fatalf("relative path = %q, want %q", guard.relativePath, mixedCaseName)
+	}
+	root, err := guard.openRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	opened, err := root.Open(guard.relativePath)
+	if err != nil {
+		t.Fatalf("open original-case relative path: %v", err)
+	}
+	opened.Close()
+
+	if runtime.GOOS == "darwin" {
+		lowerCasePath := filepath.Join(workspace, "mixed")
+		if err = os.Mkdir(lowerCasePath, 0755); err == nil {
+			lowerGuard, guardErr := newWorkspacePathGuard(workspace, "mixed")
+			if guardErr != nil {
+				t.Fatalf("case-sensitive volume lowercase access failed: %v", guardErr)
+			}
+			if lowerGuard.relativePath != "mixed" {
+				t.Fatalf("case-sensitive volume relative path = %q", lowerGuard.relativePath)
+			}
+		} else if !os.IsExist(err) {
+			t.Fatalf("probe Darwin volume case sensitivity: %v", err)
+		}
+	}
+}
+
+func TestWorkspacePathWindowsReparseHandling(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows reparse-point test")
+	}
+	workspace := t.TempDir()
+	inside := filepath.Join(workspace, "inside")
+	if err := os.Mkdir(inside, 0755); err != nil {
+		t.Fatal(err)
+	}
+	insideJunction := filepath.Join(workspace, "inside-junction")
+	createTestJunction(t, inside, insideJunction)
+	guard, err := newWorkspacePathGuard(workspace, "inside-junction")
+	if err != nil {
+		t.Fatalf("contained junction validation failed: %v", err)
+	}
+	if !guard.unsupportedReparse {
+		t.Fatal("contained junction was not classified as an unsupported reparse point")
+	}
+
+	outside := t.TempDir()
+	outsideJunction := filepath.Join(workspace, "outside-junction")
+	createTestJunction(t, outside, outsideJunction)
+	if _, err = newWorkspacePathGuard(workspace, "outside-junction"); !errors.Is(err, errWorkspacePathOutside) {
+		t.Fatalf("outside junction returned %v", err)
+	}
+}
+
+func TestWorkspacePathWindowsCrossVolumeJunction(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows cross-volume junction test")
+	}
+	workspaceBase := windowsTempDir(t, os.Getenv("LOCALAPPDATA"))
+	workspace := filepath.Join(workspaceBase, "workspace")
+	if err := os.Mkdir(workspace, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := windowsCrossVolumeTempDir(t, `D:\`)
+	junction := filepath.Join(workspace, "cross-volume")
+	createTestJunction(t, target, junction)
+	if _, err := newWorkspacePathGuard(workspace, "cross-volume"); !errors.Is(err, errWorkspacePathOutside) {
+		t.Fatalf("cross-volume junction returned %v", err)
+	}
+}
+
+func windowsTempDir(t *testing.T, parent string) string {
+	t.Helper()
+	if parent == "" {
+		t.Fatal("Windows temporary parent is unavailable")
+	}
+	path, err := os.MkdirTemp(parent, "siyuan-pr01-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(path) })
+	return path
+}
+
+func windowsCrossVolumeTempDir(t *testing.T, parent string) string {
+	t.Helper()
+	if _, err := os.Stat(parent); os.IsNotExist(err) {
+		t.Skipf("Windows cross-volume parent %s is unavailable", parent)
+	} else if err != nil {
+		t.Fatalf("inspect Windows cross-volume parent %s: %v", parent, err)
+	}
+	return windowsTempDir(t, parent)
+}
+
+func createTestSymlink(t *testing.T, target, link string) bool {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Logf("symlink privilege unavailable: %v", err)
+			return false
+		}
+		t.Fatal(err)
+	}
+	return true
+}
+
+func createTestJunction(t *testing.T, target, link string) {
+	t.Helper()
+	output, err := exec.Command("cmd", "/c", "mklink", "/J", link, target).CombinedOutput()
+	if err != nil {
+		t.Fatalf("create junction failed: %v: %s", err, output)
+	}
+}
+
+func createTestRelativeDirectorySymlink(t *testing.T, target, link string) bool {
+	t.Helper()
+	output, err := exec.Command("cmd", "/c", "mklink", "/D", link, target).CombinedOutput()
+	if err != nil {
+		t.Logf("directory symlink privilege unavailable: %v: %s", err, output)
+		return false
+	}
+	return true
+}

--- a/kernel/api/workspace_path_windows.go
+++ b/kernel/api/workspace_path_windows.go
@@ -1,0 +1,53 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+
+package api
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func resolveExistingWorkspacePath(path string) (string, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return "", err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(handle)
+
+	buffer := make([]uint16, windows.MAX_PATH)
+	for {
+		length, finalErr := windows.GetFinalPathNameByHandle(handle, &buffer[0], uint32(len(buffer)), 0)
+		if finalErr == nil && length < uint32(len(buffer)) {
+			return normalizeWindowsFinalPath(windows.UTF16ToString(buffer[:length])), nil
+		}
+		if length >= uint32(len(buffer)) {
+			buffer = make([]uint16, length+1)
+			continue
+		}
+		return "", finalErr
+	}
+}
+
+func normalizeWindowsFinalPath(path string) string {
+	if strings.HasPrefix(path, `\\?\UNC\`) {
+		path = `\\` + strings.TrimPrefix(path, `\\?\UNC\`)
+	} else {
+		path = strings.TrimPrefix(path, `\\?\`)
+	}
+	return filepath.Clean(path)
+}

--- a/kernel/plugin/api_storage.go
+++ b/kernel/plugin/api_storage.go
@@ -18,13 +18,11 @@ package plugin
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/samber/lo"
-	"github.com/siyuan-note/filelock"
 	"github.com/siyuan-note/logging"
 	"github.com/siyuan-note/siyuan/kernel/util"
 )
@@ -162,25 +160,20 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 				err = argErr
 				return
 			}
-			abs, resolveErr := resolvePath(path)
-			if resolveErr != nil {
-				err = resolveErr
-				return
-			}
-
 			go func() (result []byte, err error) {
 				defer func() {
 					if r := recover(); r != nil {
 						err = fmt.Errorf("panic during siyuan.storage.get: %v", r)
 					}
+					operationResult, operationErr := result, err
 					p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
-						if err != nil {
-							return nil, err
+						if operationErr != nil {
+							return nil, operationErr
 						}
 
 						content := rt.NewObject()
-						if err = ObjectSetDataMethods(p, rt, content, result); err != nil {
-							return nil, err
+						if dataErr := ObjectSetDataMethods(p, rt, content, operationResult); dataErr != nil {
+							return nil, dataErr
 						}
 
 						return content, nil
@@ -197,13 +190,7 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 					})
 				}()
 
-				data, readErr := filelock.ReadFile(abs)
-				if readErr != nil {
-					err = readErr
-					return
-				}
-
-				result = data
+				result, err = p.storageGet(path)
 				return
 			}()
 
@@ -248,25 +235,20 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 				return
 			}
 
-			abs, resolveErr := resolvePath(path)
-			if resolveErr != nil {
-				err = resolveErr
-				return
-			}
-
 			go func() (result any, err error) {
 				defer func() {
 					if r := recover(); r != nil {
 						err = fmt.Errorf("panic during siyuan.storage.put: %v", r)
 					}
 
+					operationResult, operationErr := result, err
 					p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
-						if lo.IsNil(err) {
-							if resolveErr := resolve(result); resolveErr != nil {
+						if lo.IsNil(operationErr) {
+							if resolveErr := resolve(operationResult); resolveErr != nil {
 								logging.LogErrorf("[plugin:%s] siyuan.storage.put resolve: %v", p.Name, resolveErr)
 							}
 						} else {
-							if rejectErr := reject(rt.NewGoError(err)); rejectErr != nil {
+							if rejectErr := reject(rt.NewGoError(operationErr)); rejectErr != nil {
 								logging.LogErrorf("[plugin:%s] siyuan.storage.put reject: %v", p.Name, rejectErr)
 							}
 						}
@@ -274,11 +256,7 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 					}, nil)
 				}()
 
-				if mkdirErr := os.MkdirAll(filepath.Dir(abs), 0755); mkdirErr != nil {
-					err = fmt.Errorf("failed to make directory: %w", mkdirErr)
-					return
-				}
-				if writeErr := filelock.WriteFile(abs, []byte(content)); writeErr != nil {
+				if writeErr := p.storagePut(path, []byte(content)); writeErr != nil {
 					err = fmt.Errorf("failed to write file: %w", writeErr)
 					return
 				}
@@ -325,29 +303,20 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 				return
 			}
 
-			abs, resolveErr := resolvePath(path)
-			if resolveErr != nil {
-				err = resolveErr
-				return
-			}
-			if abs == p.storageDir {
-				err = fmt.Errorf("cannot remove storage root")
-				return
-			}
-
 			go func() (result any, err error) {
 				defer func() {
 					if r := recover(); r != nil {
 						err = fmt.Errorf("panic during siyuan.storage.remove: %v", r)
 					}
 
+					operationResult, operationErr := result, err
 					p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
-						if lo.IsNil(err) {
-							if resolveErr := resolve(result); resolveErr != nil {
+						if lo.IsNil(operationErr) {
+							if resolveErr := resolve(operationResult); resolveErr != nil {
 								logging.LogErrorf("[plugin:%s] siyuan.storage.remove resolve: %v", p.Name, resolveErr)
 							}
 						} else {
-							if rejectErr := reject(rt.NewGoError(err)); rejectErr != nil {
+							if rejectErr := reject(rt.NewGoError(operationErr)); rejectErr != nil {
 								logging.LogErrorf("[plugin:%s] siyuan.storage.remove reject: %v", p.Name, rejectErr)
 							}
 						}
@@ -355,7 +324,7 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 					}, nil)
 				}()
 
-				if removeErr := os.RemoveAll(abs); removeErr != nil {
+				if removeErr := p.storageRemove(path); removeErr != nil {
 					err = fmt.Errorf("failed to remove: %w", removeErr)
 					return
 				}
@@ -397,24 +366,20 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 				err = argErr
 				return
 			}
-			abs, resolveErr := resolvePath(path)
-			if resolveErr != nil {
-				err = resolveErr
-				return
-			}
 
 			go func() (result any, err error) {
 				defer func() {
 					if r := recover(); r != nil {
 						err = fmt.Errorf("panic during siyuan.storage.list: %v", r)
 					}
+					operationResult, operationErr := result, err
 					p.worker.Run(func(rt *goja.Runtime) (_ any, _ error) {
-						if lo.IsNil(err) {
-							if resolveErr := resolve(result); resolveErr != nil {
+						if lo.IsNil(operationErr) {
+							if resolveErr := resolve(operationResult); resolveErr != nil {
 								logging.LogErrorf("[plugin:%s] siyuan.storage.list resolve: %v", p.Name, resolveErr)
 							}
 						} else {
-							if rejectErr := reject(rt.NewGoError(err)); rejectErr != nil {
+							if rejectErr := reject(rt.NewGoError(operationErr)); rejectErr != nil {
 								logging.LogErrorf("[plugin:%s] siyuan.storage.list reject: %v", p.Name, rejectErr)
 							}
 						}
@@ -422,27 +387,7 @@ func injectStorage(p *KernelPlugin, rt *goja.Runtime, siyuan *goja.Object) (err 
 					}, nil)
 				}()
 
-				entries, readErr := os.ReadDir(abs)
-				if readErr != nil {
-					err = fmt.Errorf("failed to read directory: %w", readErr)
-					return
-				}
-
-				results := make([]R, 0, len(entries))
-				for _, entry := range entries {
-					info, infoErr := entry.Info()
-					if infoErr != nil {
-						continue
-					}
-					results = append(results, R{
-						"name":      entry.Name(),
-						"isDir":     info.IsDir(),
-						"isSymlink": util.IsSymlink(entry),
-						"updated":   info.ModTime().Unix(),
-					})
-				}
-
-				result = results
+				result, err = p.storageList(path)
 				return
 			}()
 

--- a/kernel/plugin/api_storage_test.go
+++ b/kernel/plugin/api_storage_test.go
@@ -1,0 +1,241 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/eventloop"
+	"github.com/siyuan-note/siyuan/kernel/model"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+type storageScriptResult struct {
+	value string
+	err   error
+}
+
+func runInjectStorageScript(t *testing.T, plugin *KernelPlugin, body string) string {
+	t.Helper()
+	loop := eventloop.NewEventLoop()
+	plugin.worker.Start(loop)
+	loop.Start()
+	defer loop.Stop()
+
+	completed := make(chan storageScriptResult, 1)
+	if ok := loop.RunOnLoop(func(rt *goja.Runtime) {
+		siyuan := rt.NewObject()
+		if err := injectStorage(plugin, rt, siyuan); err != nil {
+			completed <- storageScriptResult{err: err}
+			return
+		}
+		if err := rt.Set("siyuan", siyuan); err != nil {
+			completed <- storageScriptResult{err: err}
+			return
+		}
+		if err := rt.Set("__storageTestDone", func(call goja.FunctionCall) goja.Value {
+			completed <- storageScriptResult{value: call.Argument(0).String()}
+			return goja.Undefined()
+		}); err != nil {
+			completed <- storageScriptResult{err: err}
+			return
+		}
+		if err := rt.Set("__storageTestFail", func(call goja.FunctionCall) goja.Value {
+			completed <- storageScriptResult{err: fmt.Errorf("%s", call.Argument(0).String())}
+			return goja.Undefined()
+		}); err != nil {
+			completed <- storageScriptResult{err: err}
+			return
+		}
+		script := `(async () => {` + body + `})().then(
+			(value) => __storageTestDone(JSON.stringify(value)),
+			(error) => __storageTestFail(String(error && error.message ? error.message : error))
+		);`
+		if _, err := rt.RunString(script); err != nil {
+			completed <- storageScriptResult{err: err}
+		}
+	}); !ok {
+		t.Fatal("failed to schedule storage script")
+	}
+
+	select {
+	case result := <-completed:
+		if result.err != nil {
+			t.Fatalf("storage script failed: %v", result.err)
+		}
+		return result.value
+	case <-time.After(10 * time.Second):
+		t.Fatal("storage script timed out")
+		return ""
+	}
+}
+
+func newInjectStorageTestPlugin(t *testing.T) (*KernelPlugin, string) {
+	t.Helper()
+	plugin, storageDir := newStorageTestPlugin(t)
+	plugin.Petal = &model.Petal{Name: "storage-test"}
+	return plugin, storageDir
+}
+
+func decodeStorageScriptResult(t *testing.T, value string) map[string]any {
+	t.Helper()
+	result := map[string]any{}
+	if err := json.Unmarshal([]byte(value), &result); err != nil {
+		t.Fatalf("decode %q: %v", value, err)
+	}
+	return result
+}
+
+func TestInjectStorageMethodsArgumentsAndFrozenObjects(t *testing.T) {
+	plugin, _ := newInjectStorageTestPlugin(t)
+	result := decodeStorageScriptResult(t, runInjectStorageScript(t, plugin, `
+		const storage = siyuan.storage;
+		async function rejection(call) {
+			try {
+				await call();
+				return "";
+			} catch (error) {
+				return String(error && error.message ? error.message : error);
+			}
+		}
+		const missing = {
+			get: await rejection(() => storage.get()),
+			put: await rejection(() => storage.put("only-path")),
+			remove: await rejection(() => storage.remove()),
+			list: await rejection(() => storage.list())
+		};
+		await storage.put(7, 8);
+		const converted = await (await storage.get("7")).text();
+		return {
+			methods: Object.keys(storage).sort(),
+			watcherMethods: Object.keys(storage.watcher).sort(),
+			storageFrozen: Object.isFrozen(storage),
+			watcherFrozen: Object.isFrozen(storage.watcher),
+			missing,
+			converted
+		};
+	`))
+
+	methods, _ := json.Marshal(result["methods"])
+	if string(methods) != `["get","list","put","remove","watcher"]` {
+		t.Fatalf("unexpected storage methods: %s", methods)
+	}
+	watcherMethods, _ := json.Marshal(result["watcherMethods"])
+	if string(watcherMethods) != `["add","remove"]` {
+		t.Fatalf("unexpected watcher methods: %s", watcherMethods)
+	}
+	if result["storageFrozen"] != true || result["watcherFrozen"] != true {
+		t.Fatalf("storage objects are not frozen: %#v", result)
+	}
+	missing := result["missing"].(map[string]any)
+	for method, message := range missing {
+		if !strings.Contains(message.(string), "required") {
+			t.Fatalf("%s missing-argument error = %q", method, message)
+		}
+	}
+	if result["converted"] != "8" {
+		t.Fatalf("put argument conversion = %#v", result["converted"])
+	}
+}
+
+func TestInjectStorageCRUDPromisesAndDataMethods(t *testing.T) {
+	plugin, storageDir := newInjectStorageTestPlugin(t)
+	result := decodeStorageScriptResult(t, runInjectStorageScript(t, plugin, `
+		const putValue = await siyuan.storage.put("nested/value.json", '{"answer":42}');
+		const data = await siyuan.storage.get("nested/value.json");
+		const text = await data.text();
+		const parsed = await data.json();
+		const buffer = await data.buffer();
+		const arrayBuffer = await data.arrayBuffer();
+		const entries = await siyuan.storage.list("nested");
+		const removeValue = await siyuan.storage.remove("nested/value.json");
+		let missing = "";
+		try {
+			await siyuan.storage.get("nested/value.json");
+		} catch (error) {
+			missing = String(error && error.message ? error.message : error);
+		}
+		return {
+			putNull: putValue === null,
+			text,
+			answer: parsed.answer,
+			bufferLength: buffer.length,
+			arrayBufferLength: arrayBuffer.byteLength,
+			entry: entries[0],
+			removeNull: removeValue === null,
+			missing
+		};
+	`))
+
+	if result["putNull"] != true || result["removeNull"] != true {
+		t.Fatalf("unexpected mutation resolve values: %#v", result)
+	}
+	if result["text"] != `{"answer":42}` || result["answer"] != float64(42) || result["bufferLength"] != float64(13) ||
+		result["arrayBufferLength"] != float64(13) {
+		t.Fatalf("unexpected data method result: %#v", result)
+	}
+	entry := result["entry"].(map[string]any)
+	if entry["name"] != "value.json" || entry["isDir"] != false || entry["isSymlink"] != false {
+		t.Fatalf("unexpected list entry: %#v", entry)
+	}
+	if result["missing"] == "" {
+		t.Fatal("missing file did not reject")
+	}
+	if _, err := os.Lstat(filepath.Join(storageDir, "nested", "value.json")); !os.IsNotExist(err) {
+		t.Fatalf("remove did not delete file: %v", err)
+	}
+}
+
+func TestInjectStorageReadOnly(t *testing.T) {
+	plugin, storageDir := newInjectStorageTestPlugin(t)
+	if err := os.WriteFile(filepath.Join(storageDir, "value"), []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	previousReadOnly := util.ReadOnly
+	util.ReadOnly = true
+	defer func() { util.ReadOnly = previousReadOnly }()
+
+	result := decodeStorageScriptResult(t, runInjectStorageScript(t, plugin, `
+		async function rejection(call) {
+			try {
+				await call();
+				return "";
+			} catch (error) {
+				return String(error && error.message ? error.message : error);
+			}
+		}
+		const text = await (await siyuan.storage.get("value")).text();
+		const entries = await siyuan.storage.list("");
+		return {
+			text,
+			entryCount: entries.length,
+			putError: await rejection(() => siyuan.storage.put("value", "changed")),
+			removeError: await rejection(() => siyuan.storage.remove("value"))
+		};
+	`))
+
+	if result["text"] != "original" || result["entryCount"] != float64(1) {
+		t.Fatalf("read operations changed in read-only mode: %#v", result)
+	}
+	if !strings.Contains(result["putError"].(string), "read-only") ||
+		!strings.Contains(result["removeError"].(string), "read-only") {
+		t.Fatalf("mutations were not rejected in read-only mode: %#v", result)
+	}
+	data, err := os.ReadFile(filepath.Join(storageDir, "value"))
+	if err != nil || string(data) != "original" {
+		t.Fatalf("read-only mutation changed data %q: %v", data, err)
+	}
+}

--- a/kernel/plugin/plugin.go
+++ b/kernel/plugin/plugin.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -266,9 +265,8 @@ func (p *KernelPlugin) start() (err error) {
 
 	p.updateState(PluginStateLoading)
 
-	baseDir := filepath.Join(util.DataDir, "storage", "petal", p.Name)
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		return fmt.Errorf("create plugin dir [%s] failed: %s", baseDir, err)
+	if err := p.ensureStorageRoot(); err != nil {
+		return fmt.Errorf("create plugin storage root [%s] failed: %w", p.storageDir, err)
 	}
 
 	if runtimeErr := p.InitRuntime(); runtimeErr != nil {

--- a/kernel/plugin/storage_link_nonwindows.go
+++ b/kernel/plugin/storage_link_nonwindows.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import "os"
+
+func storagePathInfoIsLink(info os.FileInfo) bool {
+	return info != nil && info.Mode()&os.ModeSymlink != 0
+}

--- a/kernel/plugin/storage_link_windows.go
+++ b/kernel/plugin/storage_link_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"os"
+	"syscall"
+)
+
+func storagePathInfoIsLink(info os.FileInfo) bool {
+	if info == nil || info.Mode()&os.ModeSymlink != 0 {
+		return info != nil
+	}
+	data, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	return ok && data.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0
+}

--- a/kernel/plugin/storage_lock.go
+++ b/kernel/plugin/storage_lock.go
@@ -1,0 +1,36 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"errors"
+	"sync"
+)
+
+// Locks are shared in-process by normalized storage root and never retired, so
+// detached CRUD from an old generation and a new startup use the same lock.
+// This lock coordinates only SiYuan operations; physical path isolation from
+// external concurrent moves of open directories is out of scope.
+var storageTreeLocks sync.Map
+
+func storageTreeLock(storageDir string) (*sync.RWMutex, error) {
+	key, err := normalizeStorageRootLockKey(storageDir)
+	if err != nil {
+		return nil, err
+	}
+	lock, _ := storageTreeLocks.LoadOrStore(key, &sync.RWMutex{})
+	return lock.(*sync.RWMutex), nil
+}
+
+func (p *KernelPlugin) storageTreeLock() (*sync.RWMutex, error) {
+	if p == nil {
+		return nil, errors.New("siyuan.storage: storage root is unavailable")
+	}
+	return storageTreeLock(p.storageDir)
+}

--- a/kernel/plugin/storage_open_nonwindows.go
+++ b/kernel/plugin/storage_open_nonwindows.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"os"
+	"syscall"
+)
+
+func openStorageFileForRead(parent *os.Root, name string) (*os.File, error) {
+	return parent.OpenFile(name, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}

--- a/kernel/plugin/storage_open_windows.go
+++ b/kernel/plugin/storage_open_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import "os"
+
+func openStorageFileForRead(parent *os.Root, name string) (*os.File, error) {
+	return parent.OpenFile(name, os.O_RDONLY, 0)
+}

--- a/kernel/plugin/storage_path_nonwindows.go
+++ b/kernel/plugin/storage_path_nonwindows.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+func validStoragePathComponent(component string) bool {
+	return component != "" && component != "." && component != ".." && !strings.ContainsRune(component, 0)
+}
+
+func normalizeStorageRootLockKey(storageDir string) (string, error) {
+	if storageDir == "" {
+		return "", errors.New("siyuan.storage: storage root is unavailable")
+	}
+	return filepath.Abs(filepath.Clean(storageDir))
+}

--- a/kernel/plugin/storage_path_windows.go
+++ b/kernel/plugin/storage_path_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+func validStoragePathComponent(component string) bool {
+	if component == "" || component == "." || component == ".." || strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") {
+		return false
+	}
+	for _, char := range component {
+		if char < 0x20 || strings.ContainsRune(`<>:"/\|?*`, char) {
+			return false
+		}
+	}
+	base := component
+	if index := strings.IndexByte(base, '.'); index >= 0 {
+		base = base[:index]
+	}
+	switch strings.ToUpper(base) {
+	case "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		return false
+	}
+	return true
+}
+
+func normalizeStorageRootLockKey(storageDir string) (string, error) {
+	if storageDir == "" {
+		return "", errors.New("siyuan.storage: storage root is unavailable")
+	}
+	absolute, err := filepath.Abs(filepath.Clean(storageDir))
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(absolute), nil
+}

--- a/kernel/plugin/storage_rename_nonwindows.go
+++ b/kernel/plugin/storage_rename_nonwindows.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"context"
+	"os"
+)
+
+func commitStorageRename(ctx context.Context, root *os.Root, oldName, newName string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return root.Rename(oldName, newName)
+}

--- a/kernel/plugin/storage_rename_windows.go
+++ b/kernel/plugin/storage_rename_windows.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	storageRenameRetryCount = 3
+	storageRenameRetryDelay = 200 * time.Millisecond
+)
+
+func storageRenameErrorIsTransient(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}
+
+func waitStorageRenameRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func retryStorageRename(ctx context.Context, rename func() error, wait func(context.Context, time.Duration) error) error {
+	for retry := 0; ; retry++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := rename()
+		if err == nil || retry >= storageRenameRetryCount || !storageRenameErrorIsTransient(err) {
+			return err
+		}
+		if err = wait(ctx, storageRenameRetryDelay); err != nil {
+			return err
+		}
+	}
+}
+
+func commitStorageRename(ctx context.Context, root *os.Root, oldName, newName string) error {
+	return retryStorageRename(ctx, func() error {
+		return root.Rename(oldName, newName)
+	}, waitStorageRenameRetry)
+}

--- a/kernel/plugin/storage_rename_windows_test.go
+++ b/kernel/plugin/storage_rename_windows_test.go
@@ -1,0 +1,102 @@
+//go:build windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func storageRenameTestError(err error) error {
+	return &os.LinkError{Op: "rename", Old: "old", New: "new", Err: err}
+}
+
+func TestStorageRenameRetryPolicy(t *testing.T) {
+	t.Run("transient success", func(t *testing.T) {
+		attempts := 0
+		waits := 0
+		err := retryStorageRename(context.Background(), func() error {
+			attempts++
+			if attempts < 3 {
+				return storageRenameTestError(windows.ERROR_SHARING_VIOLATION)
+			}
+			return nil
+		}, func(_ context.Context, delay time.Duration) error {
+			waits++
+			if delay != storageRenameRetryDelay {
+				t.Fatalf("retry delay = %v", delay)
+			}
+			return nil
+		})
+		if err != nil || attempts != 3 || waits != 2 {
+			t.Fatalf("retry result err=%v attempts=%d waits=%d", err, attempts, waits)
+		}
+	})
+
+	t.Run("transient classes", func(t *testing.T) {
+		for _, transient := range []error{windows.ERROR_SHARING_VIOLATION, windows.ERROR_ACCESS_DENIED,
+			windows.ERROR_LOCK_VIOLATION} {
+			if !storageRenameErrorIsTransient(storageRenameTestError(transient)) {
+				t.Errorf("error %v was not classified as transient", transient)
+			}
+		}
+	})
+
+	t.Run("non transient", func(t *testing.T) {
+		attempts := 0
+		waits := 0
+		err := retryStorageRename(context.Background(), func() error {
+			attempts++
+			return storageRenameTestError(windows.ERROR_FILE_NOT_FOUND)
+		}, func(context.Context, time.Duration) error {
+			waits++
+			return nil
+		})
+		if !errors.Is(err, windows.ERROR_FILE_NOT_FOUND) || attempts != 1 || waits != 0 {
+			t.Fatalf("retry result err=%v attempts=%d waits=%d", err, attempts, waits)
+		}
+	})
+
+	t.Run("retry limit", func(t *testing.T) {
+		attempts := 0
+		waits := 0
+		err := retryStorageRename(context.Background(), func() error {
+			attempts++
+			return storageRenameTestError(windows.ERROR_LOCK_VIOLATION)
+		}, func(context.Context, time.Duration) error {
+			waits++
+			return nil
+		})
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) || attempts != 4 || waits != 3 {
+			t.Fatalf("retry result err=%v attempts=%d waits=%d", err, attempts, waits)
+		}
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		attempts := 0
+		err := retryStorageRename(ctx, func() error {
+			attempts++
+			return storageRenameTestError(windows.ERROR_ACCESS_DENIED)
+		}, func(context.Context, time.Duration) error {
+			cancel()
+			return ctx.Err()
+		})
+		if !errors.Is(err, context.Canceled) || attempts != 1 {
+			t.Fatalf("retry result err=%v attempts=%d", err, attempts)
+		}
+	})
+}

--- a/kernel/plugin/storage_safe.go
+++ b/kernel/plugin/storage_safe.go
@@ -1,0 +1,740 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/siyuan-note/filelock"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+func (p *KernelPlugin) storageContext() context.Context {
+	if p != nil && p.context != nil {
+		return p.context
+	}
+	return context.Background()
+}
+
+func (p *KernelPlugin) cleanStoragePath(relPath string, allowRoot bool) (relative, absolute string, err error) {
+	if p == nil || p.storageDir == "" {
+		return "", "", errors.New("siyuan.storage: storage root is unavailable")
+	}
+	if relPath == "" {
+		relPath = "."
+	}
+	if filepath.IsAbs(relPath) || filepath.VolumeName(relPath) != "" {
+		return "", "", errors.New("siyuan.storage: invalid path")
+	}
+	if relPath != "." {
+		for _, component := range strings.Split(filepath.ToSlash(relPath), "/") {
+			if !validStoragePathComponent(component) {
+				return "", "", errors.New("siyuan.storage: invalid path component")
+			}
+		}
+	}
+	relative = filepath.Clean(relPath)
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", "", errors.New("siyuan.storage: path traversal not allowed")
+	}
+	if !allowRoot && relative == "." {
+		return "", "", errors.New("siyuan.storage: storage root is not a valid file target")
+	}
+	absolute = filepath.Join(p.storageDir, relative)
+	return relative, absolute, nil
+}
+
+func relativePathInside(root, target string) (string, bool) {
+	relative, err := filepath.Rel(root, target)
+	if err != nil || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return relative, true
+}
+
+func (p *KernelPlugin) openStorageRoot(create bool) (*os.Root, error) {
+	if p == nil || p.storageDir == "" {
+		return nil, errors.New("siyuan.storage: storage root is unavailable")
+	}
+	workspaceDir, err := filepath.Abs(util.WorkspaceDir)
+	if err != nil {
+		return nil, err
+	}
+	storageDir, err := filepath.Abs(p.storageDir)
+	if err != nil {
+		return nil, err
+	}
+	relative, inside := relativePathInside(workspaceDir, storageDir)
+	if !inside || relative == "." {
+		return nil, errors.New("siyuan.storage: storage root is outside workspace")
+	}
+	workspaceRoot, err := os.OpenRoot(workspaceDir)
+	if err != nil {
+		return nil, err
+	}
+	defer workspaceRoot.Close()
+	storageRoot, err := openStorageDescendantNoLinks(p.storageContext(), workspaceRoot, relative, create)
+	if err != nil {
+		return nil, fmt.Errorf("siyuan.storage: open storage root: %w", err)
+	}
+	return storageRoot, nil
+}
+
+func (p *KernelPlugin) ensureStorageRoot() error {
+	ctx := p.storageContext()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	treeLock, err := p.storageTreeLock()
+	if err != nil {
+		return err
+	}
+	treeLock.Lock()
+	defer treeLock.Unlock()
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	root, err := p.openStorageRoot(true)
+	if err != nil {
+		return fmt.Errorf("siyuan.storage: create storage root: %w", err)
+	}
+	defer root.Close()
+	rootIdentity, err := root.Stat(".")
+	if err != nil {
+		return err
+	}
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	return p.validateStorageRootIdentity(rootIdentity)
+}
+
+func openStorageDescendantNoLinks(ctx context.Context, base *os.Root, relative string, create bool) (*os.Root, error) {
+	relative = filepath.Clean(relative)
+	if relative == "." || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil, errors.New("storage directory is outside its root")
+	}
+	current := base
+	currentOwned := false
+	closeCurrent := func() {
+		if currentOwned {
+			_ = current.Close()
+		}
+	}
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		if err := ctx.Err(); err != nil {
+			closeCurrent()
+			return nil, err
+		}
+		if !validStoragePathComponent(component) {
+			closeCurrent()
+			return nil, errors.New("invalid storage directory component")
+		}
+		before, statErr := current.Lstat(component)
+		if os.IsNotExist(statErr) && create {
+			if mkdirErr := current.Mkdir(component, 0755); mkdirErr != nil && !os.IsExist(mkdirErr) {
+				closeCurrent()
+				return nil, mkdirErr
+			}
+			before, statErr = current.Lstat(component)
+		}
+		if statErr != nil {
+			closeCurrent()
+			return nil, statErr
+		}
+		if storagePathInfoIsLink(before) || !before.IsDir() {
+			closeCurrent()
+			return nil, errors.New("storage directory contains a link or non-directory component")
+		}
+		next, openErr := current.OpenRoot(component)
+		if openErr != nil {
+			closeCurrent()
+			return nil, openErr
+		}
+		after, afterErr := current.Lstat(component)
+		opened, openedErr := next.Stat(".")
+		if afterErr != nil || openedErr != nil || storagePathInfoIsLink(after) || !after.IsDir() || !os.SameFile(before, after) || !os.SameFile(after, opened) {
+			_ = next.Close()
+			closeCurrent()
+			if afterErr != nil {
+				return nil, afterErr
+			}
+			if openedErr != nil {
+				return nil, openedErr
+			}
+			return nil, errors.New("storage directory changed or resolved through a link")
+		}
+		closeCurrent()
+		current = next
+		currentOwned = true
+	}
+	if !currentOwned {
+		return nil, errors.New("storage directory path is empty")
+	}
+	return current, nil
+}
+
+func openStorageParentNoLinks(ctx context.Context, root *os.Root, relative string, create bool) (parent *os.Root, parentRelative, base string, err error) {
+	parentRelative, base = filepath.Dir(relative), filepath.Base(relative)
+	if parentRelative == "." {
+		parent, err = root.OpenRoot(".")
+		return
+	}
+	parent, err = openStorageDescendantNoLinks(ctx, root, parentRelative, create)
+	return
+}
+
+func openStorageEntry(parent *os.Root, name string) (*os.File, os.FileInfo, error) {
+	before, err := parent.Lstat(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if storagePathInfoIsLink(before) || !before.Mode().IsRegular() {
+		return nil, nil, errors.New("storage target is not a regular file")
+	}
+	file, err := openStorageFileForRead(parent, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	opened, openedErr := file.Stat()
+	after, afterErr := parent.Lstat(name)
+	if openedErr != nil || afterErr != nil || storagePathInfoIsLink(after) || !opened.Mode().IsRegular() || !after.Mode().IsRegular() || !os.SameFile(before, opened) || !os.SameFile(before, after) {
+		_ = file.Close()
+		if openedErr != nil {
+			return nil, nil, openedErr
+		}
+		if afterErr != nil {
+			return nil, nil, afterErr
+		}
+		return nil, nil, errors.New("storage target changed or resolved through a link")
+	}
+	return file, opened, nil
+}
+
+func openStorageDirectory(parent *os.Root, name string) (*os.Root, os.FileInfo, error) {
+	before, err := parent.Lstat(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if storagePathInfoIsLink(before) || !before.IsDir() {
+		return nil, nil, errors.New("storage target is not a real directory")
+	}
+	directory, err := parent.OpenRoot(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	opened, openedErr := directory.Stat(".")
+	after, afterErr := parent.Lstat(name)
+	if openedErr != nil || afterErr != nil || storagePathInfoIsLink(after) || !after.IsDir() || !os.SameFile(before, opened) || !os.SameFile(before, after) {
+		_ = directory.Close()
+		if openedErr != nil {
+			return nil, nil, openedErr
+		}
+		if afterErr != nil {
+			return nil, nil, afterErr
+		}
+		return nil, nil, errors.New("storage directory changed or resolved through a link")
+	}
+	return directory, opened, nil
+}
+
+func validateStorageEntryIdentity(parent *os.Root, name string, expected os.FileInfo, requireRegular bool) error {
+	current, err := parent.Lstat(name)
+	if err != nil {
+		return err
+	}
+	if storagePathInfoIsLink(current) || !os.SameFile(expected, current) {
+		return errors.New("storage target identity changed")
+	}
+	if requireRegular && !current.Mode().IsRegular() {
+		return errors.New("storage target is not a regular file")
+	}
+	return nil
+}
+
+func validateStorageDirectoryBinding(ctx context.Context, root, parent *os.Root, parentRelative string) error {
+	opened, err := parent.Stat(".")
+	if err != nil {
+		return err
+	}
+	if parentRelative == "." {
+		current, statErr := root.Stat(".")
+		if statErr != nil {
+			return statErr
+		}
+		if !os.SameFile(opened, current) {
+			return errors.New("storage parent directory identity changed")
+		}
+		return nil
+	}
+	current, err := openStorageDescendantNoLinks(ctx, root, parentRelative, false)
+	if err != nil {
+		return err
+	}
+	defer current.Close()
+	currentInfo, err := current.Stat(".")
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(opened, currentInfo) {
+		return errors.New("storage parent directory identity changed")
+	}
+	return nil
+}
+
+func (p *KernelPlugin) validateStorageRootIdentity(expected os.FileInfo) error {
+	current, err := p.openStorageRoot(false)
+	if err != nil {
+		return err
+	}
+	defer current.Close()
+	currentInfo, err := current.Stat(".")
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(expected, currentInfo) {
+		return errors.New("siyuan.storage: storage root identity changed")
+	}
+	return nil
+}
+
+type storageContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *storageContextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(buffer)
+}
+
+func readStorageFileWithContext(ctx context.Context, file *os.File) ([]byte, error) {
+	return io.ReadAll(&storageContextReader{ctx: ctx, reader: file})
+}
+
+func createStorageTemp(ctx context.Context, parent *os.Root, data []byte) (name string, info os.FileInfo, err error) {
+	if err = ctx.Err(); err != nil {
+		return
+	}
+	name = ".siyuan-storage-" + uuid.NewString() + ".tmp"
+	temp, err := parent.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return "", nil, err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = temp.Close()
+		}
+		if err != nil {
+			_ = parent.Remove(name)
+		}
+	}()
+	if _, err = io.Copy(temp, &storageContextReader{ctx: ctx, reader: bytes.NewReader(data)}); err != nil {
+		return
+	}
+	if err = ctx.Err(); err != nil {
+		return
+	}
+	if err = temp.Sync(); err != nil {
+		return
+	}
+	if err = temp.Chmod(0644); err != nil {
+		return
+	}
+	if info, err = temp.Stat(); err != nil {
+		return
+	}
+	err = temp.Close()
+	closed = true
+	return
+}
+
+func (p *KernelPlugin) storageGet(relPath string) ([]byte, error) {
+	ctx := p.storageContext()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	relative, absolute, err := p.cleanStoragePath(relPath, false)
+	if err != nil {
+		return nil, err
+	}
+	treeLock, err := p.storageTreeLock()
+	if err != nil {
+		return nil, err
+	}
+	treeLock.RLock()
+	defer treeLock.RUnlock()
+	if err = ctx.Err(); err != nil {
+		return nil, err
+	}
+	filelock.Lock(absolute)
+	defer filelock.Unlock(absolute)
+	if err = ctx.Err(); err != nil {
+		return nil, err
+	}
+	root, err := p.openStorageRoot(false)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	rootIdentity, err := root.Stat(".")
+	if err != nil {
+		return nil, err
+	}
+	parent, parentRelative, base, err := openStorageParentNoLinks(ctx, root, relative, false)
+	if err != nil {
+		return nil, err
+	}
+	defer parent.Close()
+	file, info, err := openStorageEntry(parent, base)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("storage target is not a regular file")
+	}
+	data, err := readStorageFileWithContext(ctx, file)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateStorageEntryIdentity(parent, base, info, true); err != nil {
+		return nil, err
+	}
+	if err = validateStorageDirectoryBinding(ctx, root, parent, parentRelative); err != nil {
+		return nil, err
+	}
+	if err = p.validateStorageRootIdentity(rootIdentity); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (p *KernelPlugin) storagePut(relPath string, data []byte) error {
+	ctx := p.storageContext()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	relative, absolute, err := p.cleanStoragePath(relPath, false)
+	if err != nil {
+		return err
+	}
+	treeLock, err := p.storageTreeLock()
+	if err != nil {
+		return err
+	}
+	treeLock.Lock()
+	defer treeLock.Unlock()
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	filelock.Lock(absolute)
+	defer filelock.Unlock(absolute)
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	root, err := p.openStorageRoot(false)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	rootIdentity, err := root.Stat(".")
+	if err != nil {
+		return err
+	}
+	parent, parentRelative, base, err := openStorageParentNoLinks(ctx, root, relative, true)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	var existing os.FileInfo
+	existed := false
+	if existing, err = parent.Lstat(base); err == nil {
+		existed = true
+		if storagePathInfoIsLink(existing) || !existing.Mode().IsRegular() {
+			return errors.New("storage target is not a regular file")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	tempName, tempIdentity, err := createStorageTemp(ctx, parent, data)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = parent.Remove(tempName)
+		}
+	}()
+	current, statErr := parent.Lstat(base)
+	if existed {
+		if statErr != nil || storagePathInfoIsLink(current) || !current.Mode().IsRegular() || !os.SameFile(existing, current) {
+			return errors.New("storage target identity changed before commit")
+		}
+	} else if !os.IsNotExist(statErr) {
+		if statErr != nil {
+			return statErr
+		}
+		return errors.New("storage target appeared before commit")
+	}
+	if err = validateStorageDirectoryBinding(ctx, root, parent, parentRelative); err != nil {
+		return err
+	}
+	if err = p.validateStorageRootIdentity(rootIdentity); err != nil {
+		return err
+	}
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	tempRelative := filepath.Join(parentRelative, tempName)
+	if err = commitStorageRename(ctx, root, tempRelative, relative); err != nil {
+		return err
+	}
+	committed = true
+	committedInfo, err := root.Lstat(relative)
+	if err != nil || storagePathInfoIsLink(committedInfo) || !committedInfo.Mode().IsRegular() || !os.SameFile(tempIdentity, committedInfo) {
+		return errors.New("storage target identity changed during commit")
+	}
+	if err = validateStorageDirectoryBinding(ctx, root, parent, parentRelative); err != nil {
+		return err
+	}
+	if err = p.validateStorageRootIdentity(rootIdentity); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *KernelPlugin) storageRemove(relPath string) error {
+	ctx := p.storageContext()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	relative, absolute, err := p.cleanStoragePath(relPath, false)
+	if err != nil {
+		return err
+	}
+	treeLock, err := p.storageTreeLock()
+	if err != nil {
+		return err
+	}
+	treeLock.Lock()
+	defer treeLock.Unlock()
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	filelock.Lock(absolute)
+	defer filelock.Unlock(absolute)
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	root, err := p.openStorageRoot(false)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	rootIdentity, err := root.Stat(".")
+	if err != nil {
+		return err
+	}
+	parent, parentRelative, base, err := openStorageParentNoLinks(ctx, root, relative, false)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	if err = validateStorageDirectoryBinding(ctx, root, parent, parentRelative); err != nil {
+		return err
+	}
+	if err = p.validateStorageRootIdentity(rootIdentity); err != nil {
+		return err
+	}
+	target, err := parent.Lstat(base)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if storagePathInfoIsLink(target) {
+		return errors.New("storage remove target is a link or reparse point")
+	}
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	// The tree write lock linearizes whole-tree operations in-process;
+	// Root.RemoveAll removes only a static internal link itself.
+	// Physical path isolation from an external process concurrently moving an open
+	// directory is out of scope.
+	if err = root.RemoveAll(relative); err != nil {
+		return err
+	}
+	if err = validateStorageDirectoryBinding(ctx, root, parent, parentRelative); err != nil {
+		return err
+	}
+	return p.validateStorageRootIdentity(rootIdentity)
+}
+
+type storageListSnapshotEntry struct {
+	name string
+	info os.FileInfo
+}
+
+func sameStorageMetadata(left, right os.FileInfo) bool {
+	return os.SameFile(left, right) && left.Mode() == right.Mode() && left.Size() == right.Size() && left.ModTime().Equal(right.ModTime())
+}
+
+func snapshotStorageListEntry(entry os.DirEntry, lstat func(string) (os.FileInfo, error)) (storageListSnapshotEntry, bool) {
+	info, err := entry.Info()
+	if err != nil {
+		return storageListSnapshotEntry{}, false
+	}
+	current, err := lstat(entry.Name())
+	if err != nil || !sameStorageMetadata(info, current) {
+		return storageListSnapshotEntry{}, false
+	}
+	return storageListSnapshotEntry{name: entry.Name(), info: current}, true
+}
+
+func storageListSnapshotResult(entry storageListSnapshotEntry) R {
+	// Public fields follow Go ModeSymlink; storagePathInfoIsLink still rejects all
+	// Windows reparse points during traversal.
+	return R{
+		"name":      entry.name,
+		"isDir":     entry.info.IsDir(),
+		"isSymlink": entry.info.Mode()&os.ModeSymlink != 0,
+		"updated":   entry.info.ModTime().Unix(),
+	}
+}
+
+func filterStorageListSnapshot(ctx context.Context, snapshot []storageListSnapshotEntry,
+	lstat func(string) (os.FileInfo, error)) ([]R, error) {
+	results := make([]R, 0, len(snapshot))
+	for _, entry := range snapshot {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		current, err := lstat(entry.name)
+		if err != nil || !sameStorageMetadata(entry.info, current) {
+			continue
+		}
+		results = append(results, storageListSnapshotResult(entry))
+	}
+	return results, nil
+}
+
+func readStorageDirectoryEntries(directory *os.Root) ([]os.DirEntry, error) {
+	file, err := directory.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	entries, readErr := file.ReadDir(-1)
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	return entries, nil
+}
+
+func (p *KernelPlugin) storageList(relPath string) ([]R, error) {
+	ctx := p.storageContext()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	relative, absolute, err := p.cleanStoragePath(relPath, true)
+	if err != nil {
+		return nil, err
+	}
+	treeLock, err := p.storageTreeLock()
+	if err != nil {
+		return nil, err
+	}
+	treeLock.RLock()
+	defer treeLock.RUnlock()
+	if err = ctx.Err(); err != nil {
+		return nil, err
+	}
+	filelock.Lock(absolute)
+	defer filelock.Unlock(absolute)
+	if err = ctx.Err(); err != nil {
+		return nil, err
+	}
+	root, err := p.openStorageRoot(false)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	rootIdentity, err := root.Stat(".")
+	if err != nil {
+		return nil, err
+	}
+	parent, parentRelative, base, err := openStorageParentNoLinks(ctx, root, relative, false)
+	if err != nil {
+		return nil, err
+	}
+	defer parent.Close()
+	directory, directoryIdentity, err := openStorageDirectory(parent, base)
+	if err != nil {
+		return nil, err
+	}
+	defer directory.Close()
+	entries, err := readStorageDirectoryEntries(directory)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := make([]storageListSnapshotEntry, 0, len(entries))
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return nil, err
+		}
+		if candidate, ok := snapshotStorageListEntry(entry, directory.Lstat); ok {
+			snapshot = append(snapshot, candidate)
+		}
+	}
+	results, err := filterStorageListSnapshot(ctx, snapshot, directory.Lstat)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateStorageEntryIdentity(parent, base, directoryIdentity, false); err != nil {
+		return nil, err
+	}
+	if err = validateStorageDirectoryBinding(ctx, root, parent, parentRelative); err != nil {
+		return nil, err
+	}
+	if err = p.validateStorageRootIdentity(rootIdentity); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/kernel/plugin/storage_safe_nonwindows_test.go
+++ b/kernel/plugin/storage_safe_nonwindows_test.go
@@ -1,0 +1,117 @@
+//go:build !windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+func TestStorageRootCreationRejectsSymlink(t *testing.T) {
+	workspace := t.TempDir()
+	previousWorkspace := util.WorkspaceDir
+	util.WorkspaceDir = workspace
+	t.Cleanup(func() { util.WorkspaceDir = previousWorkspace })
+
+	outside := filepath.Join(workspace, "outside")
+	if err := os.MkdirAll(filepath.Join(workspace, "data"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(outside, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "data", "storage")); err != nil {
+		t.Fatal(err)
+	}
+	storageDir := filepath.Join(workspace, "data", "storage", "petal", "test")
+	plugin := &KernelPlugin{storageDir: storageDir, context: context.Background()}
+	if err := plugin.ensureStorageRoot(); err == nil {
+		t.Fatal("storage root creation accepted symlink component")
+	}
+	if _, err := os.Lstat(filepath.Join(outside, "petal")); !os.IsNotExist(err) {
+		t.Fatalf("storage root creation escaped through symlink: %v", err)
+	}
+}
+
+func TestStorageRejectsLinksAndContainsRemove(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+	outside := filepath.Join(filepath.Dir(storageDir), "outside")
+	if err := os.MkdirAll(outside, 0755); err != nil {
+		t.Fatal(err)
+	}
+	outsideFile := filepath.Join(outside, "keep")
+	if err := os.WriteFile(outsideFile, []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideFile, filepath.Join(storageDir, "file-link")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := plugin.storageGet("file-link"); err == nil {
+		t.Fatal("get accepted symlink")
+	}
+	if err := plugin.storagePut("file-link", []byte("replace")); err == nil {
+		t.Fatal("put accepted symlink")
+	}
+	if err := plugin.storageRemove("file-link"); err == nil {
+		t.Fatal("remove accepted symlink")
+	}
+
+	if err := os.Symlink(outside, filepath.Join(storageDir, "dir-link")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := plugin.storageList("dir-link"); err == nil {
+		t.Fatal("list accepted symlink directory")
+	}
+	if err := plugin.storagePut(filepath.Join("dir-link", "escaped"), []byte("data")); err == nil {
+		t.Fatal("put traversed symlink directory")
+	}
+
+	contained := filepath.Join(storageDir, "contained")
+	if err := os.Mkdir(contained, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(contained, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := plugin.storageRemove("contained"); err != nil {
+		t.Fatalf("remove contained directory: %v", err)
+	}
+	if data, err := os.ReadFile(outsideFile); err != nil || string(data) != "keep" {
+		t.Fatalf("remove escaped storage root: %q, %v", data, err)
+	}
+}
+
+func TestStorageGetRejectsFIFOWithoutBlocking(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+	if err := syscall.Mkfifo(filepath.Join(storageDir, "fifo"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := plugin.storageGet("fifo")
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("get accepted FIFO")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("get blocked while opening FIFO")
+	}
+}

--- a/kernel/plugin/storage_safe_test.go
+++ b/kernel/plugin/storage_safe_test.go
@@ -1,0 +1,452 @@
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/siyuan-note/filelock"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+func newStorageTestPlugin(t *testing.T) (*KernelPlugin, string) {
+	t.Helper()
+	workspace := t.TempDir()
+	previousWorkspace := util.WorkspaceDir
+	util.WorkspaceDir = workspace
+	t.Cleanup(func() { util.WorkspaceDir = previousWorkspace })
+
+	storageDir := filepath.Join(workspace, "data", "storage", "petal", "test")
+	if err := os.MkdirAll(storageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	return &KernelPlugin{storageDir: storageDir, context: context.Background()}, storageDir
+}
+
+func TestStorageRootCreation(t *testing.T) {
+	workspace := t.TempDir()
+	previousWorkspace := util.WorkspaceDir
+	util.WorkspaceDir = workspace
+	t.Cleanup(func() { util.WorkspaceDir = previousWorkspace })
+
+	storageDir := filepath.Join(workspace, "data", "storage", "petal", "test")
+	plugin := &KernelPlugin{storageDir: storageDir, context: context.Background()}
+	if err := plugin.ensureStorageRoot(); err != nil {
+		t.Fatalf("ensure storage root: %v", err)
+	}
+	if info, err := os.Stat(storageDir); err != nil || !info.IsDir() {
+		t.Fatalf("storage root was not created: %v", err)
+	}
+}
+
+func TestStorageCRUD(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+
+	if err := plugin.storagePut(filepath.Join("nested", "value.txt"), []byte("first")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := plugin.storagePut(filepath.Join("nested", "value.txt"), []byte("second")); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	data, err := plugin.storageGet(filepath.Join("nested", "value.txt"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(data, []byte("second")) {
+		t.Fatalf("get = %q", data)
+	}
+
+	entries, err := plugin.storageList("nested")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 1 || entries[0]["name"] != "value.txt" || entries[0]["isDir"] != false || entries[0]["isSymlink"] != false {
+		t.Fatalf("unexpected entries: %#v", entries)
+	}
+	rootEntries, err := plugin.storageList("")
+	if err != nil || len(rootEntries) != 1 || rootEntries[0]["name"] != "nested" || rootEntries[0]["isDir"] != true {
+		t.Fatalf("unexpected root entries: %#v, %v", rootEntries, err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(storageDir, "nested", ".siyuan-storage-*.tmp"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary files remain: %v, %v", matches, err)
+	}
+	if err = plugin.storageRemove("nested"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err = os.Lstat(filepath.Join(storageDir, "nested")); !os.IsNotExist(err) {
+		t.Fatalf("removed directory still exists: %v", err)
+	}
+	if err = plugin.storageRemove("nested"); err != nil {
+		t.Fatalf("remove missing: %v", err)
+	}
+}
+
+func TestStorageRejectsInvalidPaths(t *testing.T) {
+	plugin, _ := newStorageTestPlugin(t)
+	invalid := []string{"..", filepath.Join("..", "escape"), string(filepath.Separator) + "absolute"}
+	for _, path := range invalid {
+		if err := plugin.storagePut(path, []byte("data")); err == nil {
+			t.Errorf("put accepted %q", path)
+		}
+		if _, err := plugin.storageGet(path); err == nil {
+			t.Errorf("get accepted %q", path)
+		}
+		if err := plugin.storageRemove(path); err == nil {
+			t.Errorf("remove accepted %q", path)
+		}
+		if _, err := plugin.storageList(path); err == nil {
+			t.Errorf("list accepted %q", path)
+		}
+	}
+	for _, path := range []string{"", "."} {
+		if err := plugin.storagePut(path, []byte("data")); err == nil {
+			t.Errorf("put accepted storage root %q", path)
+		}
+		if err := plugin.storageRemove(path); err == nil {
+			t.Errorf("remove accepted storage root %q", path)
+		}
+	}
+}
+
+func TestStorageConcurrentCRUD(t *testing.T) {
+	plugin, _ := newStorageTestPlugin(t)
+	if err := plugin.storagePut("value", []byte("initial")); err != nil {
+		t.Fatal(err)
+	}
+
+	var wait sync.WaitGroup
+	errors := make(chan error, 8)
+	for worker := 0; worker < 8; worker++ {
+		wait.Add(1)
+		go func(worker int) {
+			defer wait.Done()
+			for iteration := 0; iteration < 25; iteration++ {
+				value := []byte(fmt.Sprintf("%d-%d", worker, iteration))
+				if err := plugin.storagePut("value", value); err != nil {
+					errors <- err
+					return
+				}
+				if _, err := plugin.storageGet("value"); err != nil {
+					errors <- err
+					return
+				}
+			}
+		}(worker)
+	}
+	wait.Wait()
+	close(errors)
+	for err := range errors {
+		t.Error(err)
+	}
+}
+
+func TestStorageTreeLockRegistry(t *testing.T) {
+	root := t.TempDir()
+	first, err := storageTreeLock(filepath.Join(root, "storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	alias, err := storageTreeLock(filepath.Join(root, "other", "..", "storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := storageTreeLock(filepath.Join(root, "other"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != alias {
+		t.Fatal("clean aliases did not share a storage tree lock")
+	}
+	if first == other {
+		t.Fatal("different storage roots shared a storage tree lock")
+	}
+}
+
+type observedStorageContext struct {
+	context.Context
+	checked chan struct{}
+	once    sync.Once
+}
+
+func newObservedStorageContext(ctx context.Context) *observedStorageContext {
+	return &observedStorageContext{Context: ctx, checked: make(chan struct{})}
+}
+
+func (ctx *observedStorageContext) Err() error {
+	err := ctx.Context.Err()
+	if err == nil {
+		ctx.once.Do(func() { close(ctx.checked) })
+	}
+	return err
+}
+
+func waitForStorageTreeLock(t *testing.T, lock *sync.RWMutex) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if lock.TryLock() {
+			lock.Unlock()
+			time.Sleep(time.Millisecond)
+			continue
+		}
+		return
+	}
+	t.Fatal("storage operation did not acquire the tree lock")
+}
+
+func TestStorageCrossGenerationWriteCompletesBeforeStartup(t *testing.T) {
+	oldPlugin, storageDir := newStorageTestPlugin(t)
+	newContext := newObservedStorageContext(context.Background())
+	newPlugin := &KernelPlugin{storageDir: storageDir, context: newContext}
+	lock, err := oldPlugin.storageTreeLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(storageDir, "value")
+	filelock.Lock(target)
+	fileLocked := true
+	defer func() {
+		if fileLocked {
+			filelock.Unlock(target)
+		}
+	}()
+
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- oldPlugin.storagePut("value", []byte("old")) }()
+	waitForStorageTreeLock(t, lock)
+
+	startupDone := make(chan error, 1)
+	go func() { startupDone <- newPlugin.ensureStorageRoot() }()
+	<-newContext.checked
+	select {
+	case err = <-startupDone:
+		t.Fatalf("startup passed an active old-generation write: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	filelock.Unlock(target)
+	fileLocked = false
+	if err = <-writeDone; err != nil {
+		t.Fatalf("old-generation write: %v", err)
+	}
+	if err = <-startupDone; err != nil {
+		t.Fatalf("new-generation startup: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "old" {
+		t.Fatalf("unexpected committed data %q: %v", data, err)
+	}
+}
+
+func TestStorageAncestorRemoveAndDescendantPutAreLinearized(t *testing.T) {
+	first, storageDir := newStorageTestPlugin(t)
+	second := &KernelPlugin{storageDir: storageDir, context: context.Background()}
+	for iteration := 0; iteration < 25; iteration++ {
+		if err := first.storageRemove("dir"); err != nil {
+			t.Fatal(err)
+		}
+		if err := first.storagePut(filepath.Join("dir", "old"), []byte("old")); err != nil {
+			t.Fatal(err)
+		}
+		start := make(chan struct{})
+		errors := make(chan error, 2)
+		go func() {
+			<-start
+			errors <- first.storageRemove("dir")
+		}()
+		go func() {
+			<-start
+			errors <- second.storagePut(filepath.Join("dir", "new"), []byte("new"))
+		}()
+		close(start)
+		for operation := 0; operation < 2; operation++ {
+			if err := <-errors; err != nil {
+				t.Fatalf("concurrent operation: %v", err)
+			}
+		}
+		data, err := os.ReadFile(filepath.Join(storageDir, "dir", "new"))
+		if err == nil && string(data) != "new" {
+			t.Fatalf("partially committed descendant data: %q", data)
+		}
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("unexpected descendant state: %v", err)
+		}
+	}
+}
+
+func TestStorageCanceledQueuedGenerationHasNoSideEffect(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+	oldContext, cancelOld := context.WithCancel(context.Background())
+	observedOldContext := newObservedStorageContext(oldContext)
+	oldPlugin := &KernelPlugin{storageDir: storageDir, context: observedOldContext}
+	newPlugin := &KernelPlugin{storageDir: storageDir, context: context.Background()}
+	lock, err := plugin.storageTreeLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock.Lock()
+
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- oldPlugin.storagePut("canceled", []byte("old")) }()
+	<-observedOldContext.checked
+	cancelOld()
+	startupDone := make(chan error, 1)
+	go func() { startupDone <- newPlugin.ensureStorageRoot() }()
+	lock.Unlock()
+
+	if err = <-writeDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("queued old-generation write error = %v", err)
+	}
+	if err = <-startupDone; err != nil {
+		t.Fatalf("new-generation startup: %v", err)
+	}
+	if _, err = os.Lstat(filepath.Join(storageDir, "canceled")); !os.IsNotExist(err) {
+		t.Fatalf("canceled operation had a side effect: %v", err)
+	}
+}
+
+func TestStorageDetectsRootAndParentReplacement(t *testing.T) {
+	t.Run("root", func(t *testing.T) {
+		plugin, storageDir := newStorageTestPlugin(t)
+		root, err := plugin.openStorageRoot(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer root.Close()
+		expected, err := root.Stat(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		moved := storageDir + "-moved"
+		if err = os.Rename(storageDir, moved); err != nil {
+			t.Fatal(err)
+		}
+		if err = os.Mkdir(storageDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err = plugin.validateStorageRootIdentity(expected); err == nil {
+			t.Fatal("storage root replacement was not detected")
+		}
+	})
+
+	t.Run("parent", func(t *testing.T) {
+		plugin, storageDir := newStorageTestPlugin(t)
+		if err := os.Mkdir(filepath.Join(storageDir, "parent"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		root, err := plugin.openStorageRoot(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer root.Close()
+		parent, parentRelative, _, err := openStorageParentNoLinks(context.Background(), root,
+			filepath.Join("parent", "value"), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer parent.Close()
+		moved := filepath.Join(storageDir, "parent-moved")
+		if err = os.Rename(filepath.Join(storageDir, "parent"), moved); err != nil {
+			t.Fatal(err)
+		}
+		if err = os.Mkdir(filepath.Join(storageDir, "parent"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err = validateStorageDirectoryBinding(context.Background(), root, parent, parentRelative); err == nil {
+			t.Fatal("storage parent replacement was not detected")
+		}
+	})
+}
+
+type storageTestDirEntry struct {
+	name string
+	info os.FileInfo
+	err  error
+}
+
+func (entry storageTestDirEntry) Name() string               { return entry.name }
+func (entry storageTestDirEntry) IsDir() bool                { return entry.info != nil && entry.info.IsDir() }
+func (entry storageTestDirEntry) Type() os.FileMode          { return entry.info.Mode().Type() }
+func (entry storageTestDirEntry) Info() (os.FileInfo, error) { return entry.info, entry.err }
+
+func TestStorageListSnapshotSkipsEntryFailuresAndChurn(t *testing.T) {
+	directory := t.TempDir()
+	for _, name := range []string{"a", "b"} {
+		if err := os.WriteFile(filepath.Join(directory, name), []byte(name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lstat := func(name string) (os.FileInfo, error) { return os.Lstat(filepath.Join(directory, name)) }
+	if _, ok := snapshotStorageListEntry(storageTestDirEntry{name: "broken", err: errors.New("metadata")}, lstat); ok {
+		t.Fatal("entry metadata failure was not skipped")
+	}
+
+	snapshot := make([]storageListSnapshotEntry, 0, len(entries))
+	for _, entry := range entries {
+		candidate, ok := snapshotStorageListEntry(entry, lstat)
+		if !ok {
+			t.Fatalf("failed to snapshot %q", entry.Name())
+		}
+		snapshot = append(snapshot, candidate)
+	}
+	if err = os.Remove(filepath.Join(directory, "b")); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(filepath.Join(directory, "c"), []byte("c"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	results, err := filterStorageListSnapshot(context.Background(), snapshot, lstat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0]["name"] != "a" {
+		t.Fatalf("unexpected filtered snapshot: %#v", results)
+	}
+}
+
+func TestStorageListSortedAndSnapshotMetadata(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+	for _, name := range []string{"z", "a", "m"} {
+		if err := os.WriteFile(filepath.Join(storageDir, name), []byte(name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	results, err := plugin.storageList("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 || results[0]["name"] != "a" || results[1]["name"] != "m" || results[2]["name"] != "z" {
+		t.Fatalf("storage list is not sorted: %#v", results)
+	}
+	for _, result := range results {
+		name := result["name"].(string)
+		info, statErr := os.Lstat(filepath.Join(storageDir, name))
+		if statErr != nil {
+			t.Fatal(statErr)
+		}
+		if result["isDir"] != info.IsDir() || result["isSymlink"] != (info.Mode()&os.ModeSymlink != 0) ||
+			result["updated"] != info.ModTime().Unix() {
+			t.Fatalf("inconsistent metadata for %q: %#v", name, result)
+		}
+	}
+}

--- a/kernel/plugin/storage_safe_windows_test.go
+++ b/kernel/plugin/storage_safe_windows_test.go
@@ -1,0 +1,255 @@
+//go:build windows
+
+// SiYuan - Refactor your thinking
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package plugin
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unicode/utf16"
+
+	"golang.org/x/sys/windows"
+)
+
+type storageWindowsFileInfo struct {
+	name       string
+	mode       os.FileMode
+	attributes uint32
+}
+
+func (info storageWindowsFileInfo) Name() string       { return info.name }
+func (info storageWindowsFileInfo) Size() int64        { return 0 }
+func (info storageWindowsFileInfo) Mode() os.FileMode  { return info.mode }
+func (info storageWindowsFileInfo) ModTime() time.Time { return time.Unix(123, 0) }
+func (info storageWindowsFileInfo) IsDir() bool        { return info.mode.IsDir() }
+func (info storageWindowsFileInfo) Sys() any {
+	return &syscall.Win32FileAttributeData{FileAttributes: info.attributes}
+}
+
+func TestStorageWindowsTreeLockAliases(t *testing.T) {
+	root := t.TempDir()
+	first, err := storageTreeLock(filepath.Join(root, "Storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	alias, err := storageTreeLock(strings.ToUpper(filepath.Join(root, "alias", "..", "storage")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != alias {
+		t.Fatal("Windows clean and case aliases did not share a storage tree lock")
+	}
+}
+
+func TestStorageWindowsReparseMetadataPolicy(t *testing.T) {
+	reparse := storageWindowsFileInfo{
+		name:       "reparse",
+		mode:       0644,
+		attributes: syscall.FILE_ATTRIBUTE_REPARSE_POINT,
+	}
+	if !storagePathInfoIsLink(reparse) {
+		t.Fatal("reparse point was not rejected by the traversal classification")
+	}
+	if storageListSnapshotResult(storageListSnapshotEntry{name: reparse.Name(), info: reparse})["isSymlink"] != false {
+		t.Fatal("non-symlink reparse point was reported as a symlink")
+	}
+
+	symlink := storageWindowsFileInfo{
+		name:       "symlink",
+		mode:       os.ModeSymlink | 0777,
+		attributes: syscall.FILE_ATTRIBUTE_REPARSE_POINT,
+	}
+	if storageListSnapshotResult(storageListSnapshotEntry{name: symlink.Name(), info: symlink})["isSymlink"] != true {
+		t.Fatal("Go ModeSymlink entry was not reported as a symlink")
+	}
+}
+
+func createStorageJunction(t *testing.T, target, junction string) {
+	t.Helper()
+	if err := os.Mkdir(junction, 0755); err != nil {
+		t.Fatal(err)
+	}
+	junctionPointer, err := windows.UTF16PtrFromString(junction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := windows.CreateFile(junctionPointer, windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil, windows.OPEN_EXISTING,
+		windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer windows.CloseHandle(handle)
+
+	substituteName := utf16.Encode([]rune(`\??\` + target))
+	printName := utf16.Encode([]rune(target))
+	pathBuffer := make([]uint16, 0, len(substituteName)+len(printName)+2)
+	pathBuffer = append(pathBuffer, substituteName...)
+	pathBuffer = append(pathBuffer, 0)
+	printNameOffset := len(pathBuffer) * 2
+	pathBuffer = append(pathBuffer, printName...)
+	pathBuffer = append(pathBuffer, 0)
+	buffer := make([]byte, 16+len(pathBuffer)*2)
+	binary.LittleEndian.PutUint32(buffer[0:4], windows.IO_REPARSE_TAG_MOUNT_POINT)
+	binary.LittleEndian.PutUint16(buffer[4:6], uint16(8+len(pathBuffer)*2))
+	binary.LittleEndian.PutUint16(buffer[10:12], uint16(len(substituteName)*2))
+	binary.LittleEndian.PutUint16(buffer[12:14], uint16(printNameOffset))
+	binary.LittleEndian.PutUint16(buffer[14:16], uint16(len(printName)*2))
+	for index, value := range pathBuffer {
+		binary.LittleEndian.PutUint16(buffer[16+index*2:], value)
+	}
+	if err = windows.DeviceIoControl(handle, windows.FSCTL_SET_REPARSE_POINT, &buffer[0], uint32(len(buffer)), nil, 0,
+		nil, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStorageWindowsJunctionTraversalAndRemove(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+	outside := filepath.Join(filepath.Dir(storageDir), "outside")
+	if err := os.MkdirAll(outside, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(outside, "keep")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	topLevel := filepath.Join(storageDir, "junction")
+	createStorageJunction(t, outside, topLevel)
+	listed, err := plugin.storageList("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var junctionEntry R
+	for _, entry := range listed {
+		if entry["name"] == "junction" {
+			junctionEntry = entry
+			break
+		}
+	}
+	if junctionEntry == nil {
+		t.Fatalf("junction missing from list: %#v", listed)
+	}
+	info, err := os.Lstat(topLevel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if junctionEntry["isSymlink"] != (info.Mode()&os.ModeSymlink != 0) {
+		t.Fatalf("junction symlink metadata does not follow Go mode: %#v, mode=%v", junctionEntry, info.Mode())
+	}
+	if _, err = plugin.storageList("junction"); err == nil {
+		t.Fatal("list traversed a junction")
+	}
+	if err = plugin.storagePut(filepath.Join("junction", "escaped"), []byte("data")); err == nil {
+		t.Fatal("put traversed a junction")
+	}
+	if err = plugin.storageRemove("junction"); err == nil {
+		t.Fatal("remove accepted a top-level junction")
+	}
+
+	contained := filepath.Join(storageDir, "contained")
+	if err = os.Mkdir(contained, 0755); err != nil {
+		t.Fatal(err)
+	}
+	createStorageJunction(t, outside, filepath.Join(contained, "junction"))
+	if err = plugin.storageRemove("contained"); err != nil {
+		t.Fatalf("remove directory containing junction: %v", err)
+	}
+	data, err := os.ReadFile(sentinel)
+	if err != nil || string(data) != "keep" {
+		t.Fatalf("static junction removal changed sentinel %q: %v", data, err)
+	}
+}
+
+func openStorageTargetWithoutDeleteSharing(t *testing.T, path string) windows.Handle {
+	t.Helper()
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := windows.CreateFile(pathPointer, windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handle
+}
+
+func TestStorageWindowsPutRetriesSharingConflict(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+	if err := plugin.storagePut("value", []byte("initial")); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(storageDir, "value")
+
+	t.Run("transient", func(t *testing.T) {
+		handle := openStorageTargetWithoutDeleteSharing(t, target)
+		done := make(chan error, 1)
+		go func() { done <- plugin.storagePut("value", []byte("updated")) }()
+		time.Sleep(250 * time.Millisecond)
+		if err := windows.CloseHandle(handle); err != nil {
+			t.Fatal(err)
+		}
+		if err := <-done; err != nil {
+			t.Fatalf("put after transient sharing conflict: %v", err)
+		}
+		data, err := os.ReadFile(target)
+		if err != nil || string(data) != "updated" {
+			t.Fatalf("unexpected data %q: %v", data, err)
+		}
+	})
+
+	t.Run("persistent", func(t *testing.T) {
+		handle := openStorageTargetWithoutDeleteSharing(t, target)
+		defer windows.CloseHandle(handle)
+		if err := plugin.storagePut("value", []byte("blocked")); err == nil {
+			t.Fatal("put succeeded through a persistent sharing conflict")
+		}
+		matches, err := filepath.Glob(filepath.Join(storageDir, ".siyuan-storage-*.tmp"))
+		if err != nil || len(matches) != 0 {
+			t.Fatalf("temporary files remain: %v, %v", matches, err)
+		}
+	})
+}
+
+func TestStorageWindowsRejectsReservedComponents(t *testing.T) {
+	plugin, _ := newStorageTestPlugin(t)
+	for _, path := range []string{"CON", "aux.txt", "trailing.", "trailing ", "colon:name"} {
+		if err := plugin.storagePut(path, []byte("data")); err == nil {
+			t.Errorf("put accepted reserved path %q", path)
+		}
+	}
+}
+
+func TestStorageWindowsQueuedContextCancellation(t *testing.T) {
+	plugin, storageDir := newStorageTestPlugin(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	canceledPlugin := &KernelPlugin{storageDir: storageDir, context: ctx}
+	lock, err := plugin.storageTreeLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock.Lock()
+	done := make(chan error, 1)
+	go func() { done <- canceledPlugin.storagePut("value", []byte("data")) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	lock.Unlock()
+	if err = <-done; err != context.Canceled {
+		t.Fatalf("queued operation error = %v", err)
+	}
+}


### PR DESCRIPTION
## Description / 描述

Harden filesystem path containment for the existing kernel file APIs without changing their public request or response formats.

This fixes two instances of the same path-containment problem:

- `/api/file/readDir` now resolves paths relative to the workspace, rejects escaping symlinks, junctions, and reparse points, and returns an identity-validated directory snapshot without partial results.
- `siyuan.storage` CRUD now uses a contained storage root, rejects link/reparse traversal, performs same-directory atomic writes, coordinates operations across plugin generations, and preserves the existing JS methods, arguments, Promise behavior, read-only checks, and watcher API.

The change does not add compatibility readers, data migration, format versions, causal/provider/keystore logic, chunk/CAS APIs, or SSRF policy.

Validation completed with the repository Go 1.26.5 toolchain:

- Linux API and plugin focused tests, repeated tests, race tests, plugin full tests, vet, and full kernel build passed.
- Windows native API/plugin focused tests, race tests, plugin full tests, and vet passed.
- Windows tests covered junction/reparse points, cross-volume paths, case aliases, sharing conflicts, and temporary-file cleanup.
- Darwin-specific sources were cross-compiled and reviewed statically; no native Darwin host was available.

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突