### PR TITLE
Support loading bundled Skill resource files

### DIFF
--- a/kernel/mcp/server_test.go
+++ b/kernel/mcp/server_test.go
@@ -22,11 +22,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/siyuan-note/siyuan/kernel/mcp/tools"
+	"github.com/siyuan-note/siyuan/kernel/util"
 )
 
 func newTestHTTPServer(t *testing.T) (*mcpsdk.Server, *httptest.Server) {
@@ -389,6 +392,44 @@ func TestToolInputAndOutputValidation(t *testing.T) {
 	outputText, ok := outputResult.Content[0].(*mcpsdk.TextContent)
 	if !ok || !strings.Contains(outputText.Text, "must not be retried automatically") {
 		t.Fatalf("invalid output did not warn against retrying: %#v", outputResult.Content)
+	}
+}
+
+func TestSkillResourceContentSurvivesMCPConversion(t *testing.T) {
+	originalDataDir, originalHomeDir := util.DataDir, util.HomeDir
+	root := t.TempDir()
+	util.DataDir = filepath.Join(root, "workspace", "data")
+	util.HomeDir = filepath.Join(root, "home")
+	t.Cleanup(func() {
+		util.DataDir, util.HomeDir = originalDataDir, originalHomeDir
+	})
+
+	skillDir := filepath.Join(util.SkillsDir(), "transport-skill")
+	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: transport-skill\ndescription: transport test\n---\nbody"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "references", "valid.txt"), []byte("中文内容"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := tools.SkillTool.Handler(map[string]any{
+		"action": "load",
+		"name":   "transport-skill/references/valid.txt",
+	})
+	if err != nil || result.IsError || len(result.Content) != 1 {
+		t.Fatalf("unexpected Skill resource result: %#v, %v", result, err)
+	}
+	converted, err := convertContentItem(result.Content[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, ok := converted.(*mcpsdk.TextContent)
+	if !ok || text.Text != "<skill_resource skill=\"transport-skill\" path=\"references/valid.txt\">\n\n中文内容\n\n</skill_resource>" {
+		t.Fatalf("Skill resource changed during MCP conversion: %#v", converted)
 	}
 }
 

--- a/kernel/mcp/tools/skill.go
+++ b/kernel/mcp/tools/skill.go
@@ -101,12 +101,11 @@ func skillLoad(args map[string]any) (CallToolResult, error) {
 
 	var result string
 	if loaded.ResourcePath == "" {
-		// 变量（非敏感）在技能正文注入对话时解析。
+		// Variables.Resolve 还会匹配 $NAME 和 ${NAME}。
 		// 资源可能包含脚本或模板，因此只解析技能正文，避免误改资源内容。
 		loaded.Content = model.Conf.Variables.Resolve(loaded.Content)
 		result = formatSkillContent(loaded)
 	} else {
-		// 不做变量解析注入，避免误杀 $NAME ${NAME} 等 reference 文件中常见模式
 		result = formatSkillResource(loaded)
 	}
 	return CallToolResult{

--- a/kernel/mcp/tools/skill.go
+++ b/kernel/mcp/tools/skill.go
@@ -101,10 +101,12 @@ func skillLoad(args map[string]any) (CallToolResult, error) {
 
 	var result string
 	if loaded.ResourcePath == "" {
-		// 变量（非敏感）仅在技能正文注入对话时解析；资源文件必须保持原文。
+		// 变量（非敏感）在技能正文注入对话时解析。
+		// 资源可能包含脚本或模板，因此只解析技能正文，避免误改资源内容。
 		loaded.Content = model.Conf.Variables.Resolve(loaded.Content)
 		result = formatSkillContent(loaded)
 	} else {
+		// 不做变量解析注入，避免误杀 $NAME ${NAME} 等 reference 文件中常见模式
 		result = formatSkillResource(loaded)
 	}
 	return CallToolResult{

--- a/kernel/mcp/tools/skill.go
+++ b/kernel/mcp/tools/skill.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"fmt"
 	"html"
+	"path/filepath"
 	"strings"
 
 	"github.com/siyuan-note/siyuan/kernel/model"
@@ -27,12 +28,15 @@ import (
 
 var SkillTool = &Tool{
 	Name:        "skill",
-	Description: "Skill operations: load(name), save(name, content), install(url), remove(name), rename(name, new_name), list().\n\n" + skillListDesc(),
+	Description: "Skill operations: load(name) loads Skill instructions; load(name/resource-path) loads a bundled text resource; save(name, content), install(url), remove(name), rename(name, new_name), list().\n\n" + skillListDesc(),
 	InputSchema: ToolSchema{
 		Type: "object",
 		Properties: map[string]Property{
-			"action":   {Type: "string", Description: "Operation", Enum: []string{"load", "save", "install", "remove", "rename", "list"}},
-			"name":     {Type: "string", Description: "Skill name (directory name)"},
+			"action": {Type: "string", Description: "Operation", Enum: []string{"load", "save", "install", "remove", "rename", "list"}},
+			"name": {
+				Type:        "string",
+				Description: "Skill name. For load, use <skill-name> for instructions or <skill-name>/<relative-resource-path> for a bundled text resource",
+			},
 			"content":  {Type: "string", Description: "SKILL.md full content with YAML frontmatter (for save)"},
 			"url":      {Type: "string", Description: "Skill source for install: 'owner/repo' shorthand (e.g. Tencent/WeChatReading), a full GitHub URL, a raw SKILL.md URL, or a release zip URL"},
 			"new_name": {Type: "string", Description: "New skill name (for rename)"},
@@ -87,21 +91,75 @@ func skillLoad(args map[string]any) (CallToolResult, error) {
 		}, nil
 	}
 
-	content := util.LoadSkillContent(name, model.EnabledUserSkills())
-	if content == "" {
+	loaded, err := util.LoadSkill(name, model.EnabledUserSkills())
+	if err != nil {
 		return CallToolResult{
-			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("skill not found: %s", name)}},
+			Content: []ContentItem{{Type: "text", Text: err.Error()}},
 			IsError: true,
 		}, nil
 	}
 
-	// 变量（非敏感）在技能正文注入对话时解析，让 LLM 看到实际值；密钥不进上下文。
-	content = model.Conf.Variables.Resolve(content)
-
-	result := "<skill_content name=\"" + html.EscapeString(name) + "\">\n\n" + content + "\n\n</skill_content>"
+	var result string
+	if loaded.ResourcePath == "" {
+		// 变量（非敏感）仅在技能正文注入对话时解析；资源文件必须保持原文。
+		loaded.Content = model.Conf.Variables.Resolve(loaded.Content)
+		result = formatSkillContent(loaded)
+	} else {
+		result = formatSkillResource(loaded)
+	}
 	return CallToolResult{
 		Content: []ContentItem{{Type: "text", Text: result}},
 	}, nil
+}
+
+func formatSkillContent(loaded *util.SkillLoadResult) string {
+	var sb strings.Builder
+	sb.WriteString(`<skill_content name="`)
+	sb.WriteString(html.EscapeString(loaded.Name))
+	sb.WriteString("\">\n\n")
+	sb.WriteString(loaded.Content)
+
+	if len(loaded.Resources) > 0 || loaded.ResourcesTruncated {
+		sb.WriteString("\n\n<skill_resources")
+		if loaded.ResourcesTruncated {
+			sb.WriteString(` truncated="true"`)
+		}
+		sb.WriteString(">\n")
+		for _, resource := range loaded.Resources {
+			sb.WriteString("  <file>")
+			sb.WriteString(html.EscapeString(resource))
+			sb.WriteString("</file>\n")
+		}
+		sb.WriteString("</skill_resources>")
+	}
+
+	if location := workspaceSkillLocation(loaded.SkillDir); location != "" {
+		sb.WriteString("\n\n<skill_location path=\"")
+		sb.WriteString(html.EscapeString(location))
+		sb.WriteString("\">\n")
+		sb.WriteString("  For this skill directory, use the `file` tool's read-only actions: `read`, `list`, `grep`, and `find`.\n")
+		sb.WriteString("</skill_location>")
+	}
+
+	sb.WriteString("\n\n</skill_content>")
+	return sb.String()
+}
+
+func formatSkillResource(loaded *util.SkillLoadResult) string {
+	return `<skill_resource skill="` + html.EscapeString(loaded.Name) + `" path="` +
+		html.EscapeString(loaded.ResourcePath) + "\">\n\n" + loaded.Content + "\n\n</skill_resource>"
+}
+
+func workspaceSkillLocation(skillDir string) string {
+	location, err := filepath.Rel(util.WorkspaceDir, skillDir)
+	if err != nil {
+		return ""
+	}
+	location = filepath.ToSlash(location)
+	if _, err = resolvePath(location); err != nil {
+		return ""
+	}
+	return location
 }
 
 func skillSave(args map[string]any) (CallToolResult, error) {

--- a/kernel/mcp/tools/skill_test.go
+++ b/kernel/mcp/tools/skill_test.go
@@ -1,0 +1,119 @@
+// SiYuan - From thought to insight, with agents
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	kernelConf "github.com/siyuan-note/siyuan/kernel/conf"
+	"github.com/siyuan-note/siyuan/kernel/model"
+	"github.com/siyuan-note/siyuan/kernel/util"
+)
+
+func setSkillToolTestEnvironment(t *testing.T) string {
+	t.Helper()
+	originalWorkspaceDir, originalDataDir := util.WorkspaceDir, util.DataDir
+	originalHomeDir, originalConfDir := util.HomeDir, util.ConfDir
+	originalConf := model.Conf
+
+	root := t.TempDir()
+	util.WorkspaceDir = filepath.Join(root, "workspace")
+	util.DataDir = filepath.Join(util.WorkspaceDir, "data")
+	util.HomeDir = filepath.Join(root, "home")
+	util.ConfDir = filepath.Join(util.WorkspaceDir, "conf")
+	model.Conf = model.NewAppConf()
+	model.Conf.Variables = &kernelConf.Variables{Items: []*kernelConf.Variable{{Name: "VALUE", Value: "resolved"}}}
+	t.Cleanup(func() {
+		util.WorkspaceDir, util.DataDir = originalWorkspaceDir, originalDataDir
+		util.HomeDir, util.ConfDir = originalHomeDir, originalConfDir
+		model.Conf = originalConf
+	})
+	return util.SkillsDir()
+}
+
+func writeSkillToolTestFile(t *testing.T, file, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSkillLoadFormatsActivationAndRawResource(t *testing.T) {
+	skillsRoot := setSkillToolTestEnvironment(t)
+	skillDir := filepath.Join(skillsRoot, "skill-dir")
+	writeSkillToolTestFile(t, filepath.Join(skillDir, "SKILL.md"),
+		"---\nname: A&B\ndescription: description\n---\nbody {{vars.VALUE}}")
+	writeSkillToolTestFile(t, filepath.Join(skillDir, "references", "spec&notes.md"), "{{vars.VALUE}}\n")
+
+	activation, err := skillLoad(map[string]any{"name": "A&B"})
+	if err != nil || activation.IsError {
+		t.Fatalf("skillLoad(activation) = %#v, %v", activation, err)
+	}
+	activationText := activation.Content[0].Text
+	for _, expected := range []string{
+		`<skill_content name="A&amp;B">`,
+		"body resolved",
+		"<file>references/spec&amp;notes.md</file>",
+		`<skill_location path="data/storage/ai/agent/skills/skill-dir">`,
+		"use the `file` tool's read-only actions: `read`, `list`, `grep`, and `find`",
+	} {
+		if !strings.Contains(activationText, expected) {
+			t.Errorf("activation output is missing %q:\n%s", expected, activationText)
+		}
+	}
+
+	resource, err := skillLoad(map[string]any{"name": "A&B/references/spec&notes.md"})
+	if err != nil || resource.IsError {
+		t.Fatalf("skillLoad(resource) = %#v, %v", resource, err)
+	}
+	resourceText := resource.Content[0].Text
+	if !strings.Contains(resourceText, `<skill_resource skill="A&amp;B" path="references/spec&amp;notes.md">`) ||
+		!strings.Contains(resourceText, "{{vars.VALUE}}") {
+		t.Fatalf("unexpected resource output:\n%s", resourceText)
+	}
+	for _, excluded := range []string{"<skill_resources", "<skill_location", "resolved"} {
+		if strings.Contains(resourceText, excluded) {
+			t.Errorf("resource output unexpectedly contains %q:\n%s", excluded, resourceText)
+		}
+	}
+
+	truncated := formatSkillContent(&util.SkillLoadResult{Name: "truncated", ResourcesTruncated: true})
+	if !strings.Contains(truncated, `<skill_resources truncated="true">`) {
+		t.Fatalf("truncated empty manifest is not reported:\n%s", truncated)
+	}
+}
+
+func TestSkillContentOmitsLocationForWorkspaceSymlinkEscape(t *testing.T) {
+	skillsRoot := setSkillToolTestEnvironment(t)
+	externalSkill := filepath.Join(t.TempDir(), "external-skill")
+	writeSkillToolTestFile(t, filepath.Join(externalSkill, "SKILL.md"),
+		"---\nname: external\ndescription: description\n---\nbody")
+	if err := os.MkdirAll(skillsRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	linkedSkill := filepath.Join(skillsRoot, "external")
+	if err := os.Symlink(externalSkill, linkedSkill); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	loaded, err := util.LoadSkill("external", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := formatSkillContent(loaded)
+	if strings.Contains(output, "<skill_location") {
+		t.Fatalf("symlinked external skill exposed a file location:\n%s", output)
+	}
+}

--- a/kernel/mcp/tools/skill_test.go
+++ b/kernel/mcp/tools/skill_test.go
@@ -50,7 +50,7 @@ func writeSkillToolTestFile(t *testing.T, file, content string) {
 	}
 }
 
-func TestSkillLoadFormatsActivationAndRawResource(t *testing.T) {
+func TestSkillLoadResolvesVariablesOnlyInInstructions(t *testing.T) {
 	skillsRoot := setSkillToolTestEnvironment(t)
 	skillDir := filepath.Join(skillsRoot, "skill-dir")
 	writeSkillToolTestFile(t, filepath.Join(skillDir, "SKILL.md"),

--- a/kernel/util/skill.go
+++ b/kernel/util/skill.go
@@ -28,6 +28,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/88250/gulu"
 	"github.com/siyuan-note/filelock"
@@ -385,6 +386,9 @@ func readSkillResource(skillDir, skillName, resource string) (string, error) {
 	}
 	if len(data) > maxSkillResourceBytes {
 		return "", fmt.Errorf("skill resource exceeds the %d byte limit: %s/%s", maxSkillResourceBytes, skillName, resource)
+	}
+	if !utf8.Valid(data) {
+		return "", fmt.Errorf("skill resource is not valid UTF-8: %s/%s", skillName, resource)
 	}
 	return string(data), nil
 }

--- a/kernel/util/skill.go
+++ b/kernel/util/skill.go
@@ -20,10 +20,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/88250/gulu"
@@ -52,6 +55,23 @@ type skillRecord struct {
 	Content string
 	Body    string
 }
+
+// SkillLoadResult 描述技能正文激活或单个资源读取的结果。
+type SkillLoadResult struct {
+	Name               string
+	Content            string
+	ResourcePath       string
+	Resources          []string
+	ResourcesTruncated bool
+	SkillDir           string
+}
+
+const (
+	maxSkillResourceEntries       = 200
+	maxSkillResourceVisited       = 2000
+	maxSkillResourceManifestBytes = 64 * 1024
+	maxSkillResourceBytes         = 64 * 1024
+)
 
 func SkillsDir() string {
 	return filepath.Join(DataDir, "storage", "ai", "agent", "skills")
@@ -216,11 +236,157 @@ func findSkillRecord(records []skillRecord, name string) (skillRecord, bool) {
 	return skillRecord{}, false
 }
 
-func LoadSkillContent(name string, enabledUserSkills []string) string {
-	if record, ok := findSkillRecord(resolveSkillRecords(enabledUserSkills), name); ok {
-		return record.Body
+// LoadSkill 按技能名加载正文，或按“技能名/相对路径”加载单个文本资源。
+func LoadSkill(locator string, enabledUserSkills []string) (*SkillLoadResult, error) {
+	name, resource := splitSkillLocator(locator)
+	record, ok := findSkillRecord(resolveSkillRecords(enabledUserSkills), name)
+	if !ok {
+		return nil, fmt.Errorf("skill not found: %s", name)
 	}
-	return ""
+
+	skillDir := filepath.Join(record.Root, record.DirName)
+	result := &SkillLoadResult{
+		Name:     name,
+		Content:  record.Body,
+		SkillDir: skillDir,
+	}
+	if resource == "" {
+		result.Resources, result.ResourcesTruncated = listSkillResources(skillDir)
+		return result, nil
+	}
+
+	resource, err := normalizeSkillResourcePath(resource)
+	if err != nil {
+		return nil, err
+	}
+	if resource == "SKILL.md" {
+		result.Resources, result.ResourcesTruncated = listSkillResources(skillDir)
+		return result, nil
+	}
+
+	content, err := readSkillResource(skillDir, name, resource)
+	if err != nil {
+		return nil, err
+	}
+	result.Content = content
+	result.ResourcePath = resource
+	return result, nil
+}
+
+func splitSkillLocator(locator string) (name, resource string) {
+	locator = strings.TrimSpace(strings.ReplaceAll(locator, `\`, "/"))
+	name, resource, _ = strings.Cut(locator, "/")
+	return
+}
+
+func normalizeSkillResourcePath(resource string) (string, error) {
+	resource = strings.ReplaceAll(resource, `\`, "/")
+	cleaned := path.Clean(resource)
+	native := filepath.FromSlash(cleaned)
+	if cleaned == "." || path.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") ||
+		filepath.IsAbs(native) || filepath.VolumeName(native) != "" || hasWindowsDrivePrefix(cleaned) {
+		return "", fmt.Errorf("invalid skill resource path: %s", resource)
+	}
+	return cleaned, nil
+}
+
+func hasWindowsDrivePrefix(resource string) bool {
+	if len(resource) < 2 || resource[1] != ':' {
+		return false
+	}
+	drive := resource[0]
+	return 'a' <= drive && drive <= 'z' || 'A' <= drive && drive <= 'Z'
+}
+
+func listSkillResources(skillDir string) (resources []string, truncated bool) {
+	realRoot, err := filepath.EvalSymlinks(skillDir)
+	if err != nil {
+		return nil, false
+	}
+
+	visited, manifestBytes := 0, 0
+	err = filepath.WalkDir(realRoot, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if current == realRoot {
+			return nil
+		}
+		visited++
+		if visited > maxSkillResourceVisited {
+			truncated = true
+			return filepath.SkipAll
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".svn", ".hg", ".venv", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(realRoot, current)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "SKILL.md" {
+			return nil
+		}
+		if len(resources) == maxSkillResourceEntries || manifestBytes+len(rel) > maxSkillResourceManifestBytes {
+			truncated = true
+			return filepath.SkipAll
+		}
+		resources = append(resources, rel)
+		manifestBytes += len(rel)
+		return nil
+	})
+	if err != nil {
+		truncated = true
+	}
+	sort.Strings(resources)
+	return resources, truncated
+}
+
+func readSkillResource(skillDir, skillName, resource string) (string, error) {
+	realRoot, err := filepath.EvalSymlinks(skillDir)
+	if err != nil {
+		return "", fmt.Errorf("skill not found: %s", skillName)
+	}
+
+	target := filepath.Join(realRoot, filepath.FromSlash(resource))
+	realTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", fmt.Errorf("skill resource not found: %s/%s", skillName, resource)
+	}
+	if realTarget != realRoot && !gulu.File.IsSubPath(realRoot, realTarget) {
+		return "", fmt.Errorf("skill resource escapes skill directory: %s", resource)
+	}
+
+	info, err := os.Stat(realTarget)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", fmt.Errorf("skill resource is not a regular file: %s/%s", skillName, resource)
+	}
+	if info.Size() > maxSkillResourceBytes {
+		return "", fmt.Errorf("skill resource exceeds the %d byte limit: %s/%s", maxSkillResourceBytes, skillName, resource)
+	}
+
+	file, err := os.Open(realTarget)
+	if err != nil {
+		return "", fmt.Errorf("skill resource not found: %s/%s", skillName, resource)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxSkillResourceBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("skill resource read failed: %s/%s", skillName, resource)
+	}
+	if len(data) > maxSkillResourceBytes {
+		return "", fmt.Errorf("skill resource exceeds the %d byte limit: %s/%s", maxSkillResourceBytes, skillName, resource)
+	}
+	return string(data), nil
 }
 
 func validateSkillName(name string) error {

--- a/kernel/util/skill_test.go
+++ b/kernel/util/skill_test.go
@@ -222,11 +222,10 @@ func TestLoadSkillReadsOnlyEnabledUserResources(t *testing.T) {
 	}
 }
 
-func TestLoadSkillRejectsUnsafeOrOversizedResources(t *testing.T) {
+func TestLoadSkillRejectsUnsafeOrUnsupportedResources(t *testing.T) {
 	workspaceRoot, _ := setSkillTestRoots(t)
 	writeSkill(t, workspaceRoot, "safe", "safe", "description", "body")
-	legacyEncoded := []byte{0xd6, 0xd0, 0xce, 0xc4}
-	writeSkillResource(t, workspaceRoot, "safe", "legacy-gbk.txt", legacyEncoded)
+	writeSkillResource(t, workspaceRoot, "safe", "invalid-utf8.txt", []byte{0xd6, 0xd0, 0xce, 0xc4})
 	writeSkillResource(t, workspaceRoot, "safe", "limit.txt", bytes.Repeat([]byte("x"), maxSkillResourceBytes))
 	writeSkillResource(t, workspaceRoot, "safe", "large.txt", bytes.Repeat([]byte("x"), maxSkillResourceBytes+1))
 
@@ -240,9 +239,9 @@ func TestLoadSkillRejectsUnsafeOrOversizedResources(t *testing.T) {
 			t.Errorf("LoadSkill(%q) error = %v", locator, err)
 		}
 	}
-	legacy, err := LoadSkill("safe/legacy-gbk.txt", nil)
-	if err != nil || !bytes.Equal([]byte(legacy.Content), legacyEncoded) {
-		t.Fatalf("legacy-encoded resource = %v, %v", []byte(legacy.Content), err)
+	if _, err := LoadSkill("safe/invalid-utf8.txt", nil); err == nil ||
+		!strings.Contains(err.Error(), "skill resource is not valid UTF-8") {
+		t.Fatalf("invalid UTF-8 resource error = %v", err)
 	}
 	atLimit, err := LoadSkill("safe/limit.txt", nil)
 	if err != nil || len(atLimit.Content) != maxSkillResourceBytes {

--- a/kernel/util/skill_test.go
+++ b/kernel/util/skill_test.go
@@ -17,6 +17,8 @@
 package util
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -79,6 +81,17 @@ func writeSkill(t *testing.T, root, id, name, description, body string) {
 	}
 }
 
+func writeSkillResource(t *testing.T, root, id, resource string, content []byte) {
+	t.Helper()
+	file := filepath.Join(root, id, filepath.FromSlash(resource))
+	if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDiscoverSkillsUsesEnabledUserSkillsWithWorkspacePriority(t *testing.T) {
 	workspaceRoot, userRoot := setSkillTestRoots(t)
 	writeSkill(t, workspaceRoot, "workspace-shared", "Shared", "workspace description", "workspace body")
@@ -95,11 +108,13 @@ func TestDiscoverSkillsUsesEnabledUserSkillsWithWorkspacePriority(t *testing.T) 
 	if got := DiscoverSkills([]string{"SHARED", "external"}); !reflect.DeepEqual(got, want) {
 		t.Fatalf("DiscoverSkills(enabled) = %#v, want %#v", got, want)
 	}
-	if got := LoadSkillContent("shared", []string{"shared", "external"}); got != "workspace body" {
-		t.Fatalf("LoadSkillContent(shared) = %q", got)
+	shared, err := LoadSkill("shared", []string{"shared", "external"})
+	if err != nil || shared.Content != "workspace body" {
+		t.Fatalf("LoadSkill(shared) = %#v, %v", shared, err)
 	}
-	if got := LoadSkillContent("External", []string{"external"}); got != "external body" {
-		t.Fatalf("LoadSkillContent(external) = %q", got)
+	external, err := LoadSkill("External", []string{"external"})
+	if err != nil || external.Content != "external body" {
+		t.Fatalf("LoadSkill(external) = %#v, %v", external, err)
 	}
 }
 
@@ -154,6 +169,156 @@ func TestDiscoverUserSkillsFollowsDirectorySymlinks(t *testing.T) {
 	want := []UserSkillInfo{{ID: "linked", Name: "Linked", Description: "linked description"}}
 	if got := DiscoverUserSkills(nil); !reflect.DeepEqual(got, want) {
 		t.Fatalf("DiscoverUserSkills(symlink) = %#v, want %#v", got, want)
+	}
+}
+
+func TestLoadSkillListsAndReadsBundledResources(t *testing.T) {
+	workspaceRoot, _ := setSkillTestRoots(t)
+	writeSkill(t, workspaceRoot, "skill-dir", "DisplayName", "description", "body {{vars.VALUE}}")
+	writeSkillResource(t, workspaceRoot, "skill-dir", "scripts/run.py", []byte("print('ok')\n"))
+	writeSkillResource(t, workspaceRoot, "skill-dir", "references/spec.md", []byte("{{vars.VALUE}}\n"))
+	writeSkillResource(t, workspaceRoot, "skill-dir", ".git/config", []byte("ignored"))
+	writeSkillResource(t, workspaceRoot, "skill-dir", ".venv/pyvenv.cfg", []byte("ignored"))
+
+	loaded, err := LoadSkill("DisplayName", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantResources := []string{"references/spec.md", "scripts/run.py"}
+	if loaded.Name != "DisplayName" || loaded.Content != "body {{vars.VALUE}}" ||
+		!reflect.DeepEqual(loaded.Resources, wantResources) || loaded.ResourcesTruncated {
+		t.Fatalf("LoadSkill(activation) = %#v", loaded)
+	}
+
+	resource, err := LoadSkill("skill-dir/references/./spec.md", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resource.Name != "skill-dir" || resource.ResourcePath != "references/spec.md" ||
+		resource.Content != "{{vars.VALUE}}\n" || len(resource.Resources) != 0 {
+		t.Fatalf("LoadSkill(resource) = %#v", resource)
+	}
+
+	explicitSkillMD, err := LoadSkill("skill-dir/SKILL.md", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicitSkillMD.ResourcePath != "" || !reflect.DeepEqual(explicitSkillMD.Resources, wantResources) {
+		t.Fatalf("LoadSkill(SKILL.md) = %#v", explicitSkillMD)
+	}
+}
+
+func TestLoadSkillReadsOnlyEnabledUserResources(t *testing.T) {
+	_, userRoot := setSkillTestRoots(t)
+	writeSkill(t, userRoot, "external", "External", "description", "user body")
+	writeSkillResource(t, userRoot, "external", "references/spec.md", []byte("user resource"))
+
+	if _, err := LoadSkill("External/references/spec.md", nil); err == nil {
+		t.Fatal("disabled user skill resource should not be readable")
+	}
+	loaded, err := LoadSkill("External/references/spec.md", []string{"external"})
+	if err != nil || loaded.Content != "user resource" {
+		t.Fatalf("LoadSkill(enabled user resource) = %#v, %v", loaded, err)
+	}
+}
+
+func TestLoadSkillRejectsUnsafeOrOversizedResources(t *testing.T) {
+	workspaceRoot, _ := setSkillTestRoots(t)
+	writeSkill(t, workspaceRoot, "safe", "safe", "description", "body")
+	legacyEncoded := []byte{0xd6, 0xd0, 0xce, 0xc4}
+	writeSkillResource(t, workspaceRoot, "safe", "legacy-gbk.txt", legacyEncoded)
+	writeSkillResource(t, workspaceRoot, "safe", "limit.txt", bytes.Repeat([]byte("x"), maxSkillResourceBytes))
+	writeSkillResource(t, workspaceRoot, "safe", "large.txt", bytes.Repeat([]byte("x"), maxSkillResourceBytes+1))
+
+	for _, locator := range []string{
+		"safe/../outside.txt",
+		"safe/references/../../../outside.txt",
+		"safe//absolute.txt",
+		"safe/C:/absolute.txt",
+	} {
+		if _, err := LoadSkill(locator, nil); err == nil || !strings.Contains(err.Error(), "invalid skill resource path") {
+			t.Errorf("LoadSkill(%q) error = %v", locator, err)
+		}
+	}
+	legacy, err := LoadSkill("safe/legacy-gbk.txt", nil)
+	if err != nil || !bytes.Equal([]byte(legacy.Content), legacyEncoded) {
+		t.Fatalf("legacy-encoded resource = %v, %v", []byte(legacy.Content), err)
+	}
+	atLimit, err := LoadSkill("safe/limit.txt", nil)
+	if err != nil || len(atLimit.Content) != maxSkillResourceBytes {
+		t.Fatalf("resource at size limit = %d bytes, %v", len(atLimit.Content), err)
+	}
+	if _, err = LoadSkill("safe/large.txt", nil); err == nil || !strings.Contains(err.Error(), "65536 byte limit") {
+		t.Fatalf("large resource error = %v", err)
+	}
+}
+
+func TestLoadSkillEnforcesResolvedSkillRoot(t *testing.T) {
+	workspaceRoot, _ := setSkillTestRoots(t)
+	externalRoot := t.TempDir()
+	writeSkill(t, externalRoot, "linked-target", "Linked", "description", "linked body")
+	writeSkillResource(t, externalRoot, "linked-target", "references/inside.md", []byte("inside"))
+	if err := os.MkdirAll(workspaceRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(externalRoot, "linked-target"), filepath.Join(workspaceRoot, "linked")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	loaded, err := LoadSkill("Linked/references/inside.md", nil)
+	if err != nil || loaded.Content != "inside" {
+		t.Fatalf("LoadSkill(resource in symlinked skill) = %#v, %v", loaded, err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	if err = os.WriteFile(outside, []byte("outside"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	resourceLink := filepath.Join(externalRoot, "linked-target", "references", "outside.md")
+	if err = os.Symlink(outside, resourceLink); err != nil {
+		t.Skipf("resource symlinks are unavailable: %v", err)
+	}
+	if _, err = LoadSkill("Linked/references/outside.md", nil); err == nil ||
+		!strings.Contains(err.Error(), "escapes skill directory") {
+		t.Fatalf("symlink escape error = %v", err)
+	}
+}
+
+func TestLoadSkillCapsResourceManifest(t *testing.T) {
+	workspaceRoot, _ := setSkillTestRoots(t)
+	writeSkill(t, workspaceRoot, "many", "many", "description", "body")
+	for i := 0; i <= maxSkillResourceEntries; i++ {
+		writeSkillResource(t, workspaceRoot, "many", fmt.Sprintf("references/%03d.md", i), []byte("x"))
+	}
+
+	loaded, err := LoadSkill("many", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Resources) != maxSkillResourceEntries || !loaded.ResourcesTruncated {
+		t.Fatalf("resource cap = %d, truncated=%v", len(loaded.Resources), loaded.ResourcesTruncated)
+	}
+	if loaded.Resources[0] != "references/000.md" || loaded.Resources[len(loaded.Resources)-1] != "references/199.md" {
+		t.Fatalf("unexpected capped resources: first=%q last=%q", loaded.Resources[0], loaded.Resources[len(loaded.Resources)-1])
+	}
+}
+
+func TestLoadSkillCapsManifestTraversal(t *testing.T) {
+	workspaceRoot, _ := setSkillTestRoots(t)
+	writeSkill(t, workspaceRoot, "many-dirs", "many-dirs", "description", "body")
+	skillDir := filepath.Join(workspaceRoot, "many-dirs")
+	for i := 0; i < maxSkillResourceVisited; i++ {
+		if err := os.Mkdir(filepath.Join(skillDir, fmt.Sprintf("empty-%04d", i)), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	loaded, err := LoadSkill("many-dirs", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Resources) != 0 || !loaded.ResourcesTruncated {
+		t.Fatalf("manifest traversal cap = %d resources, truncated=%v", len(loaded.Resources), loaded.ResourcesTruncated)
 	}
 }
 


### PR DESCRIPTION
Feat/skill multifile resources | 支持 Skill 导入资源文件

## 问题与需求

SiYuan 能够安装多文件 Skill，但 `skill.load` 只返回 `SKILL.md`，Agent 无法从激活结果中发现和读取随 Skill 安装的资源。

本次变更按照 [Agent Skills 客户端实现指南](https://agentskills.io/client-implementation/adding-skills-support)和 [Agent Skills 规范](https://agentskills.io/specification)补充按需加载资源的能力。

## 方案

激活 Skill 时，将资源清单写入返回给 Agent 的 context；需要资源内容时，仍调用现有的 `skill` 工具。

`name` 参数增加资源路径语义：

```text
load("<skill-name>")
load("<skill-name>/<resource-path>")
```

第一种形式加载 `SKILL.md` 并列出资源，第二种形式读取指定资源。所有 Skill 都支持这种用法。

对于 SiYuan 工作空间内且能通过现有 `file` 工具访问的 Skill，激活结果还会提供工作空间相对路径，Agent 可以选择使用 `file.read`、`file.list`、`file.grep` 和 `file.find`，完成分段读取、目录浏览和内容搜索。用户级 Skill 不提供该路径，继续使用 `skill.load(name/path)`。

此方案的优势在于简单，**不引入任何额外的新工具**，仅靠提示词引导，**拓展已有行为的边界**。

## 具体变更

- Skill 加载逻辑支持 locator、资源清单和指定资源读取，并沿用现有的 Skill 优先级、启用状态和别名解析
- `skill` 工具返回 `<skill_resources>`；工作空间路径通过现有 `file` 校验后，再返回 `<skill_location>`
- 资源路径限制在 Skill 根目录内；资源清单和单次读取均有数量及大小限制
- 增加工作空间 Skill、用户级 Skill、路径边界、符号链接、输出格式和限制条件测试

## 效果示例与对比

| 场景 | 变更前 | 变更后 |
| --- | --- | --- |
| 激活 Skill | 只返回 `SKILL.md` | 返回 `SKILL.md` 和资源清单 |
| 读取工作空间 Skill 资源 | 依赖正文写死路径 | 可以使用 `skill.load(name/path)`，也可以选择 `file.read`、`file.list`、`file.grep` 或 `file.find` |
| 读取用户级 Skill 资源 | 没有可用入口 | 使用 `skill.load(name/path)` |

AGENT 可能的使用效果如下:

导入工作空间 Skill：

```json
{
  "action": "load",
  "name": "pdf-processing"
}
```

```xml
<skill_content name="pdf-processing">

# PDF Processing

处理 PDF 文件的相关指令。

<skill_resources>
  <file>references/spec.md</file>
  <file>scripts/extract.py</file>
</skill_resources>

<skill_location path="data/storage/ai/agent/skills/pdf-processing">
  For this skill directory, use the `file` tool's read-only actions: `read`, `list`, `grep`, and `find`.
</skill_location>

</skill_content>
```

其中 `skill_resources` 和 `skill_location` 均为新增。此格式参考  [Agent Skills 客户端实现指南](https://agentskills.io/client-implementation/adding-skills-support)。

此时只读取 `SKILL.md`。需要参考资料时，再读取对应资源：

```json
{
  "action": "load",
  "name": "pdf-processing/references/spec.md"
}
```

```xml
<skill_resource skill="pdf-processing" path="references/spec.md">

资源文件内容

</skill_resource>
```

`skill_location` 和内部的指令仅仅作为附加产品，在 AGENT 可能希望做 chunk 读取而非无脑全量的时候，给他提供一些工具。其启发灵感来源于 PI 的设计，在 PI Coding Agent 中，harness 不提供 skill read 工具，而是直接暴露 SKILL 所在路径，让模型自己调用 read 或者 bash 工具根据需求读取。


## 特别说明

本次变更中，`SKILL.md` 正文保留现有的非敏感变量渲染；resource 部分刻意保留原文，不进行变量渲染。

考虑如下：

- 思源内部的 SKILL 变量渲染机制误杀风险较高（`$NAME` 和 `${NAME}` 都是非常常见的模式）。
- 我个人对“在 SKILL 内部放置文字变量并按需更改”这一需求持怀疑态度（这与 SECRET Key 是两回事）。引入变量的灵活性是否确为实际需求，以及它可能带来的误杀风险，权衡之下是否值得，存疑。
- PR 不宜扩大范围，因此排除了“单独将 `$NAME` 和 `${NAME}` 排除在外、另立渲染机制”的做法。

若开发者对本 PR 的选择有异议，可以提出辩驳，也可以按自己的意愿修改，或关闭 PR。

## 变更类型

- [ ] 缺陷修复
- [ ] 代码重构
- [x] 新功能
- [ ] 文案或语言更新

## 验证

```text
go test ./util ./mcp/tools ./agent
go vet ./util ./mcp/tools
```

## 效果对比

变更前

<img width="997" height="1766" alt="图片" src="https://github.com/user-attachments/assets/f216624d-b143-4a82-9dff-966e163eecd4" />

变更后

<img width="1078" height="1548" alt="图片" src="https://github.com/user-attachments/assets/e0f076e8-60f0-43d6-bc2f-3d696b82cd15" />


## 检查清单

- [x] 已完成代码自查
- [x] 我拥有所提交代码的完整权利，并同意以 AGPL-3.0 许可证授权
- [x] PR 提交到 `dev` 分支且不存在合并冲突
