### PR TITLE
fix: replace marketplace package dir on update

### DIFF
--- a/kernel/bazaar/install.go
+++ b/kernel/bazaar/install.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/88250/gulu"
@@ -36,6 +37,7 @@ import (
 
 var downloadPackageFlight singleflight.Group
 var bazaarDownloadCloudServer = util.GetCloudServer
+var packageInstallLock sync.Mutex
 
 // downloadBazaarFile 下载集市文件
 func downloadBazaarFile(repoURLHash string, pushProgress bool) (data []byte, err error) {
@@ -190,6 +192,9 @@ func installPackage(data []byte, installPath, pkgType, packageName string, updat
 // 先拷到安装目录同级的 staging，更新时再把旧目录 rename 成 backup，最后把 staging rename 成目标路径。
 // 这样新包已删除的文件不会残留，失败时也可以把 backup rename 回去。
 func replacePackageDirectory(sourcePath, installPath string, update bool) (err error) {
+	packageInstallLock.Lock()
+	defer packageInstallLock.Unlock()
+
 	if err = os.MkdirAll(filepath.Dir(installPath), 0755); err != nil {
 		return
 	}
@@ -207,13 +212,25 @@ func replacePackageDirectory(sourcePath, installPath string, update bool) (err e
 		return
 	}
 
-	if update {
+	entries, statErr := os.ReadDir(installPath)
+	targetExists := statErr == nil
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return statErr
+	}
+	if targetExists && !update && 0 < len(entries) {
+		return errors.New("marketplace package install path already exists")
+	}
+	if update && !targetExists {
+		return os.ErrNotExist
+	}
+
+	if targetExists {
 		if err = os.Rename(installPath, backupPath); err != nil {
 			return
 		}
 	}
 	if err = os.Rename(stagingPath, installPath); err != nil {
-		if update {
+		if targetExists {
 			if rollbackErr := os.Rename(backupPath, installPath); rollbackErr != nil {
 				preserveOperationPath = true
 				return fmt.Errorf("install marketplace package failed: %w; rollback failed: %s", err, rollbackErr)
@@ -221,7 +238,7 @@ func replacePackageDirectory(sourcePath, installPath string, update bool) (err e
 		}
 		return
 	}
-	if update {
+	if targetExists {
 		if removeErr := os.RemoveAll(operationPath); removeErr != nil {
 			logging.LogWarnf("remove package backup [%s] failed: %s", backupPath, removeErr)
 		}
@@ -250,6 +267,9 @@ func InstallLocalPackage(sourcePath, installPath, pkgType, packageName string, u
 
 // UninstallPackage 卸载集市包
 func UninstallPackage(installPath string) (err error) {
+	packageInstallLock.Lock()
+	defer packageInstallLock.Unlock()
+
 	if err = os.RemoveAll(installPath); err != nil {
 		logging.LogErrorf("remove [%s] failed: %s", installPath, err)
 		return fmt.Errorf("remove community package [%s] failed", filepath.Base(installPath))

--- a/kernel/bazaar/install.go
+++ b/kernel/bazaar/install.go
@@ -180,22 +180,20 @@ func installPackage(data []byte, installPath, pkgType, packageName string, updat
 		return fmt.Errorf("marketplace package name mismatch: expected [%s], got [%s]", packageName, pkg.Name)
 	}
 
-	if err = filelock.Copy(srcPath, installPath); err != nil {
+	if err = replacePackageDirectory(srcPath, installPath, update); err != nil {
 		return
 	}
 	return
 }
 
-// InstallLocalPackage 从已解压并验证的目录安装本地集市包。
-func InstallLocalPackage(sourcePath, installPath, pkgType, packageName string, update bool) (err error) {
+// replacePackageDirectory 将 sourcePath 整目录替换到 installPath。
+// 先拷到安装目录同级的 staging，更新时再把旧目录 rename 成 backup，最后把 staging rename 成目标路径。
+// 这样新包已删除的文件不会残留，失败时也可以把 backup rename 回去。
+func replacePackageDirectory(sourcePath, installPath string, update bool) (err error) {
 	if err = os.MkdirAll(filepath.Dir(installPath), 0755); err != nil {
 		return
 	}
 
-	var fallbackInstallTime time.Time
-	if info, statErr := os.Stat(installPath); statErr == nil {
-		fallbackInstallTime = info.ModTime()
-	}
 	operationPath := filepath.Join(filepath.Dir(installPath), ".siyuan-package-install-"+gulu.Rand.String(7))
 	stagingPath := filepath.Join(operationPath, "staging")
 	backupPath := filepath.Join(operationPath, "backup")
@@ -218,15 +216,27 @@ func InstallLocalPackage(sourcePath, installPath, pkgType, packageName string, u
 		if update {
 			if rollbackErr := os.Rename(backupPath, installPath); rollbackErr != nil {
 				preserveOperationPath = true
-				return fmt.Errorf("install local marketplace package failed: %w; rollback failed: %s", err, rollbackErr)
+				return fmt.Errorf("install marketplace package failed: %w; rollback failed: %s", err, rollbackErr)
 			}
 		}
 		return
 	}
 	if update {
 		if removeErr := os.RemoveAll(operationPath); removeErr != nil {
-			logging.LogWarnf("remove local package backup [%s] failed: %s", backupPath, removeErr)
+			logging.LogWarnf("remove package backup [%s] failed: %s", backupPath, removeErr)
 		}
+	}
+	return
+}
+
+// InstallLocalPackage 从已解压并验证的目录安装本地集市包。
+func InstallLocalPackage(sourcePath, installPath, pkgType, packageName string, update bool) (err error) {
+	var fallbackInstallTime time.Time
+	if info, statErr := os.Stat(installPath); statErr == nil {
+		fallbackInstallTime = info.ModTime()
+	}
+	if err = replacePackageDirectory(sourcePath, installPath, update); err != nil {
+		return
 	}
 
 	RemoveInstalledPackageSizeCache(pkgType, packageName)

--- a/kernel/bazaar/install_test.go
+++ b/kernel/bazaar/install_test.go
@@ -198,6 +198,61 @@ func TestInstallPackageFreshInstall(t *testing.T) {
 	}
 }
 
+// TestInstallPackageFreshInstallReplacesEmptyDirectory 校验新安装可以替换已存在的空目标目录
+func TestInstallPackageFreshInstallReplacesEmptyDirectory(t *testing.T) {
+	oldTempDir := util.TempDir
+	util.TempDir = t.TempDir()
+	t.Cleanup(func() { util.TempDir = oldTempDir })
+
+	installPath := filepath.Join(t.TempDir(), "plugins", "sample")
+	if err := os.MkdirAll(installPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data := buildInstallPackageArchive(t, map[string]string{
+		"plugin.json": `{"name":"sample","version":"1.0.0"}`,
+		"index.js":    "new",
+	})
+	if err := installPackage(data, installPath, "plugins", "sample", false); err != nil {
+		t.Fatalf("expected fresh install into empty directory to succeed: %s", err)
+	}
+	if _, err := os.Stat(filepath.Join(installPath, "index.js")); err != nil {
+		t.Fatalf("installed file is missing: %s", err)
+	}
+}
+
+// TestReplacePackageDirectoryRechecksNonEmptyTarget 校验目录交换前会重新拒绝覆盖非空目标目录
+func TestReplacePackageDirectoryRechecksNonEmptyTarget(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "source")
+	installPath := filepath.Join(root, "plugins", "sample")
+	if err := os.MkdirAll(sourcePath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(installPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourcePath, "new.js"), []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installPath, "original.js"), []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := replacePackageDirectory(sourcePath, installPath, false); err == nil {
+		t.Fatal("expected replacing a non-empty target without update to be rejected")
+	}
+	content, err := os.ReadFile(filepath.Join(installPath, "original.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "original" {
+		t.Fatalf("existing package file was changed: %q", content)
+	}
+	if _, err = os.Stat(filepath.Join(installPath, "new.js")); !os.IsNotExist(err) {
+		t.Fatalf("new package file was written unexpectedly: %v", err)
+	}
+}
+
 // TestInstallPackageMissingManifest 校验下载包缺少清单文件时拒绝安装
 func TestInstallPackageMissingManifest(t *testing.T) {
 	oldTempDir := util.TempDir

--- a/kernel/bazaar/install_test.go
+++ b/kernel/bazaar/install_test.go
@@ -112,6 +112,46 @@ func TestInstallPackageRefusesOverwriteWithoutUpdate(t *testing.T) {
 	}
 }
 
+// TestInstallPackageUpdateReplacesDirectory 校验在线更新会整目录替换，新版本已删除的文件不会残留
+// https://github.com/siyuan-note/siyuan/issues/18933
+func TestInstallPackageUpdateReplacesDirectory(t *testing.T) {
+	oldTempDir := util.TempDir
+	util.TempDir = t.TempDir()
+	t.Cleanup(func() { util.TempDir = oldTempDir })
+
+	installPath := filepath.Join(t.TempDir(), "plugins", "sample")
+	if err := os.MkdirAll(installPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installPath, "stale.js"), []byte("stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installPath, "plugin.json"), []byte(`{"name":"sample","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := buildInstallPackageArchive(t, map[string]string{
+		"plugin.json": `{"name":"sample","version":"2.0.0"}`,
+		"new.js":      "new",
+	})
+	if err := installPackage(data, installPath, "plugins", "sample", true); err != nil {
+		t.Fatalf("expected update install to succeed: %s", err)
+	}
+	if _, err := os.Stat(filepath.Join(installPath, "new.js")); err != nil {
+		t.Fatalf("new package file is missing: %s", err)
+	}
+	if _, err := os.Stat(filepath.Join(installPath, "stale.js")); !os.IsNotExist(err) {
+		t.Fatalf("stale package file was not removed: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(installPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "sample" {
+		t.Fatalf("temporary installation directory was not cleaned up: %#v", entries)
+	}
+}
+
 // TestInstallPackageUpdateOverwrites 校验对同名已安装包的更新安装正常覆盖
 func TestInstallPackageUpdateOverwrites(t *testing.T) {
 	oldTempDir := util.TempDir


### PR DESCRIPTION
Closes #18933

Online marketplace update copied files over the existing install directory, so files removed in the new package stayed behind. Local zip install already swapped the directory.

Reuse that staging/backup rename path for online update so dropped files disappear. Failed rename rolls back to the previous package.

Test: `cd kernel && go test ./bazaar -run 'TestInstallPackage|TestInstallLocalPackage' -count=1`