### PR TITLE
security: harden publish-reader authorization boundaries

### DIFF
--- a/kernel/api/av.go
+++ b/kernel/api/av.go
@@ -389,6 +389,12 @@ func getAttributeViewKeysByID(c *gin.Context) {
 		return
 	}
 	avID := arg["avID"].(string)
+	if model.IsReadOnlyRoleContext(c) &&
+		!model.CheckAttributeViewAccessableByPublishAccess(c, model.GetPublishAccess(), avID) {
+		ret.Data = []any{}
+		return
+	}
+
 	keyIDsArg := arg["keyIDs"].([]any)
 	var keyIDs []string
 	for _, v := range keyIDsArg {

--- a/kernel/api/filetree.go
+++ b/kernel/api/filetree.go
@@ -1000,6 +1000,12 @@ func getDocCreateSavePath(c *gin.Context) {
 	}
 
 	notebook := arg["notebook"].(string)
+	if model.IsReadOnlyRoleContext(c) && !isNotebookVisibleByPublishAccess(model.Conf.Box(notebook), model.GetPublishAccess()) {
+		ret.Code = -1
+		ret.Msg = "notebook [" + notebook + "] not found"
+		return
+	}
+
 	docCreateSaveBox, docCreateSavePathTpl := model.ResolveDocCreateSaveLocation(notebook)
 	docCreateTemplatePath := model.Conf.FileTree.DocCreateTemplatePath
 	if box := model.Conf.Box(notebook); nil != box {
@@ -1063,6 +1069,11 @@ func getRefCreateSavePath(c *gin.Context) {
 	}
 	if "" == refCreateSavePathTpl {
 		refCreateSavePathTpl = model.Conf.FileTree.RefCreateSavePath
+	}
+	if model.IsReadOnlyRoleContext(c) && !isNotebookVisibleByPublishAccess(model.Conf.Box(refCreateSaveBox), model.GetPublishAccess()) {
+		ret.Code = -1
+		ret.Msg = "notebook [" + refCreateSaveBox + "] not found"
+		return
 	}
 
 	if refCreateSaveBox != notebook {

--- a/kernel/api/publish_hardening_test.go
+++ b/kernel/api/publish_hardening_test.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/siyuan-note/siyuan/kernel/av"
+	"github.com/siyuan-note/siyuan/kernel/conf"
+	"github.com/siyuan-note/siyuan/kernel/model"
+	"github.com/siyuan-note/siyuan/kernel/treenode"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+func TestPublishReaderCannotReadHiddenNotebookSavePaths(t *testing.T) {
+	const boxID = "20260821140000-hiddenbox"
+	oldConf, oldDataDir, oldPublishAccess := model.Conf, util.DataDir, model.GetPublishAccess()
+	util.DataDir = t.TempDir()
+	model.Conf = model.NewAppConf()
+	model.Conf.FileTree = conf.NewFileTree()
+	t.Cleanup(func() {
+		_ = model.SetPublishAccess(oldPublishAccess)
+		model.Conf, util.DataDir = oldConf, oldDataDir
+	})
+
+	boxConf := conf.NewBoxConf()
+	boxConf.Name = "Hidden notebook"
+	boxConf.DocCreateSaveBox = boxID
+	boxConf.DocCreateSavePath = "/private-docs"
+	boxConf.DocCreateTemplatePath = "/private-template.sy"
+	boxConf.RefCreateSaveBox = boxID
+	boxConf.RefCreateSavePath = "/private-refs"
+	boxConfPath := filepath.Join(util.DataDir, boxID, ".siyuan", "conf.json")
+	if err := os.MkdirAll(filepath.Dir(boxConfPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(boxConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(boxConfPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.SetPublishAccess(model.PublishAccess{{ID: boxID, Visible: false}}); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		handler gin.HandlerFunc
+		path    string
+	}{
+		{name: "document creation", handler: getDocCreateSavePath, path: "/api/filetree/getDocCreateSavePath"},
+		{name: "reference creation", handler: getRefCreateSavePath, path: "/api/filetree/getRefCreateSavePath"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, role := range []model.Role{model.RoleReader, model.RoleVisitor, model.RoleAdministrator} {
+				engine := gin.New()
+				engine.Use(func(c *gin.Context) {
+					c.Set(model.RoleContextKey, role)
+					c.Next()
+				})
+				engine.POST(test.path, test.handler)
+
+				recorder := httptest.NewRecorder()
+				request := httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(`{"notebook":"`+boxID+`"}`))
+				request.Header.Set("Content-Type", "application/json")
+				engine.ServeHTTP(recorder, request)
+
+				response := struct {
+					Code int            `json:"code"`
+					Msg  string         `json:"msg"`
+					Data map[string]any `json:"data"`
+				}{}
+				if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+					t.Fatalf("unmarshal response failed: %v; body=%s", err, recorder.Body.String())
+				}
+				if model.IsReadOnlyRole(role) {
+					if response.Code != -1 || response.Msg != "notebook ["+boxID+"] not found" || response.Data != nil {
+						t.Fatalf("reader received hidden save-path configuration: role=%d body=%s", role, recorder.Body.String())
+					}
+					continue
+				}
+				if response.Code != 0 || response.Data == nil {
+					t.Fatalf("administrator lost hidden-notebook save-path access: body=%s", recorder.Body.String())
+				}
+			}
+		})
+	}
+}
+
+func TestPublishReaderCannotEnumerateHiddenAttributeViewKeys(t *testing.T) {
+	const (
+		boxID      = "20260821135000-avbox"
+		databaseID = "20260821135001-avdb"
+		avID       = "20260821135002-av0001"
+	)
+	oldDataDir, oldBlockTreeDBPath, oldPublishAccess := util.DataDir, util.BlockTreeDBPath, model.GetPublishAccess()
+	util.DataDir = t.TempDir()
+	util.BlockTreeDBPath = filepath.Join(util.DataDir, "blocktree.db")
+	treenode.InitBlockTree(true)
+	t.Cleanup(func() {
+		treenode.CloseDatabase()
+		_ = model.SetPublishAccess(oldPublishAccess)
+		util.DataDir, util.BlockTreeDBPath = oldDataDir, oldBlockTreeDBPath
+	})
+
+	treenode.UpsertBlockTree(treenode.NewTree(boxID, "/"+databaseID+".sy", "/Database", "Database"))
+	av.UpsertBlockRel(avID, databaseID)
+	if err := model.SetPublishAccess(model.PublishAccess{{ID: databaseID, Visible: false}}); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set(model.RoleContextKey, model.RoleReader)
+		c.Next()
+	})
+	engine.POST("/api/av/getAttributeViewKeysByID", getAttributeViewKeysByID)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/av/getAttributeViewKeysByID", strings.NewReader(`{"avID":"`+avID+`","keyIDs":[]}`))
+	request.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(recorder, request)
+
+	response := struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response failed: %v; body=%s", err, recorder.Body.String())
+	}
+	if response.Code != 0 || len(response.Data) != 0 {
+		t.Fatalf("reader received hidden attribute-view key definitions: body=%s", recorder.Body.String())
+	}
+}
+
+func TestPublishReaderCannotReadHiddenNotebookRawFile(t *testing.T) {
+	const boxID = "20260821140001-hiddenbox"
+	oldConf, oldDataDir, oldPublishAccess := model.Conf, util.DataDir, model.GetPublishAccess()
+	util.DataDir = t.TempDir()
+	model.Conf = model.NewAppConf()
+	model.Conf.FileTree = conf.NewFileTree()
+	t.Cleanup(func() {
+		_ = model.SetPublishAccess(oldPublishAccess)
+		model.Conf, util.DataDir = oldConf, oldDataDir
+	})
+
+	boxConfPath := filepath.Join(util.DataDir, boxID, ".siyuan", "conf.json")
+	if err := os.MkdirAll(filepath.Dir(boxConfPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	boxConf := conf.NewBoxConf()
+	boxConf.Name = "Hidden notebook"
+	data, err := json.Marshal(boxConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(boxConfPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	secretPath := filepath.Join(util.DataDir, boxID, "20260821140002-secret.sy")
+	if err := os.WriteFile(secretPath, []byte("PRIVATE_NOTE_CANARY"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := model.SetPublishAccess(model.PublishAccess{{ID: boxID, Visible: false}}); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set(model.RoleContextKey, model.RoleReader)
+		c.Next()
+	})
+	engine.POST("/api/file/getFile", getFile)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/file/getFile", strings.NewReader(`{"path":"`+boxID+`/20260821140002-secret.sy"}`))
+	request.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusAccepted || !strings.Contains(recorder.Body.String(), `"code":403`) {
+		t.Fatalf("reader received hidden notebook raw file: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/kernel/model/publish_access.go
+++ b/kernel/model/publish_access.go
@@ -50,6 +50,22 @@ type PublishAccessItem struct {
 
 type PublishAccess []*PublishAccessItem
 
+// IsBoxVisibleByPublishAccess reports whether a notebook may be exposed to a
+// read-only publish context. An explicit publish-access entry is authoritative;
+// notebooks that are closed or encrypted are never visible to readers.
+func IsBoxVisibleByPublishAccess(box *Box, publishAccess PublishAccess) bool {
+	if nil == box || box.Closed || box.Encrypted {
+		return false
+	}
+
+	for _, item := range publishAccess {
+		if nil != item && item.ID == box.ID {
+			return item.Visible
+		}
+	}
+	return true
+}
+
 type PublishAccessStatus int
 
 const (
@@ -510,16 +526,22 @@ func CheckAbsPathAccessableByPublishAccess(c *gin.Context, absPath string, publi
 			return true
 		}
 
-		if assetPath, box, ok := assetPathFromDataRelativePath(relPath); ok {
-			return checkAssetPathAccessableByPublishAccess(c, publishAccess, assetPath, box)
+		if assetPath, boxID, ok := assetPathFromDataRelativePath(relPath); ok {
+			if boxID != "" && !IsBoxVisibleByPublishAccess(Conf.Box(boxID), publishAccess) {
+				return false
+			}
+			return checkAssetPathAccessableByPublishAccess(c, publishAccess, assetPath, boxID)
 		}
 
 		if ast.IsNodeIDPattern(pathParts[0]) {
-			box := pathParts[0]
+			boxID := pathParts[0]
+			if !IsBoxVisibleByPublishAccess(Conf.Box(boxID), publishAccess) {
+				return false
+			}
 			blockPath := "/" + strings.Join(pathParts[1:], "/")
-			passwordID, password := GetPathPasswordByPublishAccess(box, blockPath, publishAccess)
+			passwordID, password := GetPathPasswordByPublishAccess(boxID, blockPath, publishAccess)
 			publishIgnore := GetDisablePublishAccess(publishAccess)
-			return CheckPathAccessableByPublishIgnore(box, blockPath, publishIgnore) && (password == "" || CheckPublishAuthCookie(c, passwordID, password))
+			return CheckPathAccessableByPublishIgnore(boxID, blockPath, publishIgnore) && (password == "" || CheckPublishAuthCookie(c, passwordID, password))
 		}
 	}
 	return false
@@ -1022,12 +1044,7 @@ func clearAttributeViewSensitiveValue(value *av.Value) *av.Value {
 	return ret
 }
 
-func checkAttributeViewItemAccessableByPublishAccess(c *gin.Context, publishAccess PublishAccess, item av.Item) bool {
-	if nil == item {
-		return false
-	}
-
-	blockValue := item.GetBlockValue()
+func checkAttributeViewValueAccessableByPublishAccess(c *gin.Context, publishAccess PublishAccess, blockValue *av.Value) bool {
 	if nil == blockValue {
 		return false
 	}
@@ -1037,7 +1054,27 @@ func checkAttributeViewItemAccessableByPublishAccess(c *gin.Context, publishAcce
 	if nil == blockValue.Block || "" == blockValue.Block.ID {
 		return false
 	}
-	return CheckBlockIdAccessableByPublishAccess(c, publishAccess, blockValue.Block.ID)
+
+	blockTree := treenode.GetBlockTree(blockValue.Block.ID)
+	if nil == blockTree || IsEncryptedBoxDeniedByPublishAccess(blockTree.BoxID) {
+		return false
+	}
+	if !CheckPathAccessableByPublishIgnore(blockTree.BoxID, blockTree.Path, filterDisablePublishAccess(publishAccess)) {
+		return false
+	}
+	if CheckPathAccessableByPublishIgnore(blockTree.BoxID, blockTree.Path, filterInvisiblePublishAccess(publishAccess)) {
+		return true
+	}
+
+	passwordID, password := GetPathPasswordByPublishAccess(blockTree.BoxID, blockTree.Path, publishAccess)
+	return password != "" && CheckPublishAuthCookie(c, passwordID, password)
+}
+
+func checkAttributeViewItemAccessableByPublishAccess(c *gin.Context, publishAccess PublishAccess, item av.Item) bool {
+	if nil == item {
+		return false
+	}
+	return checkAttributeViewValueAccessableByPublishAccess(c, publishAccess, item.GetBlockValue())
 }
 
 func checkAttributeViewItemIDAccessableByPublishAccess(
@@ -1060,7 +1097,7 @@ func checkAttributeViewItemIDAccessableByPublishAccess(
 	if nil == blockValue.Block || "" == blockValue.Block.ID {
 		return false
 	}
-	return CheckBlockIdAccessableByPublishAccess(c, publishAccess, blockValue.Block.ID)
+	return CheckBlockIdMetadataAccessableByPublishAccess(c, publishAccess, blockValue.Block.ID)
 }
 
 func FilterBlockAttributeViewKeysByPublishAccess(c *gin.Context, publishAccess PublishAccess, blockAttributeViewKeys []*BlockAttributeViewKeys) (ret []*BlockAttributeViewKeys) {
@@ -1068,9 +1105,16 @@ func FilterBlockAttributeViewKeysByPublishAccess(c *gin.Context, publishAccess P
 	publishDisable := GetDisablePublishAccess(publishAccess)
 	ret = []*BlockAttributeViewKeys{}
 	for _, blockAttributeViewKey := range blockAttributeViewKeys {
+		if nil == blockAttributeViewKey {
+			continue
+		}
+
 		accessable := false
 		bts := treenode.GetBlockTrees(blockAttributeViewKey.BlockIDs)
 		for _, bt := range bts {
+			if nil == bt {
+				continue
+			}
 			passwordID, password := GetPathPasswordByPublishAccess(bt.BoxID, bt.Path, publishAccess)
 			if (password == "" || CheckPublishAuthCookie(c, passwordID, password)) &&
 				CheckPathAccessableByPublishIgnore(bt.BoxID, bt.Path, publishInvisible) &&
@@ -1079,12 +1123,108 @@ func FilterBlockAttributeViewKeysByPublishAccess(c *gin.Context, publishAccess P
 				break
 			}
 		}
-		if accessable {
-			blockAttributeViewKey.ItemPositions = nil
-			ret = append(ret, blockAttributeViewKey)
+		if !accessable {
+			continue
+		}
+
+		filtered := filterBlockAttributeViewKeysByPublishAccess(c, publishAccess, blockAttributeViewKey)
+		if nil != filtered {
+			ret = append(ret, filtered)
 		}
 	}
 	return
+}
+
+func filterBlockAttributeViewKeysByPublishAccess(c *gin.Context, publishAccess PublishAccess, blockAttributeViewKey *BlockAttributeViewKeys) *BlockAttributeViewKeys {
+	attrView, _ := av.ParseAttributeView(blockAttributeViewKey.AvID)
+	var blockKeyValues *av.KeyValues
+	if nil != attrView {
+		blockKeyValues = attrView.GetBlockKeyValues()
+	} else {
+		for _, keyValues := range blockAttributeViewKey.KeyValues {
+			if nil != keyValues && nil != keyValues.Key && av.KeyTypeBlock == keyValues.Key.Type {
+				blockKeyValues = keyValues
+				break
+			}
+		}
+	}
+	accessibleItemIDs := map[string]bool{}
+	if nil != blockKeyValues {
+		for _, value := range blockKeyValues.Values {
+			if nil == value || "" == value.BlockID {
+				continue
+			}
+			accessibleItemIDs[value.BlockID] = checkAttributeViewValueAccessableByPublishAccess(c, publishAccess, value)
+		}
+	}
+
+	var filter *attributeViewPublishAccessFilter
+	if nil != attrView {
+		filter = &attributeViewPublishAccessFilter{
+			c:               c,
+			publishAccess:   publishAccess,
+			attributeViews:  map[string]*av.AttributeView{attrView.ID: attrView},
+			attributeAccess: map[string]bool{},
+			itemAccess:      map[string]map[string]bool{},
+		}
+	}
+	filteredKeyValues := make([]*av.KeyValues, 0, len(blockAttributeViewKey.KeyValues))
+	for _, keyValues := range blockAttributeViewKey.KeyValues {
+		if nil == keyValues || nil == keyValues.Key {
+			continue
+		}
+		filteredKeyValues = append(filteredKeyValues, &av.KeyValues{Key: keyValues.Key})
+		filtered := filteredKeyValues[len(filteredKeyValues)-1]
+		for _, value := range keyValues.Values {
+			if nil == value || !accessibleItemIDs[value.BlockID] {
+				continue
+			}
+			filteredValue := value
+			if nil != filter {
+				filteredValue, _ = filter.filterValue(attrView, keyValues.Key, value, value.BlockID)
+			}
+			if nil != filteredValue {
+				filtered.Values = append(filtered.Values, filteredValue)
+			}
+		}
+	}
+
+	return &BlockAttributeViewKeys{
+		AvID:          blockAttributeViewKey.AvID,
+		AvName:        blockAttributeViewKey.AvName,
+		BlockIDs:      slices.Clone(blockAttributeViewKey.BlockIDs),
+		KeyValues:     filteredKeyValues,
+		ItemPositions: filterAttributeViewItemPositions(blockAttributeViewKey.ItemPositions, accessibleItemIDs),
+	}
+}
+
+func filterAttributeViewItemPositions(positions []*AttributeViewItemPosition, accessibleItemIDs map[string]bool) []*AttributeViewItemPosition {
+	if 0 == len(positions) {
+		return nil
+	}
+
+	ret := make([]*AttributeViewItemPosition, 0, len(positions))
+	for _, position := range positions {
+		if nil == position {
+			continue
+		}
+		filtered := &AttributeViewItemPosition{ViewID: position.ViewID, PreviousID: position.PreviousID}
+		if filtered.PreviousID != "" && !accessibleItemIDs[filtered.PreviousID] {
+			filtered.PreviousID = ""
+		}
+		for _, group := range position.Groups {
+			if nil == group {
+				continue
+			}
+			filteredGroup := &AttributeViewGroupItemPosition{GroupID: group.GroupID, PreviousID: group.PreviousID}
+			if filteredGroup.PreviousID != "" && !accessibleItemIDs[filteredGroup.PreviousID] {
+				filteredGroup.PreviousID = ""
+			}
+			filtered.Groups = append(filtered.Groups, filteredGroup)
+		}
+		ret = append(ret, filtered)
+	}
+	return ret
 }
 
 func FilterAttributeViewBacklinksByPublishAccess(c *gin.Context, publishAccess PublishAccess, backlinks *AttributeViewBacklinks) (ret *AttributeViewBacklinks) {

--- a/kernel/model/publish_access_hardening_test.go
+++ b/kernel/model/publish_access_hardening_test.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/88250/lute/ast"
+	"github.com/gin-gonic/gin"
+	"github.com/siyuan-note/siyuan/kernel/av"
+	"github.com/siyuan-note/siyuan/kernel/treenode"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+func TestFilterBlockAttributeViewKeysRemovesHiddenRows(t *testing.T) {
+	const (
+		boxID        = "20260821130000-avbox01"
+		databaseID   = "20260821130001-avdb01"
+		visibleRowID = "20260821130002-avrow01"
+		hiddenRowID  = "20260821130003-avrow02"
+	)
+
+	oldDataDir, oldBlockTreeDBPath := util.DataDir, util.BlockTreeDBPath
+	util.DataDir = t.TempDir()
+	util.BlockTreeDBPath = filepath.Join(util.DataDir, "blocktree.db")
+	treenode.InitBlockTree(true)
+	t.Cleanup(func() {
+		treenode.CloseDatabase()
+		util.DataDir, util.BlockTreeDBPath = oldDataDir, oldBlockTreeDBPath
+	})
+
+	for _, id := range []string{databaseID, visibleRowID, hiddenRowID} {
+		tree := treenode.NewTree(boxID, "/"+id+".sy", "/"+id, id)
+		tree.Root.AppendChild(&ast.Node{ID: id + "-p", Type: ast.NodeParagraph})
+		treenode.UpsertBlockTree(tree)
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set(RoleContextKey, RoleReader)
+
+	blockKey := &av.Key{ID: "20260821130004-block", Type: av.KeyTypeBlock, Name: "Name"}
+	secretKey := &av.Key{ID: "20260821130005-secret", Type: av.KeyTypeText, Name: "Secret"}
+	blockValue := func(rowID string) *av.Value {
+		return &av.Value{
+			ID:      rowID + "-value",
+			KeyID:   blockKey.ID,
+			BlockID: rowID,
+			Type:    av.KeyTypeBlock,
+			Block:   &av.ValueBlock{ID: rowID, Content: rowID},
+		}
+	}
+	secretValue := func(rowID, content string) *av.Value {
+		return &av.Value{
+			ID:      rowID + "-secret-value",
+			KeyID:   secretKey.ID,
+			BlockID: rowID,
+			Type:    av.KeyTypeText,
+			Text:    &av.ValueText{Content: content},
+		}
+	}
+
+	filtered := FilterBlockAttributeViewKeysByPublishAccess(c, PublishAccess{{ID: hiddenRowID, Visible: false}}, []*BlockAttributeViewKeys{{
+		AvID:     "20260821130006-av0001",
+		BlockIDs: []string{databaseID},
+		KeyValues: []*av.KeyValues{
+			{Key: blockKey, Values: []*av.Value{blockValue(visibleRowID), blockValue(hiddenRowID)}},
+			{Key: secretKey, Values: []*av.Value{secretValue(visibleRowID, "PUBLIC_ROW"), secretValue(hiddenRowID, "PRIVATE_ROW_CANARY")}},
+		},
+	}})
+	if len(filtered) != 1 {
+		t.Fatalf("expected one visible attribute view, got %d", len(filtered))
+	}
+	for _, keyValues := range filtered[0].KeyValues {
+		for _, value := range keyValues.Values {
+			if value.BlockID == hiddenRowID {
+				t.Fatalf("hidden row value survived publish filtering: key=%s value=%+v", keyValues.Key.ID, value)
+			}
+		}
+	}
+}
+
+func TestHiddenAttributeViewRowRequiresVisibilityOrPassword(t *testing.T) {
+	const (
+		boxID    = "20260821131000-box"
+		docID    = "20260821131001-doc"
+		password = "publish-password"
+	)
+	oldDataDir, oldBlockTreeDBPath := util.DataDir, util.BlockTreeDBPath
+	util.DataDir = t.TempDir()
+	util.BlockTreeDBPath = filepath.Join(util.DataDir, "blocktree.db")
+	treenode.InitBlockTree(true)
+	t.Cleanup(func() {
+		treenode.CloseDatabase()
+		util.DataDir, util.BlockTreeDBPath = oldDataDir, oldBlockTreeDBPath
+	})
+	treenode.UpsertBlockTree(treenode.NewTree(boxID, "/"+docID+".sy", "/"+docID, docID))
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	row := &av.Value{BlockID: docID, Type: av.KeyTypeBlock, Block: &av.ValueBlock{ID: docID}}
+	if checkAttributeViewValueAccessableByPublishAccess(c, PublishAccess{{ID: docID, Visible: false}}, row) {
+		t.Fatal("hidden attribute-view row without a password should be filtered")
+	}
+	protected := PublishAccess{{ID: docID, Visible: false, Password: password}}
+	if checkAttributeViewValueAccessableByPublishAccess(c, protected, row) {
+		t.Fatal("password-protected hidden attribute-view row should require its publish cookie")
+	}
+	c.Request.AddCookie(&http.Cookie{Name: "publish-auth-" + docID, Value: util.SHA256Hash([]byte(docID + password))})
+	if !checkAttributeViewValueAccessableByPublishAccess(c, protected, row) {
+		t.Fatal("authorized password-protected attribute-view row should remain visible")
+	}
+	if !checkAttributeViewValueAccessableByPublishAccess(c, PublishAccess{}, row) {
+		t.Fatal("default-visible attribute-view row should remain visible")
+	}
+}


### PR DESCRIPTION
## Description / 描述

This bug-fix PR hardens publish-reader authorization at four narrowly scoped boundaries identified during a local SiYuan security audit. It filters hidden attribute-view row values and hidden previous-row positions, denies reader access to attribute-view key definitions when all mirror databases are hidden, blocks hidden-notebook document/reference save-path configuration disclosure, and makes raw-file publish access fail closed for hidden, closed, encrypted, or missing notebooks.

The patch is intentionally limited to reader-side filtering. Administrator and editor behavior is preserved. Full-text-search count recomputation is not included because correct remediation requires a separate pagination redesign rather than an unsafe count-only workaround.

## Changes

- Filter `BlockAttributeViewKeys` at row level using the bound block value and the existing publish-access path machinery. Nested relation/rollup values continue through the existing recursive sanitizer, and returned previous-item positions are cleared when their predecessor is not visible.
- Add a reader-only visibility gate to `POST /api/av/getAttributeViewKeysByID`.
- Add reader-only visibility checks to `POST /api/filetree/getDocCreateSavePath` and `POST /api/filetree/getRefCreateSavePath`.
- Make `CheckAbsPathAccessableByPublishAccess` reject paths under notebooks that are not publish-visible before evaluating document-path rules.
- Add first-party model and API regression tests for hidden rows, hidden key definitions, hidden save-path configuration, hidden raw files, password-protected rows, and existing notebook visibility behavior.

## Validation

Focused hardening tests pass:

```text
ok   github.com/siyuan-note/siyuan/kernel/model
ok   github.com/siyuan-note/siyuan/kernel/api
```

`go vet ./api ./model` and `git diff --check` pass. The full API suite passes when excluding the pre-existing `TestPublishReaderCannotBrowseEncryptedNotebook` panic. The full model suite passes when excluding the pre-existing `TestAddAttributeViewBlockAcceptsValidBoundItemWithoutDatabaseBlock` panic and four environment-sensitive Obsidian import tests. A clean worktree at the base commit reproduced the same baseline API/model failures and the same util path-guard failures; no unrelated baseline failure was changed by this PR.

GitHub reports this master-based comparison as automatically mergeable. The branch contains two commits and five changed files.

## Security rationale

Hidden notebooks and documents are explicit confidentiality boundaries in SiYuan’s publish-access model. Response serializers, configuration endpoints, and raw-file path authorization must enforce that boundary consistently. The regression tests assert that hidden canaries do not survive reader responses while preserving visible and password-authorized behavior.

## Checklist / 检查清单

- [x] I have performed a self-review of my own code.
- [x] I have full rights to the submitted code and agree to license it under this project’s AGPL-3.0 license.
- [x] The pull request has no merge conflicts against the selected `master` base branch.
