### PR TITLE
Remove config-wrap and adapt all config items to narrow screens

### DIFF
--- a/app/src/assets/scss/business/_config.scss
+++ b/app/src/assets/scss/business/_config.scss
@@ -87,7 +87,10 @@
     display: none;
   }
 
-  &-wrap {
+  &-wrap,
+  &-item.fn__flex,
+  &-item > .fn__flex,
+  &-item .b3-label--inner.fn__flex {
     align-items: center;
   }
 
@@ -131,7 +134,7 @@
     }
   }
 
-  &-wrap--range {
+  &-range {
     min-width: 0;
 
     .config-range__mobile {
@@ -1246,7 +1249,7 @@
   }
 
   @media (max-width: 750px) {
-    .config-wrap > .fn__space {
+    .fn__flex > .fn__space {
       display: block;
     }
   }
@@ -1272,12 +1275,23 @@
   }
 }
 
-#configAccountMain.config-wrap {
+#configAccountMain {
   .config-account__row-actions {
     gap: 8px;
   }
 
   @media (max-width: 750px) {
+    // 头像资料行占满整行，内部保持横向（头像 + 信息），不被默认换行规则影响
+    .config-account__profile {
+      flex: 1 1 100%;
+      min-width: 0;
+      flex-wrap: nowrap;
+    }
+
+    .config-account__profile > .fn__space {
+      display: block;
+    }
+
     .config-account__profile-meta {
       display: block;
       flex: 0 1 auto;
@@ -1305,7 +1319,15 @@
     }
 
     .config-account__row-actions {
+      flex-wrap: nowrap;
       margin-top: 8px;
+
+      & > .b3-button {
+        flex: 0 1 auto;
+        width: auto;
+        max-width: none;
+        margin-top: 0;
+      }
     }
   }
 }

--- a/app/src/assets/scss/util/_responsive.scss
+++ b/app/src/assets/scss/util/_responsive.scss
@@ -1,7 +1,19 @@
 @media (max-width: 750px) {
   #encryptedNotebookEnabledActions {
     flex: 1 1 100%;
+    flex-wrap: wrap;
     min-width: 0;
+
+    & > .fn__space {
+      display: none;
+    }
+
+    & > .b3-button {
+      flex: 1 1 100%;
+      width: 100%;
+      max-width: 100%;
+      margin-top: 8px;
+    }
   }
 
   .config-about__motto {
@@ -44,14 +56,10 @@
       }
     }
 
-    &-wrap {
+    &-item,
+    &-item > .fn__flex,
+    &-item .b3-label--inner {
       flex-wrap: wrap;
-      align-items: flex-start;
-
-      & > .fn__flex-1 {
-        flex: 1 1 100%;
-        min-width: 0;
-      }
 
       & > .fn__space {
         display: none;
@@ -69,9 +77,22 @@
         max-width: 100%;
         margin-top: 8px;
       }
+
+      // 输入控件占满整行；普通标题（fn__flex-1）保持弹性收缩，开关行才可左右布局
+      & > .b3-text-field.fn__flex-1,
+      & > .b3-select.fn__flex-1,
+      & > .fn__flex > .b3-text-field.fn__flex-1,
+      & > .fn__flex > .b3-select.fn__flex-1,
+      & .b3-label--inner > .b3-text-field.fn__flex-1,
+      & .b3-label--inner > .b3-select.fn__flex-1 {
+        flex: 1 1 100%;
+        width: 100%;
+        max-width: 100%;
+        margin-top: 8px;
+      }
     }
 
-    &-wrap--range {
+    &-range {
       .config-range__desktop {
         display: none;
       }
@@ -86,7 +107,7 @@
     }
 
     &-item--save-path {
-      .config-wrap {
+      .fn__flex {
         & > .fn__space {
           display: none;
         }

--- a/app/src/config/entryVisibility/ui.ts
+++ b/app/src/config/entryVisibility/ui.ts
@@ -531,12 +531,12 @@ const openProfileEditor = (root: HTMLElement, profileID?: string) => {
     ${builtin ? "" : `<div class="config-group">
         <div class="config-title">${creating ? window.siyuan.languages.entryCreateProfile : escapeHtml(draft.name)}</div>
         <div class="config-items">
-            <label class="fn__flex b3-label config-item config-wrap">
+            <label class="fn__flex b3-label config-item">
                 <div class="fn__flex-1"><div class="config-name">${window.siyuan.languages.name}</div></div>
                 <span class="fn__space"></span>
                 <input class="b3-text-field fn__flex-center fn__size200" data-profile-field="name" value="${escapeAttr(draft.name)}">
             </label>
-            ${creating ? `<label class="fn__flex b3-label config-item config-wrap">
+            ${creating ? `<label class="fn__flex b3-label config-item">
                 <div class="fn__flex-1"><div class="config-name">${window.siyuan.languages.entryBasedOn}</div></div>
                 <span class="fn__space"></span>
                 <select class="b3-select fn__flex-center fn__size200" data-profile-field="template">
@@ -886,7 +886,7 @@ const importProfiles = async (root: HTMLElement, file: File) => {
 };
 
 export const genEntryVisibilityHtml = () => `<div class="b3-label config-item" data-type="entry-visibility">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <div><div class="config-name">${window.siyuan.languages.entryVisibility}</div><div class="b3-label__text">${window.siyuan.languages.entryVisibilityTip}</div></div>
         <span class="fn__space fn__flex-1"></span>
         ${getHostCapabilities().importExport ? `<button class="b3-button b3-button--outline" data-action="import"><svg class="b3-button__icon"><use xlink:href="#iconUpload"></use></svg>${window.siyuan.languages.import}</button>

--- a/app/src/config/render/render.ts
+++ b/app/src/config/render/render.ts
@@ -49,7 +49,7 @@ const genRangeRow = (
     step: number,
     value: number,
 ): string =>
-    `<div class="fn__flex b3-label config-item config-wrap config-wrap--range">
+    `<div class="fn__flex b3-label config-item config-range">
     ${genConfigItemMainHtml(title, desc)}
     <span class="fn__space"></span>
     <div class="config-range__desktop b3-tooltips b3-tooltips__n fn__flex-center" aria-label="${value}">
@@ -117,7 +117,7 @@ export const genButtonRowHtml = (
     label: string,
     icon: string,
 ): string =>
-    `<div class="fn__flex b3-label config-item config-wrap">
+    `<div class="fn__flex b3-label config-item">
     ${genConfigItemMainHtml(title, desc)}
     <span class="fn__space"></span>
     ${genButtonHtml(id, label, icon)}
@@ -130,7 +130,7 @@ export const genTextPairHtml = (
     left: StringControl,
     right: StringControl,
 ): string =>
-    `<div class="fn__flex b3-label config-item config-wrap">
+    `<div class="fn__flex b3-label config-item">
     ${genConfigItemMainHtml(title, desc)}
     <span class="fn__space"></span>
     <input class="b3-text-field fn__flex-center fn__size96" id="${left.id}" value="${Lute.EscapeHTMLStr(left.readConfig() as string)}">
@@ -173,7 +173,7 @@ export const genStackHtml = (lines: StackLine[]): string => {
             parts.push(genStackLeft(left, false));
         } else {
             const tag = right.kind === "switch" ? "label" : "div";
-            parts.push(`<${tag} class="fn__flex${right.kind === "switch" ? "" : " config-wrap"}">
+            parts.push(`<${tag} class="fn__flex">
     ${genStackLeft(left, true)}
     <span class="fn__space"></span>
     ${genStackRight(right)}
@@ -211,7 +211,7 @@ const renderControlParts = (parts: RowPart[]): string => {
         case "switch":
             return genSwitchRow(control.id, title, desc, control.readConfig() as boolean);
         case "number":
-            return `<div class="fn__flex b3-label config-item config-wrap">
+            return `<div class="fn__flex b3-label config-item">
     ${genConfigItemMainHtml(title, desc)}
     <span class="fn__space"></span>
     ${genNumberInputHtml(control.id, control.readConfig() as number, control.min, control.max, control.step, control.unit)}
@@ -221,13 +221,13 @@ const renderControlParts = (parts: RowPart[]): string => {
             return genRangeRow(control.id, title, desc ?? "", control.min, control.max, control.step, num);
         }
         case "select":
-            return `<div class="fn__flex b3-label config-item config-wrap">
+            return `<div class="fn__flex b3-label config-item">
     ${genConfigItemMainHtml(title, desc)}
     <span class="fn__space"></span>
     ${genSelectOptionsHtml(control.id, control.options, control.readConfig() as number | string)}
 </div>`;
         case "text":
-            return `<div class="fn__flex b3-label config-item config-wrap">
+            return `<div class="fn__flex b3-label config-item">
     ${genConfigItemMainHtml(title, desc ?? "")}
     <span class="fn__space"></span>
     <input class="b3-text-field fn__flex-center fn__size200" id="${control.id}" value="${Lute.EscapeHTMLStr(control.readConfig() as string)}"/>

--- a/app/src/config/setting/domIO.ts
+++ b/app/src/config/setting/domIO.ts
@@ -50,7 +50,7 @@ export const snapRangeValue = (value: number, min: number, max: number, step: nu
 
 /** 同步 range 行内滑块与移动端下拉的显示值；非 range 行返回 undefined */
 export const syncRangeRowValue = (el: HTMLElement): number | undefined => {
-    const wrap = el?.closest(".config-wrap--range");
+    const wrap = el?.closest(".config-range");
     if (!wrap) {
         return undefined;
     }

--- a/app/src/config/setting/mount.ts
+++ b/app/src/config/setting/mount.ts
@@ -63,7 +63,7 @@ export const applySettingTabSearchVisibility = (
                 lastVisibleItem = itemEl;
             } else if (itemId && unavailableItem) {
                 const unavailableElement = document.createElement("div");
-                unavailableElement.className = "fn__flex b3-label config-item config-wrap";
+                unavailableElement.className = "fn__flex b3-label config-item";
                 unavailableElement.dataset.configSearchUnavailableId = itemId;
                 const mainElement = document.createElement("div");
                 mainElement.className = "fn__flex-1 config-item__main";

--- a/app/src/config/tabs/aboutTab.ts
+++ b/app/src/config/tabs/aboutTab.ts
@@ -48,21 +48,21 @@ const registerAboutVersionGroup = (tab: SettingTabBuilder) => {
 
 const genAboutVersionHtml = (): string => {
     if (!getHostCapabilities().ownsKernel) {
-        return `<div class="fn__flex b3-label config-item config-wrap">
+        return `<div class="fn__flex b3-label config-item">
     <div class="fn__flex-1">
         <div class="config-name">${window.siyuan.languages.currentVer} v${Constants.SIYUAN_VERSION}</div>
     </div>
 </div>`;
     }
     if (window.siyuan.config.system.isMicrosoftStore) {
-        return `<div class="fn__flex b3-label config-item config-wrap">
+        return `<div class="fn__flex b3-label config-item">
     <div class="fn__flex-1">
         <div class="config-name">${window.siyuan.languages.currentVer} v${Constants.SIYUAN_VERSION}</div>
         <div class="b3-label__text">${window.siyuan.languages.isMsStoreVerTip}</div>
     </div>
 </div>`;
     }
-    return `<div class="fn__flex b3-label config-item config-wrap">
+    return `<div class="fn__flex b3-label config-item">
     <div class="fn__flex-1">
         <div class="config-name">${window.siyuan.languages.currentVer} v${Constants.SIYUAN_VERSION}</div>
         <div class="b3-label__text">${window.siyuan.languages.downloadLatestVer}</div>
@@ -104,7 +104,7 @@ const registerAboutInfoGroup = (tab: SettingTabBuilder) => {
             window.siyuan.languages.sponsor,
             motto,
         ],
-        html: () => `<div class="fn__flex b3-label config-item config-wrap">
+        html: () => `<div class="fn__flex b3-label config-item">
     <div class="fn__flex-1">
         <div class="config-about__logo">
             <img src="/stage/icon.png">

--- a/app/src/config/tabs/accessTab.ts
+++ b/app/src/config/tabs/accessTab.ts
@@ -608,7 +608,7 @@ const registerAccessPublishGroup = (tab: SettingTabBuilder) => {
             window.siyuan.languages.publishServiceNotStarted,
         ],
         html: () => `<div class="b3-label config-item">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         ${genConfigItemMainHtml(window.siyuan.languages.publishServiceAddresses, window.siyuan.languages.publishServiceAddressesTip)}
         <div class="fn__space"></div>
     </div>
@@ -722,9 +722,9 @@ const registerEncryptedNotebookGroup = (tab: SettingTabBuilder) => {
     <div class="ft__error">${window.siyuan.languages.masterPasswordMigrationPending}</div>
 </div>
 <div class="b3-label config-item fn__none" id="encryptedNotebookActions">
-    <div class="fn__flex fn__flex-center config-wrap">
+    <div class="fn__flex fn__flex-center">
         <div class="fn__flex-1"></div>
-        <div class="fn__flex fn__flex-center config-wrap" id="encryptedNotebookEnabledActions">
+        <div class="fn__flex fn__flex-center" id="encryptedNotebookEnabledActions">
             <button class="b3-button b3-button--outline fn__flex-center fn__size200" id="changeMasterPasswordBtn">
                 <svg class="svg"><use xlink:href="#iconLock"></use></svg>
                 ${window.siyuan.languages.changeMasterPassword}

--- a/app/src/config/tabs/accountUi.ts
+++ b/app/src/config/tabs/accountUi.ts
@@ -94,7 +94,7 @@ const genAccountMainHTML = () => {
         }).join("")}</div>`
         : "";
 
-    return `<div id="configAccountMain" class="b3-label--noborder fn__flex b3-label config-item config-wrap">
+    return `<div id="configAccountMain" class="b3-label--noborder fn__flex b3-label config-item">
     <div class="fn__flex fn__flex-1 config-account__profile">
     <a href="${getCloudURL("settings/avatar")}" class="config-account__profile-avatar" style="background-image: url(${window.siyuan.user.userAvatarURL})" target="_blank"></a>
     <span class="fn__space"></span>
@@ -379,7 +379,7 @@ ${iconVIP}${isOnetimePaid ? window.siyuan.languages.account4 : window.siyuan.lan
 </div>` : "";
 
     return `<div id="configAccountPayment" class="b3-label config-item${showDeactivate ? " config-account--deactivate" : ""}">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <span class="config-name">${window.siyuan.languages.paymentStatus}</span>
         <span class="fn__space"></span><span class="ft__on-surface">${statusHTML}</span>
         <div class="fn__flex-1"></div>

--- a/app/src/config/tabs/ai/aiCapabilityUi.ts
+++ b/app/src/config/tabs/ai/aiCapabilityUi.ts
@@ -243,7 +243,7 @@ const openAgentCapabilityView = (settingRoot: HTMLElement, backendCapabilities: 
                     <input class="b3-text-field b3-form__icon-input fn__block" data-type="searchAgentCapabilities" placeholder="${escapeAttribute(window.siyuan.languages.agentCapabilitiesSearch)}">
                 </div>
             </div>
-            <label class="fn__flex b3-label config-item config-wrap">
+            <label class="fn__flex b3-label config-item">
                 <div class="fn__flex-1">
                     <div class="config-name">${window.siyuan.languages.agentCapabilitiesOnlySelected}</div>
                     <div class="b3-label__text" data-type="agentCapabilitySelectedCount"></div>
@@ -301,7 +301,7 @@ const openAgentCapabilityView = (settingRoot: HTMLElement, backendCapabilities: 
             const actions = capability.actions || [];
             const opened = scope === "agent" && expanded.has(capability.id);
             return `<div class="b3-label config-item" data-capability-id="${escapeAttribute(capability.id)}">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         ${scope === "agent" ? `<button class="block__icon block__icon--show config-agent-capability__expand" data-type="toggleAgentCapabilityActions" aria-label="${escapeAttribute(window.siyuan.languages.config)}"><svg style="transform:rotate(${opened ? "90deg" : "0"});"><use xlink:href="#iconRight"></use></svg></button>` : ""}
         <div class="fn__flex-1 config-agent-capability__main">
             <div class="config-name">${escapeHtml(capability.title || capability.name)}</div>
@@ -315,7 +315,7 @@ const openAgentCapabilityView = (settingRoot: HTMLElement, backendCapabilities: 
         <div class="b3-label b3-label--inner">
             <div class="b3-label__text"><code>${escapeHtml(capability.id)}</code></div>
         </div>
-        <label class="fn__flex b3-label b3-label--inner config-wrap">
+        <label class="fn__flex b3-label b3-label--inner">
             <span class="fn__flex-1">${window.siyuan.languages.agentCapabilitiesCapabilityApprovalMode}</span>
             <span class="fn__space"></span>
             <select class="b3-select" data-type="toggleAgentCapabilityApproval">
@@ -327,7 +327,7 @@ const openAgentCapabilityView = (settingRoot: HTMLElement, backendCapabilities: 
         ${actions.length > 0 ? `<div class="b3-label b3-label--inner config-name fn__flex">
             <span class="fn__flex-1">${window.siyuan.languages.agentCapabilitiesActionApprovalMode}</span>
         </div>
-        ${actions.map((action) => `<label class="fn__flex b3-label b3-label--inner config-wrap">
+        ${actions.map((action) => `<label class="fn__flex b3-label b3-label--inner">
         <code class="fn__flex-1">${escapeHtml(action.name)}</code>
         <span class="fn__space"></span>
         <select class="b3-select" data-type="toggleAgentCapabilityActionApproval" data-capability-action="${escapeAttribute(action.name)}">

--- a/app/src/config/tabs/ai/aiProviderUi.ts
+++ b/app/src/config/tabs/ai/aiProviderUi.ts
@@ -126,7 +126,7 @@ const createProviderView = (root: HTMLElement, backLabel: string, stacked = fals
 };
 
 export const genProviderCardsHtml = (): string => `<div class="b3-label config-item" id="aiProviderCardsBlock">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         ${genConfigItemMainHtml(window.siyuan.languages.openAICompatibleProvider, window.siyuan.languages.apiProviderTip)}
         <span class="fn__space"></span>
         <button class="b3-button b3-button--outline fn__flex-center fn__size200" data-action="addProvider">
@@ -238,7 +238,7 @@ const renderDraftModels = (container: HTMLElement, models: Config.IModel[], avai
         return;
     }
     const modelInputAction = availableModels.length > 0 ? ' data-action="selectModel" data-menu="true"' : "";
-    container.innerHTML = models.map((model, index) => `<div class="fn__flex b3-label config-item config-wrap config-ai-provider__model" data-model-index="${index}">
+    container.innerHTML = models.map((model, index) => `<div class="fn__flex b3-label config-item config-ai-provider__model" data-model-index="${index}">
     <button class="block__icon block__icon--show config-ai-provider__model-drag" data-action="sortModel" type="button" draggable="true" aria-label="${window.siyuan.languages.sort}">
         <svg><use xlink:href="#iconDrag"></use></svg>
     </button>
@@ -389,17 +389,17 @@ const openProviderDetail = (root: HTMLElement, providerId?: string, preset?: IPr
     <div class="config-group">
         <div class="config-title">${window.siyuan.languages.aiProviderSettings}</div>
         <div class="config-items">
-            <label class="fn__flex b3-label config-item config-wrap">
+            <label class="fn__flex b3-label config-item">
                 ${genConfigItemMainHtml(window.siyuan.languages.customDisplayName)}
                 <span class="fn__space"></span>
                 <input class="b3-text-field fn__flex-center fn__size200" data-provider-field="displayName" type="text" spellcheck="false" value="${escapeHTML(draft.displayName || "")}">
             </label>
-            <label class="fn__flex b3-label config-item config-wrap">
+            <label class="fn__flex b3-label config-item">
                 ${genConfigItemMainHtml(window.siyuan.languages.apiBaseURL)}
                 <span class="fn__space"></span>
                 <input class="b3-text-field fn__flex-center fn__size200" data-provider-field="baseURL" type="text" spellcheck="false" value="${escapeHTML(draft.baseURL)}">
             </label>
-            <label class="fn__flex b3-label config-item config-wrap" data-type="openAIApiType">
+            <label class="fn__flex b3-label config-item" data-type="openAIApiType">
                 ${genConfigItemMainHtml(window.siyuan.languages.apiType,
         '<span class="fn__none" data-type="responsesCompatibility"></span>')}
                 <span class="fn__space"></span>
@@ -408,12 +408,12 @@ const openProviderDetail = (root: HTMLElement, providerId?: string, preset?: IPr
                     <option value="openai-responses"${draft.protocol === "openai-responses" ? " selected" : ""}>Responses API</option>
                 </select>
             </label>
-            <label class="fn__flex b3-label config-item config-wrap">
+            <label class="fn__flex b3-label config-item">
                 ${genConfigItemMainHtml(window.siyuan.languages.apiTimeout)}
                 <span class="fn__space"></span>
                 <input class="b3-text-field fn__flex-center fn__size200" data-provider-field="requestTimeout" type="number" min="1" max="600" value="${draft.requestTimeout}">
             </label>
-            <label class="fn__flex b3-label config-item config-wrap">
+            <label class="fn__flex b3-label config-item">
                 ${genConfigItemMainHtml(window.siyuan.languages.apiKey)}
                 <span class="fn__space"></span>
                 <div class="b3-form__icona fn__size200">
@@ -1044,7 +1044,7 @@ export const genGroupedModelPickerHtml = (group: ModelPickerGroup): string => {
     const selectedModelId = getSelectedModelId(group);
     const disabled = getEnabledModelGroups().length === 0 ? " disabled" : "";
     const modelLabel = getModelPickerLabel(selectedModelId);
-    return `<div class="fn__flex b3-label config-item config-wrap" id="aiModelPickerBlock-${group}" data-type="aiModelPicker" data-name="${group}">
+    return `<div class="fn__flex b3-label config-item" id="aiModelPickerBlock-${group}" data-type="aiModelPicker" data-name="${group}">
     ${genConfigItemMainHtml(window.siyuan.languages.defaultModel, desc)}
     <span class="fn__space"></span>
     <input class="b3-select fn__flex-center fn__size200" data-type="groupedModelPicker" data-group="${group}" data-model-id="${escapeHTML(selectedModelId)}" data-menu="true" type="text" value="${escapeHTML(modelLabel)}" readonly${disabled}>

--- a/app/src/config/tabs/ai/aiSkillUi.ts
+++ b/app/src/config/tabs/ai/aiSkillUi.ts
@@ -67,7 +67,7 @@ const renderUserSkills = (root: HTMLElement, skills: IUserSkillInfo[]) => {
         list.innerHTML = `<div class="b3-label config-item"><div class="b3-label__text">${window.siyuan.languages.agentUserSkillsEmpty}</div></div>`;
         return;
     }
-    list.innerHTML = `${skills.map((skill) => `<label class="fn__flex b3-label config-item config-wrap" data-user-skill-id="${escapeAttribute(skill.id)}">
+    list.innerHTML = `${skills.map((skill) => `<label class="fn__flex b3-label config-item" data-user-skill-id="${escapeAttribute(skill.id)}">
     <div class="fn__flex-1">
         <div class="config-name">${escapeHtml(skill.name)}</div>
         ${skill.description ? `<div class="b3-label__text">${escapeHtml(skill.description)}</div>` : ""}

--- a/app/src/config/tabs/ai/aiUi.ts
+++ b/app/src/config/tabs/ai/aiUi.ts
@@ -357,7 +357,7 @@ export const getMcpServersBlockKeywords = (): string[] => [
 const openedMcpOAuthURLs = new Map<string, string>();
 
 export const genMcpServersBlockHtml = (): string => `<div class="b3-label config-item" id="aiMcpServersBlock">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <span class="b3-label__text">${window.siyuan.languages.aiMcpServersTip}</span>
         <span class="fn__flex-1"></span>
         <span id="aiMcpStatusSummary" class="b3-label__text ft__on-surface fn__none"></span>

--- a/app/src/config/tabs/appTab.ts
+++ b/app/src/config/tabs/appTab.ts
@@ -236,7 +236,7 @@ const genNetworkProxyHtml = (): string => {
     <div class="b3-label__text">
         ${window.siyuan.languages.about17}
     </div>
-    <div class="b3-label__text fn__flex config-wrap" style="overflow: visible !important;">
+    <div class="b3-label__text fn__flex" style="overflow: visible !important;">
         <select id="networkProxyScheme" class="b3-select">
             <option value="" ${proxy.scheme === "" ? "selected" : ""}>${window.siyuan.languages.directConnection}</option>
             <option value="system" ${proxy.scheme === "system" ? "selected" : ""}>${window.siyuan.languages.useSystemProxy}</option>
@@ -306,7 +306,7 @@ const registerAppDataGroup = (tab: SettingTabBuilder) => {
     group.slot({
         key: "importData",
         keywords: [window.siyuan.languages.import, window.siyuan.languages.importDataTip],
-        html: () => `<div class="fn__flex b3-label config-item config-wrap">
+        html: () => `<div class="fn__flex b3-label config-item">
     ${genConfigItemMainHtml(`${window.siyuan.languages.import} Data`, window.siyuan.languages.importDataTip)}
     <span class="fn__space"></span>
     ${genImportUploadButtonHtml("importData", window.siyuan.languages.import)}
@@ -337,7 +337,7 @@ const registerAppDataGroup = (tab: SettingTabBuilder) => {
     group.slot({
         key: "importConf",
         keywords: [window.siyuan.languages.importConf, window.siyuan.languages.importConfTip],
-        html: () => `<div class="fn__flex b3-label config-item config-wrap">
+        html: () => `<div class="fn__flex b3-label config-item">
     ${genConfigItemMainHtml(window.siyuan.languages.importConf, window.siyuan.languages.importConfTip)}
     <span class="fn__space"></span>
     ${genImportUploadButtonHtml("importConf", window.siyuan.languages.import)}

--- a/app/src/config/tabs/appearanceTab.ts
+++ b/app/src/config/tabs/appearanceTab.ts
@@ -82,7 +82,7 @@ const loadAvailableFonts = async () => {
 
 const genFontConfigHtml = (configKey: FontFamiliesConfigKey, title: string, description: string) => {
     const fonts = getEditorFonts(window.siyuan.config.editor, configKey);
-    return `<div class="fn__flex b3-label config-item config-wrap" data-font-config-key="${configKey}">
+    return `<div class="fn__flex b3-label config-item" data-font-config-key="${configKey}">
     <div class="fn__flex-1 config-item__main">
         <div class="config-name">${title}</div>
         <div class="b3-label__text">${description}</div>
@@ -638,7 +638,7 @@ const fontItemFromElement = (item: HTMLElement): IFontItem => ({
     spacing: item.dataset.spacing,
 });
 
-const genBootAppearanceHtml = () => `<label class="fn__flex b3-label config-item config-wrap fn__none">
+const genBootAppearanceHtml = () => `<label class="fn__flex b3-label config-item fn__none">
     <div class="fn__flex-1 config-item__main">
         <div class="config-name">${escapeHtml(window.siyuan.languages.bootAppearance)}</div>
         <div class="b3-label__text">${escapeHtml(window.siyuan.languages.bootAppearanceTip)}</div>

--- a/app/src/config/tabs/fileTab.ts
+++ b/app/src/config/tabs/fileTab.ts
@@ -29,7 +29,7 @@ const genNotebookSavePathHtml = (
     ${genConfigItemName(title)}
     <div class="b3-label__text">${desc}</div>
     <div class="fn__hr--small"></div>
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <select class="b3-select fn__size200" id="${selectId}">${optionsHtml}</select>
         <div class="fn__space"></div>
         <input class="b3-text-field fn__flex-1" id="${pathId}" value="">
@@ -250,7 +250,7 @@ const registerFileManagementGroup = (tab: SettingTabBuilder) => {
         ${genConfigItemName(window.siyuan.languages.historyRetentionDaysTip)}
     </div>
     <div class="fn__hr--small"></div>
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <div class="fn__block">
             <div class="b3-label__text">${window.siyuan.languages.clearHistory}</div>
         </div>
@@ -258,7 +258,7 @@ const registerFileManagementGroup = (tab: SettingTabBuilder) => {
         ${genButtonHtml("clearHistory", window.siyuan.languages.purge, "iconTrashcan")}
     </div>
     <div class="fn__hr--small"></div>
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <div class="fn__block">
             <div class="b3-label__text">${window.siyuan.languages.historyRetentionDays}</div>
         </div>

--- a/app/src/config/tabs/keymapUi.ts
+++ b/app/src/config/tabs/keymapUi.ts
@@ -210,7 +210,7 @@ const genKeymapListHtml = () => {
     const pluginHtml = pluginHtmlParts.join("");
 
     return `<div class="b3-label file-tree config-keymap config-item" id="keymapList">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <input id="keymapInput" class="b3-text-field fn__flex-1" placeholder="${window.siyuan.languages.searchPlaceholder}">
         <div class="fn__space"></div>
         <label class="b3-form__icon fn__flex-1 searchByKeyLabel" style="overflow: visible">

--- a/app/src/config/tabs/secretsVariablesUi.ts
+++ b/app/src/config/tabs/secretsVariablesUi.ts
@@ -30,7 +30,7 @@ export const genSecretsBlockHtml = (): string => `<div class="b3-label config-it
     <div class="fn__hr--small"></div>
     <div id="secretList"></div>
     <div class="fn__hr"></div>
-    <div class="config-wrap">
+    <div class="fn__flex">
         <button class="b3-button b3-button--outline fn__flex-center fn__size200" data-type="addSecret">
             <svg><use xlink:href="#iconAdd"></use></svg>
             ${window.siyuan.languages.addSecret}
@@ -129,7 +129,7 @@ export const genVariablesBlockHtml = (): string => `<div class="b3-label config-
     <div class="fn__hr--small"></div>
     <div id="variableList"></div>
     <div class="fn__hr"></div>
-    <div class="config-wrap">
+    <div class="fn__flex">
         <button class="b3-button b3-button--outline fn__flex-center fn__size200" data-type="addVariable">
             <svg><use xlink:href="#iconAdd"></use></svg>
             ${window.siyuan.languages.addVariable}

--- a/app/src/config/tabs/syncTab.ts
+++ b/app/src/config/tabs/syncTab.ts
@@ -81,7 +81,7 @@ const registerSyncGroup = (tab: SettingTabBuilder) => {
         key: "syncCloudDir",
         keywords: [window.siyuan.languages.cloudSyncDir, window.siyuan.languages.cloudSyncDirTip, window.siyuan.languages.config],
         html: () => `<div class="b3-label config-item" id="syncCloudDirBlock">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         ${genConfigItemMainHtml(window.siyuan.languages.cloudSyncDir, window.siyuan.languages.cloudSyncDirTip)}
         <div class="fn__space"></div>
         <button class="b3-button b3-button--outline fn__flex-center fn__size200" data-action="config">
@@ -100,7 +100,7 @@ const registerSyncGroup = (tab: SettingTabBuilder) => {
             window.siyuan.languages.dataSnapshot,
         ],
         html: () => `<div class="b3-label config-item" id="syncCloudBackupBlock">
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         ${genConfigItemMainHtml(window.siyuan.languages.cloudBackup, window.siyuan.languages.cloudBackupTip)}
         <div class="fn__space"></div>
         <button class="b3-button b3-button--outline fn__flex-center fn__size200" id="openCloudBackup">
@@ -144,7 +144,7 @@ const registerRepoGroup = (tab: SettingTabBuilder) => {
             window.siyuan.languages.copyKey,
             window.siyuan.languages.resetRepo,
         ],
-        html: () => `<div class="fn__flex b3-label config-item config-wrap">
+        html: () => `<div class="fn__flex b3-label config-item">
     <div class="fn__flex-1 fn__flex-center">
         ${genConfigItemName(window.siyuan.languages.dataRepoKey)}
         <div class="fn__hr--small"></div>

--- a/app/src/menus/onGetnotebookconf.ts
+++ b/app/src/menus/onGetnotebookconf.ts
@@ -66,7 +66,7 @@ export const onGetnotebookconf = (data: INotebookConf) => {
     <div class="config-name">${window.siyuan.languages.fileTree12}</div>
     <div class="b3-label__text">${window.siyuan.languages.fileTree13}</div>
     <span class="fn__hr"></span>
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <select class="b3-select fn__size200" id="docCreateSaveBox">${genNotebookOption(data.conf.docCreateSaveBox, data.box)}</select>
         <div class="fn__space"></div>
         <input class="b3-text-field fn__flex-1" id="docCreateSavePath" value="">
@@ -80,7 +80,7 @@ export const onGetnotebookconf = (data: INotebookConf) => {
     <div class="config-name">${window.siyuan.languages.fileTree5}</div>
     <div class="b3-label__text">${window.siyuan.languages.fileTree6}</div>
     <span class="fn__hr"></span>
-    <div class="fn__flex config-wrap">
+    <div class="fn__flex">
         <select class="b3-select fn__size200" id="refCreateSaveBox">${genNotebookOption(data.conf.refCreateSaveBox, data.box)}</select>
         <div class="fn__space"></div>
         <input class="b3-text-field fn__flex-1" id="refCreateSavePath" value="">

--- a/app/src/plugin/Setting.ts
+++ b/app/src/plugin/Setting.ts
@@ -64,7 +64,7 @@ export class Setting {
     </div>
 </${tagName}>`;
             } else {
-                html = `<${tagName} class="fn__flex b3-label config-item${tagName === "label" ? "" : " config-wrap"}">
+                html = `<${tagName} class="fn__flex b3-label config-item">
     <div class="fn__flex-1">
         ${titleBlock}
     </div>

--- a/app/src/protyle/export/exportMd.ts
+++ b/app/src/protyle/export/exportMd.ts
@@ -35,9 +35,9 @@ export const openExportOptionsDialog = (onConfirm: (options: IExportMdOptionsPay
             `<option value="${o.value}" ${conf[id] === o.value ? "selected" : ""}>${o.label}</option>`).join("");
         return `<select id="${id}" class="b3-select fn__flex-center fn__size200">${opts}</select>`;
     };
-    // 一行：左侧标题+说明，右侧控件。复用设置面板标准布局 class（config-item config-wrap）
+    // 一行：左侧标题+说明，右侧控件。复用设置面板标准布局 class（config-item）
     const row = (title: string, desc: string, control: string) =>
-        `<label class="fn__flex b3-label config-item config-wrap">
+        `<label class="fn__flex b3-label config-item">
             <div class="fn__flex-1">
                 <div class="config-name">${title}</div>
                 <div class="b3-label__text">${desc}</div>


### PR DESCRIPTION
移除 config-wrap 类名，让所有设置项默认适配窄屏

## 背景

当前只有标记了 `config-wrap` 类的设置项在窄屏（≤750px）下才会换行适配，新增设置项时容易遗漏标记，导致窄屏下布局溢出。

## 改动

- 窄屏媒体查询中的适配规则锚点从 `.config-wrap` 改为 `.config-item`，所有设置项默认适配，无需再手动添加标记类
- 删除全部模板中的 `config-wrap` 类名
- range 行类名 `config-wrap--range` 重构为独立的 `config-range`，并同步更新 JS 选择器（`domIO.ts`）
- 开关行保持左右布局（标题在左、开关在右），输入控件在窄屏下全宽换行
- 账户页（`#configAccountMain`）窄屏布局保持资料行占满整行、操作按钮独立一行
- 桌面端布局不受影响（规则仅在 `max-width: 750px` 媒体查询内生效）

## 测试

- typecheck 与 eslint 通过
- config 相关测试（89 个）通过

## 验证

需要在窄屏下检查设置面板各标签页的布局表现。