### PR TITLE
:bug: Fix the aggregated Other file type count in data snapshots

### DIFF
--- a/kernel/model/repository.go
+++ b/kernel/model/repository.go
@@ -1065,7 +1065,8 @@ func statTypesByPath(files []*entity.File) (ret []*TypeCount) {
 	if 10 < len(ret) {
 		otherCount := 0
 		for _, tc := range ret[10:] {
-			tc.Count += otherCount
+			// 累加到 otherCount 上，而不是加到即将被丢弃的元素上，否则 Other 恒为 0
+			otherCount += tc.Count
 		}
 		other := &TypeCount{
 			Type:  "Other",

--- a/kernel/model/repository.go
+++ b/kernel/model/repository.go
@@ -1065,7 +1065,6 @@ func statTypesByPath(files []*entity.File) (ret []*TypeCount) {
 	if 10 < len(ret) {
 		otherCount := 0
 		for _, tc := range ret[10:] {
-			// 累加到 otherCount 上，而不是加到即将被丢弃的元素上，否则 Other 恒为 0
 			otherCount += tc.Count
 		}
 		other := &TypeCount{

--- a/kernel/model/repository_types_count_test.go
+++ b/kernel/model/repository_types_count_test.go
@@ -1,0 +1,141 @@
+// SiYuan - From thought to insight, with agents
+// Copyright (c) 2020-present, b3log.org
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/siyuan-note/dejavu/entity"
+)
+
+// files 构造 counts 指定的文件列表：扩展名 -> 文件数。
+func files(counts map[string]int) (ret []*entity.File) {
+	for ext, count := range counts {
+		for i := 0; i < count; i++ {
+			ret = append(ret, &entity.File{Path: fmt.Sprintf("/assets/%s-%d.%s", ext, i, ext)})
+		}
+	}
+	return
+}
+
+// 第 11 项及之后的类型聚合为 Other，其计数应为这些类型的文件数之和（Issue #19398）。
+func TestStatTypesByPathAggregatesOther(t *testing.T) {
+	counts := map[string]int{
+		"sy": 500, "png": 300, "jpg": 120, "pdf": 40, "mp3": 20,
+		"md": 15, "webp": 10, "gif": 8, "zip": 5, "json": 4,
+		// 前 10 项之外：
+		"svg": 3, "mp4": 2,
+	}
+	total := 0
+	for _, count := range counts {
+		total += count
+	}
+
+	ret := statTypesByPath(files(counts))
+
+	if 11 != len(ret) {
+		t.Fatalf("len = %d, 期望 11（前 10 项 + Other）: %s", len(ret), format(ret))
+	}
+	other := ret[10]
+	if "Other" != other.Type {
+		t.Fatalf("ret[10].Type = %q，期望 Other: %s", other.Type, format(ret))
+	}
+	// svg 3 + mp4 2
+	if 5 != other.Count {
+		t.Errorf("Other.Count = %d，期望 5: %s", other.Count, format(ret))
+	}
+
+	// 各项之和应等于文件总数，用户看到的差额正是这里被漏掉的部分。
+	sum := 0
+	for _, tc := range ret {
+		sum += tc.Count
+	}
+	if total != sum {
+		t.Errorf("各项之和 = %d，文件总数 = %d: %s", sum, total, format(ret))
+	}
+
+	// 前 10 项自身的计数不应被聚合改动（util.Ext 返回带点的扩展名）。
+	if 500 != ret[0].Count || ".sy" != ret[0].Type {
+		t.Errorf("ret[0] = %s %d，期望 .sy 500", ret[0].Type, ret[0].Count)
+	}
+}
+
+// 类型不超过 10 种时不应出现 Other。
+func TestStatTypesByPathWithoutOther(t *testing.T) {
+	ret := statTypesByPath(files(map[string]int{"sy": 3, "png": 2, "pdf": 1}))
+
+	if 3 != len(ret) {
+		t.Fatalf("len = %d，期望 3: %s", len(ret), format(ret))
+	}
+	for _, tc := range ret {
+		if "Other" == tc.Type {
+			t.Errorf("不应出现 Other: %s", format(ret))
+		}
+	}
+}
+
+// 正好 10 种类型时也不聚合（边界：10 < len(ret) 为假）。
+func TestStatTypesByPathExactlyTenTypes(t *testing.T) {
+	counts := map[string]int{
+		"sy": 10, "png": 9, "jpg": 8, "pdf": 7, "mp3": 6,
+		"md": 5, "webp": 4, "gif": 3, "zip": 2, "json": 1,
+	}
+
+	ret := statTypesByPath(files(counts))
+
+	if 10 != len(ret) {
+		t.Fatalf("len = %d，期望 10: %s", len(ret), format(ret))
+	}
+	sum := 0
+	for _, tc := range ret {
+		sum += tc.Count
+	}
+	if 55 != sum {
+		t.Errorf("各项之和 = %d，期望 55: %s", sum, format(ret))
+	}
+}
+
+// 无扩展名的文件归入 NoExt，并参与聚合。
+func TestStatTypesByPathNoExt(t *testing.T) {
+	ret := statTypesByPath([]*entity.File{
+		{Path: "/data/.siyuan/conf"},
+		{Path: "/data/widgets/README"},
+		{Path: "/assets/a.png"},
+	})
+
+	found := false
+	for _, tc := range ret {
+		if "NoExt" == tc.Type {
+			found = true
+			if 2 != tc.Count {
+				t.Errorf("NoExt.Count = %d，期望 2: %s", tc.Count, format(ret))
+			}
+		}
+	}
+	if !found {
+		t.Errorf("未统计 NoExt: %s", format(ret))
+	}
+}
+
+func format(ret []*TypeCount) string {
+	s := ""
+	for _, tc := range ret {
+		s += fmt.Sprintf("%s=%d ", tc.Type, tc.Count)
+	}
+	return s
+}


### PR DESCRIPTION
## Description / 描述

Fixes https://github.com/siyuan-note/siyuan/issues/19398 — exactly the inversion the issue names, nothing else.

`statTypesByPath` added the accumulator **to each element** past the tenth instead of accumulating their counts **into** it:

```go
otherCount := 0
for _, tc := range ret[10:] {
    tc.Count += otherCount   // 累加器被加到元素上，自身永不改变
}
other := &TypeCount{Type: "Other", Count: otherCount}  // 恒为 0
```

`otherCount` never changes, so `Other` is always 0. The elements it wrote to are dropped by the `append(ret[:10], other)` on the next line, so nothing else was affected either. One line:

```go
otherCount += tc.Count
```

The reporter's snapshot is reproduced by the test: the ten listed types sum to 1022 against a file count of 1027, and the missing 5 (svg 3 + mp4 2) were shown as `Other 0`, which reads to a user as "there are no other file types".

`statTypesByPath` 把累加器加到了第 11 项及之后的元素上，而不是把它们的计数累加进累加器，所以 `otherCount` 恒为 0，`Other` 也恒为 0。被写入的那些元素随后就被 `append(ret[:10], other)` 丢弃，因此其他统计项没有受到影响。

## Type of change / 变更类型

- [x] Bug fix
      缺陷修复
- [ ] Refactoring
      代码重构
- [ ] New feature
      新功能
- [ ] Text updates or new language additions
      修改文案或增加新语言

## Tests

`kernel/model/repository_types_count_test.go`, four cases, no fixtures and no I/O:

- the issue's own snapshot shape (12 types, 1027 files): `Other` is 5, the sum of all entries equals the file count, and the first ten entries keep their own counts
- three types: no `Other` entry at all
- exactly ten types: still no `Other`, because the guard is `10 < len(ret)`
- files without an extension count as `NoExt` and take part in the aggregation

`go test ./model/ -run TestStatTypesByPath` → ok. With only `repository.go` reverted and the tests kept, the first case fails with the issue's numbers:

```
--- FAIL: TestStatTypesByPathAggregatesOther
    Other.Count = 0，期望 5: .sy=500 .png=300 .jpg=120 .pdf=40 .mp3=20 .md=15 .webp=10 .gif=8 .zip=5 .json=4 Other=0
    各项之和 = 1022，文件总数 = 1027
```

`gofmt` and `go vet ./model/` clean.

## Checklist / 检查清单

- [x] I have performed a self-review of my own code
      我对自己的代码进行了自我审查
- [x] I have full rights to the submitted code and agree to license it under this project's AGPL-3.0 license
      我拥有所提交代码的完整权利，并同意其以本项目的 AGPL-3.0 许可证授权
- [x] PR is submitted to the `dev` branch and has no merge conflicts
      PR 提交到 `dev` 分支，并且没有合并冲突

The template asks for discussion on the issue first, and #19398 has none yet — it is a one-line inversion with the root cause already identified there, so I opened this rather than waiting. Close it without hesitation if you would rather settle the issue first, or if @TCOTC was already going to fix it.

模板要求先在 issue 中讨论，而 #19398 目前还没有回复。考虑到这是一个 issue 中已定位根因的单行修复，我直接提交了 PR；如果你们希望先讨论，或者 @TCOTC 本来就要修，请直接关闭。

AI disclosure: written by Claude (Anthropic) under my review and testing; no human reviewed it besides me.
