### PR TITLE
Improve copying selected rich text and images to Office

### DIFF
--- a/app/src/protyle/preview/index.ts
+++ b/app/src/protyle/preview/index.ts
@@ -11,7 +11,13 @@ import {Constants} from "../../constants";
 import {getSearch, isMobile} from "../../util/functions";
 /// #if !BROWSER
 import {shell} from "electron";
-import {enhanceRichClipboard, hasRichClipboardImages} from "../util/richClipboard";
+import {
+    enhanceRichClipboard,
+    hasRichClipboardImages,
+    hasRichClipboardMath,
+    hasRichClipboardTables,
+    prepareExternalClipboardHTML,
+} from "../util/richClipboard";
 /// #endif
 /// #if !MOBILE
 import {openAsset, openBy} from "../../editor/util";
@@ -97,20 +103,27 @@ export class Preview {
             const copyElement = document.createElement("div");
             copyElement.appendChild(range.cloneContents());
             const copiedHTML = copyElement.innerHTML;
-            if (!hasRichClipboardImages(copiedHTML)) {
+            const hasImages = hasRichClipboardImages(copiedHTML);
+            const hasMath = hasRichClipboardMath(copiedHTML);
+            const hasTables = hasRichClipboardTables(copiedHTML);
+            if (!hasImages && !hasMath && !hasTables) {
                 return;
             }
+            const clipboardHTML = hasMath || hasTables ?
+                prepareExternalClipboardHTML(copiedHTML) : copiedHTML;
 
             const marker = `<!--siyuan-rich-clipboard='${Lute.NewNodeID()}'-->`;
             const text = selection.toString();
-            const html = marker + copiedHTML;
+            const html = marker + clipboardHTML;
             event.preventDefault();
             event.clipboardData.setData("text/plain", text);
             event.clipboardData.setData("text/html", html);
-            enhanceRichClipboard(text, html, protyle.notebookId, {
-                marker,
-                removeMarker: true,
-            });
+            if (hasImages) {
+                enhanceRichClipboard(text, html, protyle.notebookId, {
+                    marker,
+                    removeMarker: true,
+                });
+            }
         };
         document.addEventListener("copy", this.copyEventHandler);
         /// #endif

--- a/app/src/protyle/util/compatibility.ts
+++ b/app/src/protyle/util/compatibility.ts
@@ -12,6 +12,7 @@ import type {App} from "../../index";
 import {genUUID} from "../../util/genID";
 import {buildBlockDOMClipboardData} from "./blockDOMClipboard";
 import {buildWebClipboardHTML, getTextSiyuanFromTextHTML} from "./clipboardData";
+import {prepareExternalClipboardHTML} from "./richClipboard";
 
 export {encodeBase64, getTextSiyuanFromTextHTML} from "./clipboardData";
 
@@ -460,7 +461,11 @@ export const writeClipboardData = async (data: IClipboardWriteData, options: ICl
 
 export const writeBlockDOMClipboard = async (lute: Lute, blockDOM: string) => {
     const {textPlain, textHTML, textSiyuan} = buildBlockDOMClipboardData(lute, blockDOM);
-    const result = await writeClipboardData({textPlain, textHTML, textSiyuan});
+    const result = await writeClipboardData({
+        textPlain,
+        textHTML: prepareExternalClipboardHTML(textHTML),
+        textSiyuan,
+    });
     if (result.error) {
         console.log("Write block DOM clipboard error:", result.error);
     }

--- a/app/src/protyle/util/richClipboard.ts
+++ b/app/src/protyle/util/richClipboard.ts
@@ -1,4 +1,5 @@
 import {Constants} from "../../constants";
+import {looseJsonParse} from "../../util/functions";
 /// #if !BROWSER
 import {ipcRenderer} from "electron";
 /// #endif
@@ -44,6 +45,8 @@ const richClipboardImageExts = new Set([
 const richClipboardAttributes = new Set([
     "align",
     "alt",
+    "cellpadding",
+    "cellspacing",
     "checked",
     "colspan",
     "controls",
@@ -84,7 +87,252 @@ const richClipboardTextMarkTags = new Map([
     ["u", "u"],
 ]);
 
+const getRichClipboardImageURL = (imageElement: HTMLImageElement) => {
+    const src = imageElement.getAttribute("src")?.trim();
+    if (!src) {
+        return "";
+    }
+    try {
+        return new URL(src, window.location.href).href;
+    } catch {
+        return src;
+    }
+};
+
+const getRichClipboardPixelWidth = (width: string | null | undefined) => {
+    if (!width || (!/^\d+(?:\.\d+)?(?:px)?$/i.test(width.trim()))) {
+        return 0;
+    }
+    return parseFloat(width);
+};
+
+const normalizeRichClipboardImages = (template: HTMLTemplateElement) => {
+    const sourceImages = new Map<string, HTMLImageElement[]>();
+    Array.from(document.images).forEach(imageElement => {
+        const rect = imageElement.getBoundingClientRect();
+        const url = getRichClipboardImageURL(imageElement);
+        if (!url || rect.width <= 0 || rect.height <= 0) {
+            return;
+        }
+        const images = sourceImages.get(url) || [];
+        images.push(imageElement);
+        sourceImages.set(url, images);
+    });
+
+    let normalized = false;
+    template.content.querySelectorAll<HTMLImageElement>("img[src]:not(.emoji)").forEach(imageElement => {
+        const parentWidth = imageElement.parentElement?.style.width || "";
+        let width = getRichClipboardPixelWidth(imageElement.style.width) ||
+            getRichClipboardPixelWidth(imageElement.getAttribute("width")) ||
+            getRichClipboardPixelWidth(parentWidth);
+        if (!width) {
+            const candidates = sourceImages.get(getRichClipboardImageURL(imageElement)) || [];
+            const sourceImage = candidates.find(candidate => candidate.parentElement?.style.width === parentWidth) ||
+                candidates[0];
+            width = sourceImage?.getBoundingClientRect().width || 0;
+        }
+
+        imageElement.style.maxWidth = "600px";
+        imageElement.style.height = "auto";
+        imageElement.removeAttribute("height");
+        if (width > 0) {
+            const normalizedWidth = Math.min(600, Math.round(width));
+            imageElement.style.width = `${normalizedWidth}px`;
+            imageElement.setAttribute("width", normalizedWidth.toString());
+        }
+        normalized = true;
+    });
+    return normalized;
+};
+
+const getRichClipboardTableColumnCount = (tableElement: HTMLTableElement) => {
+    const firstRow = tableElement.rows[0];
+    if (!firstRow) {
+        return 0;
+    }
+    return Array.from(firstRow.cells).reduce((count, cell) => {
+        return count + Math.max(1, parseInt(cell.getAttribute("colspan") || "1"));
+    }, 0);
+};
+
+const normalizeRichClipboardTableSize = (tableElement: HTMLTableElement) => {
+    const columnCount = getRichClipboardTableColumnCount(tableElement);
+    if (columnCount === 0) {
+        return;
+    }
+
+    let colgroupElement = tableElement.querySelector<HTMLTableColElement>(":scope > colgroup");
+    if (!colgroupElement) {
+        colgroupElement = document.createElement("colgroup");
+        tableElement.prepend(colgroupElement);
+    }
+    const columnElements = Array.from(colgroupElement.querySelectorAll<HTMLTableColElement>(":scope > col"));
+    while (columnElements.length < columnCount) {
+        const columnElement = document.createElement("col");
+        colgroupElement.append(columnElement);
+        columnElements.push(columnElement);
+    }
+
+    const columnWidths = columnElements.slice(0, columnCount).map(columnElement => {
+        const width = parseFloat(columnElement.style.width || columnElement.style.minWidth ||
+            columnElement.getAttribute("width") || "");
+        return Math.max(80, Number.isFinite(width) ? width : 80);
+    });
+    const sourceWidth = columnWidths.reduce((width, columnWidth) => width + columnWidth, 0);
+    const targetWidth = Math.min(640, sourceWidth);
+    const scale = targetWidth / sourceWidth;
+    const normalizedWidths = columnWidths.map(columnWidth => Math.round(columnWidth * scale));
+    const normalizedTableWidth = normalizedWidths.reduce((width, columnWidth) => width + columnWidth, 0);
+
+    columnElements.slice(0, columnCount).forEach((columnElement, index) => {
+        const width = normalizedWidths[index];
+        columnElement.style.width = `${width}px`;
+        columnElement.style.minWidth = "";
+        columnElement.setAttribute("width", width.toString());
+    });
+    let columnIndex = 0;
+    Array.from(tableElement.rows[0].cells).forEach(cellElement => {
+        const colspan = Math.max(1, parseInt(cellElement.getAttribute("colspan") || "1"));
+        const width = normalizedWidths.slice(columnIndex, columnIndex + colspan)
+            .reduce((cellWidth, columnWidth) => cellWidth + columnWidth, 0);
+        cellElement.style.width = `${width}px`;
+        cellElement.setAttribute("width", width.toString());
+        columnIndex += colspan;
+    });
+
+    tableElement.setAttribute("width", normalizedTableWidth.toString());
+    tableElement.setAttribute("cellpadding", "0");
+    tableElement.setAttribute("cellspacing", "0");
+    tableElement.style.width = `${normalizedTableWidth}px`;
+    tableElement.style.tableLayout = "fixed";
+    tableElement.style.fontSize = "14px";
+    tableElement.style.lineHeight = "1.5";
+};
+
+const normalizeRichClipboardTableBorders = (template: HTMLTemplateElement) => {
+    let normalized = false;
+    template.content.querySelectorAll<HTMLTableElement>("table").forEach(tableElement => {
+        normalizeRichClipboardTableSize(tableElement);
+        tableElement.setAttribute("border", "1");
+        tableElement.style.borderCollapse = "collapse";
+        tableElement.style.border = "1px solid #000";
+        tableElement.querySelectorAll<HTMLElement>("th, td").forEach(cellElement => {
+            cellElement.style.border = "1px solid #000";
+            cellElement.style.boxSizing = "border-box";
+            cellElement.style.height = "28px";
+            cellElement.style.padding = "4px 8px";
+            cellElement.style.verticalAlign = "middle";
+        });
+        normalized = true;
+    });
+    return normalized;
+};
+
+const normalizeRichClipboardFontColors = (template: HTMLTemplateElement) => {
+    const elements = Array.from(template.content.querySelectorAll<HTMLElement>("[style]"))
+        .filter(element => element.style.color.includes("var("));
+    if (elements.length === 0 || !document.body) {
+        return false;
+    }
+
+    const probeElement = document.createElement("span");
+    probeElement.style.position = "fixed";
+    probeElement.style.visibility = "hidden";
+    probeElement.style.pointerEvents = "none";
+    document.body.append(probeElement);
+    elements.forEach(element => {
+        probeElement.style.color = "";
+        probeElement.style.color = element.style.color;
+        const color = getComputedStyle(probeElement).color;
+        if (color) {
+            element.style.color = color;
+        }
+    });
+    probeElement.remove();
+    return true;
+};
+
+const convertRichClipboardMath = (template: HTMLTemplateElement) => {
+    if (typeof window.katex?.renderToString !== "function") {
+        return false;
+    }
+
+    let macros = {};
+    try {
+        macros = looseJsonParse(window.siyuan.config.editor.katexMacros || "{}");
+    } catch (e) {
+        console.warn("KaTex macros is not JSON", e);
+    }
+
+    let converted = false;
+    template.content.querySelectorAll<HTMLElement>(
+        '[data-subtype="math"][data-content], span.language-math, div.language-math'
+    ).forEach(element => {
+        if (!template.content.contains(element)) {
+            return;
+        }
+        const math = element.getAttribute("data-content") || element.textContent;
+        if (!math) {
+            return;
+        }
+        const displayMode = element.tagName === "DIV";
+        try {
+            const mathTemplate = document.createElement("template");
+            mathTemplate.innerHTML = window.katex.renderToString(math, {
+                displayMode,
+                output: "mathml",
+                macros,
+                trust: true,
+                strict: (errorCode) => errorCode === "unicodeTextInMathMode" ? "ignore" : "warn",
+            });
+            const mathElement = mathTemplate.content.querySelector("math");
+            if (!mathElement) {
+                return;
+            }
+            const semanticsElement = mathElement.firstElementChild;
+            if (semanticsElement?.localName === "semantics" && semanticsElement.firstElementChild) {
+                semanticsElement.replaceWith(semanticsElement.firstElementChild);
+            }
+            if (displayMode) {
+                mathElement.setAttribute("display", "block");
+            }
+            element.replaceWith(mathElement);
+            converted = true;
+        } catch (e) {
+            console.warn("Convert rich clipboard math error:", e);
+        }
+    });
+    return converted;
+};
+
+export const prepareExternalClipboardHTML = (html: string) => {
+    const template = document.createElement("template");
+    template.innerHTML = html;
+    const textMarksConverted = convertRichClipboardTextMarks(template);
+    const mathConverted = convertRichClipboardMath(template);
+    const imagesNormalized = normalizeRichClipboardImages(template);
+    const tableBordersNormalized = normalizeRichClipboardTableBorders(template);
+    const fontColorsNormalized = normalizeRichClipboardFontColors(template);
+    return textMarksConverted || mathConverted || imagesNormalized || tableBordersNormalized || fontColorsNormalized ?
+        template.innerHTML : html;
+};
+
+export const hasRichClipboardMath = (html: string) => {
+    const template = document.createElement("template");
+    template.innerHTML = html;
+    return Boolean(template.content.querySelector(
+        '[data-subtype="math"][data-content], span.language-math, div.language-math'
+    ));
+};
+
+export const hasRichClipboardTables = (html: string) => {
+    const template = document.createElement("template");
+    template.innerHTML = html;
+    return Boolean(template.content.querySelector("table"));
+};
+
 const convertRichClipboardTextMarks = (template: HTMLTemplateElement) => {
+    let converted = false;
     template.content.querySelectorAll<HTMLElement>("span[data-type]").forEach(element => {
         const tags = element.dataset.type.split(/\s+/)
             .map(type => richClipboardTextMarkTags.get(type))
@@ -114,7 +362,9 @@ const convertRichClipboardTextMarks = (template: HTMLTemplateElement) => {
             replacement.setAttribute("style", style);
         }
         element.replaceWith(replacement);
+        converted = true;
     });
+    return converted;
 };
 
 const getTableSourceLines = (tableElement: HTMLTableElement) => {
@@ -191,7 +441,13 @@ export const prepareRichClipboardHTML = (html: string) => {
     const template = document.createElement("template");
     template.innerHTML = html;
     convertRichClipboardTextMarks(template);
+    normalizeRichClipboardImages(template);
+    const source = getRichClipboardSourceLines(template.content).join("\n");
+    convertRichClipboardMath(template);
     template.content.querySelectorAll("*").forEach(element => {
+        if (element.closest("math")) {
+            return;
+        }
         Array.from(element.attributes).forEach(attribute => {
             if (!richClipboardAttributes.has(attribute.name) &&
                 !(attribute.name === "class" && attribute.value.split(/\s+/).every(item => item.startsWith("language-")))) {
@@ -199,9 +455,11 @@ export const prepareRichClipboardHTML = (html: string) => {
             }
         });
     });
+    normalizeRichClipboardTableBorders(template);
+    normalizeRichClipboardFontColors(template);
     return {
         html: template.innerHTML.trim(),
-        source: getRichClipboardSourceLines(template.content).join("\n"),
+        source,
     };
 };
 

--- a/app/src/protyle/util/richClipboard.ts
+++ b/app/src/protyle/util/richClipboard.ts
@@ -179,10 +179,9 @@ const normalizeRichClipboardTableSize = (tableElement: HTMLTableElement) => {
         return Math.max(80, Number.isFinite(width) ? width : 80);
     });
     const sourceWidth = columnWidths.reduce((width, columnWidth) => width + columnWidth, 0);
-    const targetWidth = Math.min(640, sourceWidth);
+    const targetWidth = Math.min(540, Math.max(360, sourceWidth));
     const scale = targetWidth / sourceWidth;
     const normalizedWidths = columnWidths.map(columnWidth => Math.round(columnWidth * scale));
-    const normalizedTableWidth = normalizedWidths.reduce((width, columnWidth) => width + columnWidth, 0);
 
     columnElements.slice(0, columnCount).forEach((columnElement, index) => {
         const width = normalizedWidths[index];
@@ -200,10 +199,9 @@ const normalizeRichClipboardTableSize = (tableElement: HTMLTableElement) => {
         columnIndex += colspan;
     });
 
-    tableElement.setAttribute("width", normalizedTableWidth.toString());
+    tableElement.setAttribute("width", "100%");
     tableElement.setAttribute("cellpadding", "0");
     tableElement.setAttribute("cellspacing", "0");
-    tableElement.style.width = `${normalizedTableWidth}px`;
     tableElement.style.tableLayout = "fixed";
     tableElement.style.fontSize = "14px";
     tableElement.style.lineHeight = "1.5";

--- a/app/src/protyle/wysiwyg/index.ts
+++ b/app/src/protyle/wysiwyg/index.ts
@@ -167,7 +167,7 @@ import {setFold} from "../util/blockFold";
 import {BlockPanel} from "../../block/Panel";
 import {isEncryptedBox, parseSiYuanUriInfo} from "../../util/pathName";
 import {processSiYuanUri} from "../../util/uri";
-import {enhanceRichClipboard, prepareRichClipboardHTML} from "../util/richClipboard";
+import {enhanceRichClipboard, prepareExternalClipboardHTML, prepareRichClipboardHTML} from "../util/richClipboard";
 import {buildBlockDOMClipboardRichData} from "../util/blockDOMClipboard";
 import {addSpellcheckMenuItems, requestSpellcheckContext} from "../../menus/spellcheck";
 import {getAVTemplateInteractiveElement, isAVTemplateLink} from "../render/av/attributeValue";
@@ -1008,6 +1008,8 @@ export class WYSIWYG {
                     const prepared = prepareRichClipboardHTML(exportedHTML);
                     exportedHTML = prepared.html;
                     clipboardText = prepared.source;
+                } else {
+                    exportedHTML = prepareExternalClipboardHTML(exportedHTML);
                 }
                 const clipboardHTML = (nestedListPaste ? NESTED_LIST_PASTE_MARKER : "") + exportedHTML;
                 const textHTML = `<!--data-siyuan='${encodeBase64(textSiyuan)}'-->${clipboardHTML}`;
@@ -3325,9 +3327,9 @@ export class WYSIWYG {
                     event.clipboardData.setData("text/siyuan", textSiyuan);
                 }
                 // 在 text/html 中插入注释节点，用于右键菜单粘贴时获取 text/siyuan 数据
-                const exportedHTML = blockDOMClipboardRichData?.textHTML ??
+                const exportedHTML = prepareExternalClipboardHTML(blockDOMClipboardRichData?.textHTML ??
                     removeZWJ((selectTableElement || selectTableRange) ? html :
-                        protyle.lute.BlockDOM2HTML(selectAVElement ? textPlain : html));
+                        protyle.lute.BlockDOM2HTML(selectAVElement ? textPlain : html)));
                 const textHTML = `<!--data-siyuan='${encodeBase64(textSiyuan)}'-->${exportedHTML}`;
                 if (!cutClipboardWritten) {
                     event.clipboardData.setData("text/html", textHTML);


### PR DESCRIPTION
## Description / 描述

进一步改进https://github.com/siyuan-note/siyuan/issues/18377

- 公式粘贴：之前无法复制行内公式和块级公式到Word，现在将 LaTeX 转换为MathML，可以成功粘贴可编辑公式到Word
- 行内样式粘贴：将思源文本标记转换为标准 HTML 标签，支持复制加粗、斜体、下划线、删除线、上标和下标等格式
- 带颜色文字粘贴：将思源字体颜色使用的 CSS 变量解析为明确的 RGB 颜色，解决选择“保留源格式”后字体颜色仍然丢失的问题
- 表格
    - 为复制的表格统一添加 1px 黑色边框，避免粘贴到 PowerPoint 后边框颜色丢失。
- 图片最大宽度设置为640px，避免word选择保留源格式粘贴，图片会变很大，超出Word边界

<img width="2560" height="1524" alt="复制到word" src="https://github.com/user-attachments/assets/9637485d-33b0-431e-bb06-910e57e097cf" />


## Type of change / 变更类型

- [ ] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [x] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突